### PR TITLE
Track regions of the TVM guest physical address space

### DIFF
--- a/page-tracking/src/collections/page_vec.rs
+++ b/page-tracking/src/collections/page_vec.rs
@@ -159,8 +159,14 @@ impl<T> From<SequentialPages<InternalClean>> for RawPageVec<T> {
 impl<T> Deref for RawPageVec<T> {
     type Target = [T];
 
-    fn deref(&self) -> &[T] {
-        unsafe { core::slice::from_raw_parts(self.0.as_ptr(), self.0.len()) }
+    fn deref(&self) -> &Self::Target {
+        self.0.as_slice()
+    }
+}
+
+impl<T> DerefMut for RawPageVec<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut_slice()
     }
 }
 

--- a/page-tracking/src/collections/page_vec.rs
+++ b/page-tracking/src/collections/page_vec.rs
@@ -84,6 +84,11 @@ impl<T> RawPageVec<T> {
         self.0.retain(f)
     }
 
+    /// See `std::vec::insert`
+    pub fn insert(&mut self, index: usize, element: T) {
+        self.0.insert(index, element);
+    }
+
     /// See `std::vec::remove`
     pub fn remove(&mut self, index: usize) -> T {
         self.0.remove(index)


### PR DESCRIPTION
Introduce `VmRegionList` which tracks the distinct regions in a TVM's guest physical address space, similar in principle to KVM `memslots`. This will be used in follow-on patches to support demand faulting of zero pages and emulated MMIO (and can also be used to support shared memory).

Patches 1 and 2 are minor `PageVec` fixes, patch 3 fixes an error path when mapping pages, patch 4 introduces the VM region tracking, and patch 5 removes hooks for handling demand faults when copying to/from the guest address space.