### PR TITLE
Support lazy mapping of zero pages

### DIFF
--- a/page-tracking/src/page_tracker.rs
+++ b/page-tracking/src/page_tracker.rs
@@ -11,7 +11,7 @@ use crate::page_info::{PageInfo, PageMap, PageState};
 use crate::{HwMemMap, PageList, TlbVersion};
 
 /// Errors related to managing physical page information.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Error {
     /// Too many guests started by the host at once.
     GuestOverflow,

--- a/riscv-pages/src/page.rs
+++ b/riscv-pages/src/page.rs
@@ -126,7 +126,7 @@ impl<AS: AddressSpace> PartialOrd for RawAddr<AS> {
 }
 
 /// An address of a Page in an address space. It is guaranteed to be aligned to a page boundary.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct PageAddr<AS: AddressSpace> {
     addr: RawAddr<AS>,
 }
@@ -214,12 +214,6 @@ impl<AS: AddressSpace> PageAddr<AS> {
     /// Gets the index of the page in the system (the linear page count from address 0).
     pub fn index(&self) -> usize {
         self.pfn().bits() as usize
-    }
-}
-
-impl<AS: AddressSpace> PartialEq for PageAddr<AS> {
-    fn eq(&self, other: &Self) -> bool {
-        self.addr == other.addr
     }
 }
 

--- a/sbi/src/sbi.rs
+++ b/sbi/src/sbi.rs
@@ -435,12 +435,29 @@ pub enum TvmCpuExitCode {
     ConfidentialPageFault = 4,
 
     /// The vCPU executed a WFI instruction.
-    WaitForInterupt = 5,
+    WaitForInterrupt = 5,
 
     /// The vCPU encountered an exception that the TSM cannot handle internally and that cannot
     /// be safely delegated to the host. The value of the SCAUSE register is stored in `ExitCause0`.
     /// The vCPU is no longer runnable.
     UnhandledException = 6,
+}
+
+impl TvmCpuExitCode {
+    /// Creates a `TvmCpuExitCode` from the raw value as returned in A1.
+    pub fn from_reg(a1: u64) -> Result<Self> {
+        use TvmCpuExitCode::*;
+        match a1 {
+            0 => Ok(HostInterrupt),
+            1 => Ok(SystemReset),
+            2 => Ok(HartStart),
+            3 => Ok(HartStop),
+            4 => Ok(ConfidentialPageFault),
+            5 => Ok(WaitForInterrupt),
+            6 => Ok(UnhandledException),
+            _ => Err(Error::InvalidParam),
+        }
+    }
 }
 
 /// List of registers that can be read or written for a TVM's vCPU.

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -318,7 +318,6 @@ impl<'vcpu, 'pages, T: GuestStagePageTable> ActiveVmCpu<'vcpu, 'pages, T> {
         match Trap::from_scause(self.state.trap_csrs.scause).unwrap() {
             Trap::Exception(VirtualSupervisorEnvCall) => {
                 let sbi_msg = SbiMessage::from_regs(&self.state.guest_regs.gprs).ok();
-                self.state.guest_regs.sepc += 4;
                 VmCpuExit::Ecall(sbi_msg)
             }
             Trap::Exception(GuestInstructionPageFault)
@@ -474,8 +473,9 @@ impl VmCpu {
         }
     }
 
-    /// Updates A0/A1 with the result of an SBI call.
+    /// Increments SEPC and Updates A0/A1 with the result of an SBI call.
     pub fn set_ecall_result(&mut self, result: SbiReturnType) {
+        self.state.guest_regs.sepc += 4;
         match result {
             SbiReturnType::Legacy(a0) => {
                 self.set_gpr(GprIndex::A0, a0);


### PR DESCRIPTION
This series adds support for lazily-mapped (confidential) zero pages in TVMs.

I've chosen to implement this by having the host declare the confidential memory regions in the guest physical address space up front, and then allowing insertion of zero pages (via `TvmAddZeroPages`) both pre and post-finalization. This makes management of confidential memory more like how we expect to manage shared memory and emulated MMIO: declare the regions up front, then insert the pages and/or handle faults at runtime. It also makes supporting the insertion of pages at initialization vs runtime a bit cleaner since they can use (almost) the exact same code path. This does rework the `VmRegionList` I just added, but as I was implementing lazy mapping and MMIO I found this model to be much cleaner.

Patches 1 and 3 are prep work for allowing mapping of zero pages at runtime, while patch 2 adds the TEECALL for declaring the confidential memory regions. Patches 4 and 5 add support for reporting page faults in confidential memory regions both directly and as a result of guest ECALL. Patch 6 exercises all of this by having `tellus` fault in zero-pages for `guestvm` only after `guestvm` accesses the pages, instead of mapping them in from the start.