### PR TITLE
Rework guest memory access in preparation for MMIO

### DIFF
--- a/lds/qemu.lds
+++ b/lds/qemu.lds
@@ -30,6 +30,13 @@ SECTIONS
         *(.rodata .rodata.*)
     } >ram AT>ram :text
 
+    .extable : {
+        . = ALIGN(8);
+	PROVIDE(_extable_start = .);
+	KEEP(*(.extable))
+	PROVIDE(_extable_end = .);
+    } >ram AT>ram :text
+
     .data : {
         . = ALIGN(4096);
         *(.sdata .sdata.*) *(.data .data.*)

--- a/src/guest_mem.S
+++ b/src/guest_mem.S
@@ -4,23 +4,32 @@
 
 // Very unoptimized memcpy() to/from guest memory functions, using the HLV/HSV instructions.
 
+// Adds the instruction at 'lbl' to the exception table.
+.macro add_extable lbl
+.pushsection .extable, "a"
+.balign      8
+.quad        \lbl
+.popsection
+.endm
+
 .section .text
 
 // memcpy() to a guest physical address using HSV.
 .global _copy_to_guest
 _copy_to_guest:
     // handle_trap assumes t0 holds the address of where we want to jump to when we encounter
-    // a fault.
+    // a fault and will stick SCAUSE in t1.
     la    t0, _ret_from_copy
-    // _ret_from_copy assumes old VSATP is in t1 and return value is in t2.
-    csrrw t1, vsatp, zero
+    // _ret_from_copy assumes the return value is in t2.
     mv    t2, zero
 1:
     beq   t2, a2, _ret_from_copy
     lb    t3, (a1)
     // HSV.B encoding:
     //   0110001 rs2[4:0] rs1[4:0] 100 00000 1110011
+2:
     .word 0x63c54073 // hsv.b t3, (a0)
+    add_extable 2b
     addi  a0, a0, 1
     addi  a1, a1, 1
     addi  t2, t2, 1
@@ -30,24 +39,24 @@ _copy_to_guest:
 .global _copy_from_guest
 _copy_from_guest:
     // handle_trap assumes t0 holds the address of where we want to jump to when we encounter
-    // a fault.
+    // a fault and will stick SCAUSE in t1.
     la    t0, _ret_from_copy
-    // _ret_from_copy assumes old VSATP is in t1 and return value is in t2.
-    csrrw t1, vsatp, zero
+    // _ret_from_copy assumes the return value is in t2.
     mv    t2, zero
-2:
+1:
     beq   t2, a2, _ret_from_copy
     // HLV.B encoding:
     //   0110000 00000 rs1[4:0] 100 rd[4:0] 1110011
+2:
     .word 0x6005ce73 // hlv.b t3, (a1)
+    add_extable 2b
     sb    t3, (a0)
     addi  a0, a0, 1
     addi  a1, a1, 1
     addi  t2, t2, 1
-    j     2b
+    j     1b
 
 .align 2
 _ret_from_copy:
-    csrw  vsatp, t1
     mv    a0, t2
     ret

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,8 @@
     lang_items,
     asm_const,
     const_ptr_offset_from,
-    let_chains
+    let_chains,
+    ptr_sub_ptr
 )]
 
 use core::alloc::{GlobalAlloc, Layout};

--- a/src/smp.rs
+++ b/src/smp.rs
@@ -26,7 +26,6 @@ extern "C" {
 pub struct PerCpu {
     cpu_id: CpuId,
     vmid_tracker: RefCell<VmIdTracker>,
-    in_guest_copy: RefCell<bool>,
     online: Once<bool>,
 }
 
@@ -65,7 +64,6 @@ impl PerCpu {
             let pcpu = PerCpu {
                 cpu_id,
                 vmid_tracker: RefCell::new(VmIdTracker::new()),
-                in_guest_copy: RefCell::new(false),
                 online: Once::new(),
             };
             // Safety: ptr is guaranteed to be properly aligned and point to valid memory owned by
@@ -126,22 +124,6 @@ impl PerCpu {
     /// Returns a mutable reference to this CPU's VMID tracker.
     pub fn vmid_tracker_mut(&self) -> RefMut<VmIdTracker> {
         self.vmid_tracker.borrow_mut()
-    }
-
-    /// Marks this CPU as being in the process of copying to/from guest memory. This is used to
-    /// detect and recover from page faults that arise from accessing guest memory.
-    pub fn enter_guest_memcpy(&self) {
-        *self.in_guest_copy.borrow_mut() = true;
-    }
-
-    /// Exits this CPU from copying to/from guest memory.
-    pub fn exit_guest_memcpy(&self) {
-        *self.in_guest_copy.borrow_mut() = false;
-    }
-
-    /// Returns true if this CPU is currently copying to/from guest memory.
-    pub fn in_guest_memcpy(&self) -> bool {
-        *self.in_guest_copy.borrow()
     }
 }
 


### PR DESCRIPTION
Since we'll need to be more permissive about which faults can be fixed up when fetching guest instructions (due to using guest virtual addresses), let's constrain recoverable faults to specific instructions which are allowed to fault. Taking some inspiration from Linux, this series creates an exception fixup table which holds the addresses of such instructions.