### PR TITLE
Emulated MMIO support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
+name = "riscv-decode"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec7a6dc0b0bb96a4d23271864a45c0d24dcd9dde2a1b630a35f79fa29c588bf"
+
+[[package]]
 name = "riscv_page_tables"
 version = "0.1.0"
 dependencies = [
@@ -386,6 +392,7 @@ version = "0.1.0"
 name = "riscv_regs"
 version = "0.1.0"
 dependencies = [
+ "riscv-decode",
  "riscv_page_tables",
  "riscv_pages",
  "tock-registers",

--- a/drivers/src/pci/config_space.rs
+++ b/drivers/src/pci/config_space.rs
@@ -8,7 +8,7 @@ use core::ops::Range;
 use data_model::Le32;
 use device_tree::DeviceTree;
 use page_tracking::HwMemMap;
-use riscv_pages::{DeviceMemType, PageSize, RawAddr, SupervisorPageAddr, SupervisorPhys};
+use riscv_pages::{DeviceMemType, PageAddr, PageSize, RawAddr, SupervisorPageAddr};
 
 use super::address::{Address, Bus, Device, Function, Segment};
 use super::header::Header;
@@ -67,7 +67,7 @@ impl PciConfigSpace {
             .value_u64();
 
         let config_addr_raw = regs.next().ok_or(Error::NoConfigBase)?;
-        let config_base = SupervisorPageAddr::new(RawAddr::new(config_addr_raw, SupervisorPhys))
+        let config_base = PageAddr::new(RawAddr::supervisor(config_addr_raw))
             .ok_or(Error::ConfigSpaceMisaligned(config_addr_raw))?;
 
         let config_size = regs.next().ok_or(Error::NoConfigSize)?;
@@ -280,8 +280,7 @@ mod tests {
         config_slice[1024] = 0xffff_ffff;
 
         let config_space = PciConfigSpace {
-            config_base: SupervisorPageAddr::new(RawAddr::new(config_start, SupervisorPhys))
-                .unwrap(),
+            config_base: PageAddr::new(RawAddr::supervisor(config_start)).unwrap(),
             config_size: 8192,
             segment: Segment::default(),
             start_bus: Bus::default(),

--- a/riscv-pages/src/lib.rs
+++ b/riscv-pages/src/lib.rs
@@ -20,6 +20,8 @@ mod state;
 
 pub use memory_type::{DeviceMemType, MemType};
 pub use page::*;
-pub use page_owner_id::{AddressSpace, GuestPhys, PageOwnerId, SupervisorPhys, SupervisorVirt};
+pub use page_owner_id::{
+    AddressSpace, GuestPhys, GuestVirt, PageOwnerId, SupervisorPhys, SupervisorVirt,
+};
 pub use sequential_pages::{Error as SequentialPagesError, SeqPageIter, SequentialPages};
 pub use state::*;

--- a/riscv-pages/src/page.rs
+++ b/riscv-pages/src/page.rs
@@ -7,7 +7,9 @@ use core::marker::PhantomData;
 use core::slice;
 
 use crate::state::*;
-use crate::{AddressSpace, GuestPhys, MemType, PageOwnerId, SupervisorPhys, SupervisorVirt};
+use crate::{
+    AddressSpace, GuestPhys, GuestVirt, MemType, PageOwnerId, SupervisorPhys, SupervisorVirt,
+};
 
 // PFN constants, currently sv48x4 hard-coded
 // TODO parameterize based on address mode
@@ -86,17 +88,17 @@ impl<AS: AddressSpace> RawAddr<AS> {
 
 impl RawAddr<SupervisorPhys> {
     /// Creates a `RawAddr` in the `SupervisorPhys` address space.
-    /// Short for `RawAddr::new(addr, SupervisorPhys)`.
+    /// Short for `RawAddr::new(addr, SupervisorPhys::default())`.
     pub fn supervisor(addr: u64) -> Self {
-        Self(addr, SupervisorPhys)
+        Self(addr, SupervisorPhys::default())
     }
 }
 
 impl RawAddr<SupervisorVirt> {
     /// Creates a `RawAddr` in the `SupervisorVirt` address space.
-    /// Short for `RawAddr::new(addr, SupervisorVirt)`.
+    /// Short for `RawAddr::new(addr, SupervisorVirt::default())`.
     pub fn supervisor_virt(addr: u64) -> Self {
-        Self(addr, SupervisorVirt)
+        Self(addr, SupervisorVirt::default())
     }
 }
 
@@ -108,10 +110,20 @@ impl RawAddr<GuestPhys> {
     }
 }
 
+impl RawAddr<GuestVirt> {
+    /// Creates a `RawAddr` in the `GuestVirt` address space of the VM provided by `PageOwnerId`.
+    /// Short for `RawAddr::new(addr, GuestVirt::new(id))`.
+    pub fn guest_virt(addr: u64, id: PageOwnerId) -> Self {
+        Self(addr, GuestVirt::new(id))
+    }
+}
+
 /// Convenience type alias for supervisor-physical addresses.
 pub type SupervisorPhysAddr = RawAddr<SupervisorPhys>;
 /// Convenience type alias for guest-physical addresses.
 pub type GuestPhysAddr = RawAddr<GuestPhys>;
+/// Convenience type alias for guest-virtual addresses.
+pub type GuestVirtAddr = RawAddr<GuestVirt>;
 
 impl<AS: AddressSpace> From<PageAddr<AS>> for RawAddr<AS> {
     fn from(p: PageAddr<AS>) -> RawAddr<AS> {
@@ -291,7 +303,7 @@ impl<AS: AddressSpace> Pfn<AS> {
 impl Pfn<SupervisorPhys> {
     /// Creates a PFN from raw bits.
     pub fn supervisor(bits: u64) -> Self {
-        Pfn(bits, SupervisorPhys)
+        Pfn(bits, SupervisorPhys::default())
     }
 }
 

--- a/riscv-pages/src/page_owner_id.rs
+++ b/riscv-pages/src/page_owner_id.rs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use core::marker::PhantomData;
+
 /// `PageOwnerId` represents the entity that owns a given page.
 /// The hypervisor (Salus = HS mode) is special cased as is the primary host running in VS mode.
 /// 0 = host
@@ -48,47 +50,69 @@ impl PageOwnerId {
     }
 }
 
+/// Identifies if a raw address is virtual (subject to at least one stage of translation) or physical
+/// (the output of first-stage translation).
+pub trait AddressType: Clone + Copy + PartialEq + Eq {}
+
+/// Physical addresses.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Physical {}
+impl AddressType for Physical {}
+
+/// Virtual addresses.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Virtual {}
+impl AddressType for Virtual {}
+
 /// `AddressSpace` identifies the address space that a raw address is in.
 pub trait AddressSpace: Clone + Copy + PartialEq + Eq {
     /// Returns the `PageOwnerId` for the address space.
     fn id(&self) -> PageOwnerId;
 }
 
-/// Represents the supervisor (i.e. "actual") physical address space.
+/// Represents a supervisor address space.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct SupervisorPhys;
+pub struct Supervisor<T: AddressType>(PhantomData<T>);
 
-impl AddressSpace for SupervisorPhys {
+impl<T: AddressType> Default for Supervisor<T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T: AddressType> AddressSpace for Supervisor<T> {
     fn id(&self) -> PageOwnerId {
         PageOwnerId::hypervisor()
     }
 }
+
+/// Represents the supervisor (i.e. "actual") physical address space.
+pub type SupervisorPhys = Supervisor<Physical>;
 
 /// Represents the supervisor's virtual address space.
+pub type SupervisorVirt = Supervisor<Virtual>;
+
+/// Represents a guest address space.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct SupervisorVirt;
+pub struct Guest<T: AddressType>(PageOwnerId, PhantomData<T>);
 
-impl AddressSpace for SupervisorVirt {
-    fn id(&self) -> PageOwnerId {
-        PageOwnerId::hypervisor()
-    }
-}
-
-/// Represents a guest physical address space.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct GuestPhys(PageOwnerId);
-
-impl GuestPhys {
-    /// Creates a new tag representing a guest physical address space with the given ID.
+impl<T: AddressType> Guest<T> {
+    /// Creates a new tag representing a guest address space with the given ID.
     pub fn new(id: PageOwnerId) -> Self {
         // Hypervisor should never own pages that are mapped into a GPA.
         assert!(id != PageOwnerId::hypervisor());
-        Self(id)
+        Self(id, PhantomData)
     }
 }
 
-impl AddressSpace for GuestPhys {
+impl<T: AddressType> AddressSpace for Guest<T> {
     fn id(&self) -> PageOwnerId {
         self.0
     }
 }
+
+/// Represents a guest physical address space.
+pub type GuestPhys = Guest<Physical>;
+
+/// Represents a guest virtual address space.
+pub type GuestVirt = Guest<Virtual>;

--- a/riscv-regs/Cargo.toml
+++ b/riscv-regs/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 
 [dependencies]
 tock-registers = { version = "0.7" }
+riscv-decode = "0.2"
 riscv_pages = { path = "../riscv-pages" }
 riscv_page_tables = { path = "../riscv-page-tables" }

--- a/riscv-regs/src/decode.rs
+++ b/riscv-regs/src/decode.rs
@@ -1,0 +1,46 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Instruction decoding for RISC-V 64.
+use riscv_decode::{decode, instruction_length};
+
+// Use the types from the riscv_decode crate.
+pub use riscv_decode::{DecodingError, Instruction};
+
+/// A RISC-V instruction that has been decoded. Only supports 2 or 4 bytes instructions for now.
+#[derive(Clone, Copy, Debug)]
+pub struct DecodedInstruction {
+    instruction: Instruction,
+    len: usize,
+    raw: u32,
+}
+
+impl DecodedInstruction {
+    /// Creates a new `DecodedInstruction` from raw instruction bytes.
+    pub fn from_raw(raw: u32) -> Result<Self, DecodingError> {
+        let len = instruction_length(raw as u16);
+        let instruction = decode(raw)?;
+        Ok(Self {
+            instruction,
+            len,
+            raw,
+        })
+    }
+
+    /// Returns the raw instruction bytes.
+    pub fn raw(&self) -> u32 {
+        self.raw
+    }
+
+    /// Returns the decoded instruction.
+    pub fn instruction(&self) -> Instruction {
+        self.instruction
+    }
+
+    /// Returns the length of the raw instruction in bytes.
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+}

--- a/riscv-regs/src/lib.rs
+++ b/riscv-regs/src/lib.rs
@@ -10,11 +10,14 @@
 //! inst - auto-generated register definitions
 //! regs - RV64 General Purpose Registers (GPRs), 0-31.
 //! csrs - (H)S-mode CSRs
+//! decode - basic RV64 instruction decoding
 
 mod csrs;
+mod decode;
 mod inst;
 mod regs;
 
 pub use csrs::*;
+pub use decode::*;
 pub use inst::*;
 pub use regs::*;

--- a/riscv-regs/src/regs.rs
+++ b/riscv-regs/src/regs.rs
@@ -12,8 +12,11 @@
 pub struct GeneralPurposeRegisters([u64; 32]);
 
 /// Index of risc-v general purpose registers in `GeneralPurposeRegisters`.
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GprIndex {
-    RA = 0,
+    Zero = 0,
+    RA,
     GP,
     TP,
     S0,
@@ -44,6 +47,50 @@ pub enum GprIndex {
     T5,
     T6,
     SP,
+}
+
+impl GprIndex {
+    pub fn from_raw(raw: u32) -> Option<Self> {
+        use GprIndex::*;
+        let index = match raw {
+            0 => Zero,
+            1 => RA,
+            2 => SP,
+            3 => GP,
+            4 => TP,
+            5 => T0,
+            6 => T1,
+            7 => T2,
+            8 => S0,
+            9 => S1,
+            10 => A0,
+            11 => A1,
+            12 => A2,
+            13 => A3,
+            14 => A4,
+            15 => A5,
+            16 => A6,
+            17 => A7,
+            18 => S2,
+            19 => S3,
+            20 => S4,
+            21 => S5,
+            22 => S6,
+            23 => S7,
+            24 => S8,
+            25 => S9,
+            26 => S10,
+            27 => S11,
+            28 => T3,
+            29 => T4,
+            30 => T5,
+            31 => T6,
+            _ => {
+                return None;
+            }
+        };
+        Some(index)
+    }
 }
 
 impl GeneralPurposeRegisters {

--- a/sbi/src/sbi.rs
+++ b/sbi/src/sbi.rs
@@ -507,6 +507,27 @@ pub enum TvmMmioOpCode {
     // TODO: AMO instructions?
 }
 
+impl TvmMmioOpCode {
+    /// Returns the `TvmMmioOpCode` specified by the raw value.
+    pub fn from_reg(cause1: u64) -> Result<Self> {
+        use TvmMmioOpCode::*;
+        match cause1 {
+            0 => Ok(Load64),
+            1 => Ok(Load32),
+            2 => Ok(Load32U),
+            3 => Ok(Load16),
+            4 => Ok(Load16U),
+            5 => Ok(Load8),
+            6 => Ok(Load8U),
+            7 => Ok(Store64),
+            8 => Ok(Store32),
+            9 => Ok(Store16),
+            10 => Ok(Store8),
+            _ => Err(Error::InvalidParam),
+        }
+    }
+}
+
 /// List of registers that can be read or written for a TVM's vCPU.
 #[repr(u64)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/guest_mem.S
+++ b/src/guest_mem.S
@@ -60,3 +60,41 @@ _copy_from_guest:
 _ret_from_copy:
     mv    a0, t2
     ret
+
+// Fetch an instruction from guest memory using HLVX. Only supports 2 or 4 byte instructions.
+//
+// Arguments:
+//   A0: Guest address of the instruction to fetch, using the translation modes/tables currently
+//       programmed in HGATP and VSATP.
+//   A1: Pointer to a u32 where the instruction will be written.
+//
+// Returns -1 on error.
+.global _fetch_guest_instruction
+_fetch_guest_instruction:
+    // handle_trap assumes t0 holds the address of where we want to jump to when we encounter
+    // a fault and will stick SCAUSE in t1.
+    la    t0, 4f
+    // HLVX.HU encoding:
+    //   0110010 00011 rs1[4:0] 100 rd[4:0] 1110011
+1:
+    .word 0x643543f3 // hlvx.hu t2, (a0)
+    add_extable 1b
+    sw    t2, (a1)
+    addi  a0, a0, 2
+    addi  a1, a1, 2
+    // If it's a compressed instrution (bits [1:0] != 'b11) then we're done.
+    li    t3, 3
+    and   t2, t2, t3
+    bne   t2, t3, 3f
+    // Load the next half-word.
+2:
+    .word 0x643543f3 // hlvx.hu t2, (a0)
+    add_extable 2b
+    sw    t2, (a1)
+3:
+    mv    a0, zero
+    ret
+4:
+    // Took a fault, return -1.
+    not   a0, zero
+    ret


### PR DESCRIPTION
This series add support for emulated MMIO between a TVM and its host via the TSM, using the API defined previously in #10.

Patch 1 adds a `GuestVirtAddr` type since we'll be dealing with guest virtual addresses for instruction fetches.

Patch 2 wires up the `TvmAddEmulatedMmioRegion` TEECALL with faults in the region remaining unhandled.

Patches 3 through 5 are prep work for fetching & decoding guest instructions, with patch 4 adding instruction decode via the `riscv_decode` crate.

Patch 6 is the meat of the series, adding handling for emulated MMIO faults using the HLVX instructions and supporting the completion of MMIO loads/stores using the virtual vCPU registers introduced by the emulated MMIO API.

Patches 7 and 8 add a simple MMIO test case to `tellus` and `guestvm` to exercise both the load and store path.