### PR TITLE
Add PMU functionality...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "lazy_static",
- "spin 0.9.3",
+ "spin 0.9.4",
  "spki",
 ]
 
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -201,7 +201,9 @@ dependencies = [
  "riscv_page_tables",
  "riscv_pages",
  "riscv_regs",
- "spin 0.9.3",
+ "s_mode_utils",
+ "sbi",
+ "spin 0.9.4",
  "tock-registers",
 ]
 
@@ -284,9 +286,9 @@ checksum = "cda653ca797810c02f7ca4b804b40b8b95ae046eb989d356bce17919a8c25499"
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -321,7 +323,7 @@ name = "hyp_alloc"
 version = "0.1.0"
 dependencies = [
  "riscv_pages",
- "spin 0.9.3",
+ "spin 0.9.4",
 ]
 
 [[package]]
@@ -335,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "64de3cc433455c14174d42e554d4027ee631c4d046d43e3ecc6efc4636cdc7a7"
 
 [[package]]
 name = "lock_api"
@@ -396,15 +398,16 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "riscv_pages",
- "spin 0.9.3",
+ "spin 0.9.4",
 ]
 
 [[package]]
 name = "pest"
-version = "2.1.3"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+checksum = "69486e2b8c2d2aeb9762db7b4e00b0331156393555cff467f4163ff06821eef8"
 dependencies = [
+ "thiserror",
  "ucd-trie",
 ]
 
@@ -444,18 +447,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -478,7 +481,7 @@ version = "0.1.0"
 dependencies = [
  "page_tracking",
  "riscv_pages",
- "spin 0.9.3",
+ "spin 0.9.4",
 ]
 
 [[package]]
@@ -545,7 +548,7 @@ dependencies = [
  "s_mode_utils",
  "sbi",
  "sha2 0.10.2",
- "spin 0.9.3",
+ "spin 0.9.4",
  "test_workloads",
 ]
 
@@ -630,9 +633,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
 ]
@@ -660,13 +663,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -693,6 +696,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tock-registers"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +732,12 @@ name = "ucd-trie"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,7 @@ dependencies = [
  "attestation",
  "der",
  "device_tree",
+ "riscv_regs",
  "s_mode_utils",
  "sbi",
 ]

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -20,3 +20,6 @@ riscv_pages = { path = "../riscv-pages" }
 riscv_regs = { path = "../riscv-regs" }
 spin = { version = "*", default-features = false, features = ["once"] }
 tock-registers = { version = "0.7" }
+sbi = { path = "../sbi" }
+s_mode_utils = { path = "../s-mode-utils" }
+

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -22,6 +22,8 @@ pub mod imsic;
 pub mod iommu;
 /// Provides PCI bus scanning and device discovery.
 pub mod pci;
+/// Caches information about platform hardware and firmware PMU counters.
+pub mod pmu;
 
 pub use cpu::{CpuId, CpuInfo, MAX_CPUS};
 

--- a/drivers/src/pmu.rs
+++ b/drivers/src/pmu.rs
@@ -1,0 +1,126 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2
+
+use core::ops::ControlFlow;
+
+use arrayvec::ArrayVec;
+use sbi::{api::pmu, Error as SbiError, PmuCounterInfo, PmuCounterStopFlags, Result as SbiResult};
+use spin::Once;
+
+/// Maximum number of supported platform PMU counters
+pub const MAX_HARDWARE_COUNTERS: usize = 32;
+
+/// Caches information about platform hardware counters.
+pub struct PmuInfo {
+    hw_counters_info: ArrayVec<Option<PmuCounterInfo>, MAX_HARDWARE_COUNTERS>,
+    valid_hw_counters_mask: u64,
+}
+
+impl PmuInfo {
+    fn new() -> Self {
+        Self {
+            hw_counters_info: ArrayVec::new(),
+            valid_hw_counters_mask: 0,
+        }
+    }
+
+    fn is_valid_hardware_counter(info: PmuCounterInfo) -> bool {
+        use riscv_regs::{CSR_CYCLE, CSR_HPMCOUNTER31};
+        info.get_csr() >= (CSR_CYCLE as u64) && info.get_csr() <= (CSR_HPMCOUNTER31 as u64)
+    }
+
+    fn init_counter(&mut self, counter_index: u64) -> SbiResult<ControlFlow<()>> {
+        let info = pmu::get_counter_info(counter_index);
+        let counter_index = counter_index as usize;
+        if let Ok(info) = info {
+            // Assume that all HW counters are enumerated upfront. The counters may be sparse,
+            // but the presence of a firmware counter indicates HW counters are exhausted.
+            if info.is_firmware_counter() {
+                return Ok(ControlFlow::Break(()));
+            } else if !Self::is_valid_hardware_counter(info) {
+                return Err(SbiError::NotSupported);
+            }
+            self.hw_counters_info.push(Some(info));
+            self.valid_hw_counters_mask |= 1 << counter_index;
+        } else {
+            // Hardware counters can be sparse, and may not be implemented.
+            self.hw_counters_info.push(None);
+        }
+        Ok(ControlFlow::Continue(()))
+    }
+
+    /// Initializes the global PmuInfo structure with the information obtained from the platform SBI.
+    pub fn init() -> SbiResult<()> {
+        let mut pmu_info = PmuInfo::new();
+        let num_counters = pmu::get_num_counters()?;
+        for i in 0..num_counters.min(MAX_HARDWARE_COUNTERS as u64) {
+            if matches!(pmu_info.init_counter(i)?, ControlFlow::Break(())) {
+                break;
+            }
+        }
+        if !pmu_info.hw_counters_info.is_empty() {
+            // Stop and reset all HW counters at the outset
+            let stop_flags = PmuCounterStopFlags::default().set_reset_flag();
+            let _ = pmu::stop_counters(0, pmu_info.valid_hw_counters_mask, stop_flags);
+            PMU_INFO.call_once(|| pmu_info);
+            Ok(())
+        } else {
+            Err(SbiError::NotSupported)
+        }
+    }
+
+    /// Returns a reference to the global PmuInfo structure.
+    pub fn get() -> SbiResult<&'static PmuInfo> {
+        PMU_INFO.get().ok_or(SbiError::NotSupported)
+    }
+
+    /// Returns the counter index for the specified CSR
+    pub fn csr_to_counter_index(&self, csr: u64) -> SbiResult<u64> {
+        let counter_index = self
+            .hw_counters_info
+            .iter()
+            .position(|info| info.filter(|i| i.get_csr() == csr).is_some())
+            .ok_or(SbiError::InvalidParam)? as u64;
+        Ok(counter_index)
+    }
+
+    /// Returns the number of hardware counters supported by the platform
+    pub fn get_num_counters(&self) -> u64 {
+        self.hw_counters_info.len() as u64
+    }
+
+    /// Returns cached information for the hardware counter specified by counter_index.
+    pub fn get_counter_info(&self, counter_index: u64) -> SbiResult<PmuCounterInfo> {
+        let info = self
+            .hw_counters_info
+            .get(counter_index as usize)
+            .and_then(|info| info.as_ref())
+            .ok_or(SbiError::InvalidParam)?;
+        Ok(*info)
+    }
+
+    /// Returns the CSR for the specified counter index
+    pub fn counter_index_to_csr(&self, counter_index: u64) -> SbiResult<u64> {
+        Ok(self.get_counter_info(counter_index)?.get_csr())
+    }
+
+    /// Validates the counter_index and counter_mask bit-mask for counter start and stop operations.
+    /// The counter_mask is relative to counter_index. The return value is a sanitized version
+    /// of the original counter_mask, with set bits representing implemented platform counters.
+    pub fn filter_counter_mask(&self, counter_index: u64, counter_mask: u64) -> SbiResult<u64> {
+        let counter_index = counter_index as usize;
+        // Validate entire counter mask to ensure that no spurious bits corresponding to
+        // non-hardware counter indexes were set. Since hardware counters can be sparse, it's OK to set bits
+        // for unimplemented hardware counters, as long as they don't exceed the last known valid index. The
+        // platform will automatically select available matching counters based on the mask.
+        if (u64::BITS as usize - counter_mask.leading_zeros() as usize) + counter_index
+            > self.hw_counters_info.len()
+        {
+            return Err(SbiError::InvalidParam);
+        }
+        Ok(counter_mask & (self.valid_hw_counters_mask >> counter_index))
+    }
+}
+
+static PMU_INFO: Once<PmuInfo> = Once::new();

--- a/s-mode-utils/src/abort.rs
+++ b/s-mode-utils/src/abort.rs
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(all(target_arch = "riscv64", target_os = "none"))]
 use core::arch::asm;
 
+#[cfg(all(target_arch = "riscv64", target_os = "none"))]
 /// Silently ends execution of this thread forever.
 pub fn abort() -> ! {
     loop {
@@ -13,4 +15,10 @@ pub fn abort() -> ! {
             asm!("wfi", options(nomem, nostack));
         }
     }
+}
+
+#[cfg(not(any(target_arch = "riscv64", target_os = "none")))]
+/// Silently ends execution of this thread forever.
+pub fn abort() -> ! {
+    panic!("");
 }

--- a/sbi/src/api/mod.rs
+++ b/sbi/src/api/mod.rs
@@ -13,3 +13,6 @@ pub mod state;
 /// Host interfaces for confidential computing.
 #[cfg(all(target_arch = "riscv64", target_os = "none"))]
 pub mod tsm;
+
+/// Host interfaces for PMU.
+pub mod pmu;

--- a/sbi/src/api/pmu.rs
+++ b/sbi/src/api/pmu.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ecall_send;
+use crate::{
+    PmuCounterConfigFlags, PmuCounterStartFlags, PmuCounterStopFlags, PmuEventType, PmuFunction,
+};
+use crate::{PmuCounterInfo, Result, SbiMessage};
+
+/// Returns the number of PMU counters supported by the platform
+pub fn get_num_counters() -> Result<u64> {
+    let msg = SbiMessage::Pmu(PmuFunction::GetNumCounters);
+    // Safety: PmuFunction doesn't touch memory
+    unsafe { ecall_send(&msg) }
+}
+
+/// Returns information about the PMU counter specified by counter_index
+pub fn get_counter_info(counter_index: u64) -> Result<PmuCounterInfo> {
+    let msg = SbiMessage::Pmu(PmuFunction::GetCounterInfo(counter_index));
+    // Safety: PmuFunction doesn't touch memory
+    let info = unsafe { ecall_send(&msg) }?;
+    Ok(PmuCounterInfo::new(info))
+}
+
+/// Configures PMU counters specified by counter_index and counter_mask
+pub fn configure_matching_counters(
+    counter_index: u64,
+    counter_mask: u64,
+    config_flags: PmuCounterConfigFlags,
+    event_type: PmuEventType,
+    event_data: u64,
+) -> Result<u64> {
+    let msg = SbiMessage::Pmu(PmuFunction::ConfigureMatchingCounters {
+        counter_index,
+        counter_mask,
+        config_flags,
+        event_type,
+        event_data,
+    });
+    // Safety: PmuFunction does not touch memory.
+    unsafe { ecall_send(&msg) }
+}
+
+/// Starts the counters specified by counter_index and counter_mask
+pub fn start_counters(
+    counter_index: u64,
+    counter_mask: u64,
+    start_flags: PmuCounterStartFlags,
+    initial_value: u64,
+) -> Result<()> {
+    let msg = SbiMessage::Pmu(PmuFunction::StartCounters {
+        counter_index,
+        counter_mask,
+        start_flags,
+        initial_value,
+    });
+    // Safety: PmuFunction does not touch memory.
+    unsafe { ecall_send(&msg) }?;
+    Ok(())
+}
+
+/// Stops the counters specified by counter_index and counter_mask
+pub fn stop_counters(
+    counter_index: u64,
+    counter_mask: u64,
+    stop_flags: PmuCounterStopFlags,
+) -> Result<()> {
+    let msg = SbiMessage::Pmu(PmuFunction::StopCounters {
+        counter_index,
+        counter_mask,
+        stop_flags,
+    });
+    // Safety: PmuFunction does not touch memory.
+    unsafe { ecall_send(&msg) }?;
+    Ok(())
+}
+
+/// Reads the firmware counter specified by counter_index
+pub fn read_firmware_counter(counter_index: u64) -> Result<u64> {
+    let msg = SbiMessage::Pmu(PmuFunction::ReadFirmwareCounter(counter_index));
+    // Safety: PmuFunction does not touch memory.
+    unsafe { ecall_send(&msg) }
+}

--- a/sbi/src/consts.rs
+++ b/sbi/src/consts.rs
@@ -8,6 +8,7 @@
 pub const EXT_PUT_CHAR: u64 = 0x01;
 pub const EXT_BASE: u64 = 0x10;
 pub const EXT_HART_STATE: u64 = 0x48534D;
+pub const EXT_PMU: u64 = 0x504D55;
 pub const EXT_RESET: u64 = 0x53525354;
 pub const EXT_TEE: u64 = 0x41544545;
 pub const EXT_MEASUREMENT: u64 = 0x5464545;

--- a/sbi/src/pmu.rs
+++ b/sbi/src/pmu.rs
@@ -1,0 +1,757 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::*;
+use crate::function::*;
+use ConfigFlagsValues::*;
+
+/// Functions for the Performance Monitoring Unit (PMU) extension
+/// Specific details can be found in the SBI documentation for the PMU extension.
+#[derive(Copy, Clone)]
+pub enum PmuFunction {
+    /// Returns the total number of performance counters (hardware and firmware).
+    GetNumCounters,
+    /// Returns information about hardware counter specified by the inner value.
+    GetCounterInfo(u64),
+    /// Configures the counters selected by counter_index and counter_mask.
+    /// See the sbi_pmu_counter_config_matching documentation for details.
+    ConfigureMatchingCounters {
+        /// Counter index base.
+        counter_index: u64,
+        /// Counter index mask.
+        counter_mask: u64,
+        /// Counter configuration flags.
+        config_flags: PmuCounterConfigFlags,
+        /// Counter event type.
+        event_type: PmuEventType,
+        /// Counter event data.
+        event_data: u64,
+    },
+    /// Starts the counters selected by counter_index and counter_mask.
+    /// See the sbi_pmu_counter_start documentation for details.
+    StartCounters {
+        /// Counter index base.
+        counter_index: u64,
+        /// Counter index mask.
+        counter_mask: u64,
+        /// Counter start flags.
+        start_flags: PmuCounterStartFlags,
+        /// Counter initial value (used in conjunction with start_flags).
+        initial_value: u64,
+    },
+    /// Stops the counters selected by counter_index and counter_mask.
+    /// See the sbi_pmu_counter_stop documentation for details.
+    StopCounters {
+        /// Counter index base.
+        counter_index: u64,
+        /// Counter index mask.
+        counter_mask: u64,
+        /// Counter stop flags.
+        stop_flags: PmuCounterStopFlags,
+    },
+    /// Returns the current value firmware counter specified by the inner value.
+    ReadFirmwareCounter(u64),
+}
+
+/// This encapsulates the bit-fields for PMU config_flags parameter as described in the SBI documentation
+/// for sbi_pmu_counter_config_matching
+#[derive(Copy, Clone, Default)]
+pub struct PmuCounterConfigFlags(u64);
+
+#[derive(Copy, Clone)]
+#[repr(u64)]
+enum ConfigFlagsValues {
+    SkipMatch = 1,
+    ClearValue = (1 << 1),
+    AutoStart = (1 << 2),
+    Vuinh = (1 << 3),
+    Vsinh = (1 << 4),
+    Uinh = (1 << 5),
+    Sinh = (1 << 6),
+    Minh = (1 << 7),
+}
+
+impl PmuCounterConfigFlags {
+    /// Constructs a new PmuCounterConfigFlags from a valid passed-in value.
+    pub fn from_raw_value(value: u64) -> Result<Self> {
+        const CONFIG_FLAG_INVERSE_MASK: u64 = !0xEF;
+        if value & CONFIG_FLAG_INVERSE_MASK == 0 {
+            Ok(PmuCounterConfigFlags(value))
+        } else {
+            Err(Error::InvalidParam)
+        }
+    }
+
+    /// Returns the raw inner value.
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+
+    /// Sets the skip_match bit-flag (skips counter matching).
+    pub fn set_skip_match(self) -> Self {
+        PmuCounterConfigFlags(self.0 | SkipMatch as u64)
+    }
+
+    /// Returns if the skip_match bit-flag is set.
+    pub fn is_skip_match(&self) -> bool {
+        self.0 & SkipMatch as u64 != 0
+    }
+
+    /// Returns if the skip_match bit-flag is set.
+    pub fn unset_skip_match(&self) -> Self {
+        PmuCounterConfigFlags(self.0 & !(SkipMatch as u64))
+    }
+
+    /// Sets the clear_value bit-flag (clears the counter value).
+    pub fn set_clear_value(self) -> Self {
+        PmuCounterConfigFlags(self.0 | (ClearValue as u64))
+    }
+
+    /// Returns if the clear_value bit-flag is set.
+    pub fn is_clear_value(&self) -> bool {
+        self.0 & (ClearValue as u64) != 0
+    }
+
+    /// Returns if the skip_match bit-flag is set.
+    pub fn unset_clear_value(&self) -> Self {
+        PmuCounterConfigFlags(self.0 & !(ClearValue as u64))
+    }
+
+    /// Sets the auto_start bit-flag (automatically starts the counter).
+    pub fn set_auto_start(self) -> Self {
+        PmuCounterConfigFlags(self.0 | (AutoStart as u64))
+    }
+
+    /// Returns if the auto_start bit-flag is set.
+    pub fn is_auto_start(&self) -> bool {
+        self.0 & (AutoStart as u64) != 0
+    }
+
+    /// Returns if the auto_start bit-flag is set.
+    pub fn unset_auto_start(&self) -> Self {
+        PmuCounterConfigFlags(self.0 & !(AutoStart as u64))
+    }
+
+    /// Sets the vuinh bit-flag (inhibit counter in VU-mode).
+    pub fn set_vuinh(self) -> Self {
+        PmuCounterConfigFlags(self.0 | (Vuinh as u64))
+    }
+
+    /// Returns if the vuinh bit-flag is set.
+    pub fn is_vuinh(&self) -> bool {
+        self.0 & (Vuinh as u64) != 0
+    }
+
+    /// Sets the vsinh bit-flag (inhibit counter in VS-mode).
+    pub fn set_vsinh(self) -> Self {
+        PmuCounterConfigFlags(self.0 | (Vsinh as u64))
+    }
+
+    /// Returns if the vsinh bit-flag is set.
+    pub fn is_vsinh(&self) -> bool {
+        self.0 & (Vsinh as u64) != 0
+    }
+
+    /// Sets the uinh bit-flag (inhibit counter in U-mode).
+    pub fn set_uinh(self) -> Self {
+        PmuCounterConfigFlags(self.0 | (Uinh as u64))
+    }
+
+    /// Returns if the uinh bit-flag is set.
+    pub fn is_uinh(&self) -> bool {
+        self.0 & (Uinh as u64) != 0
+    }
+
+    /// Sets the sinh bit-flag (inhibit counter in S-mode).
+    pub fn set_sinh(self) -> Self {
+        PmuCounterConfigFlags(self.0 | (Sinh as u64))
+    }
+
+    /// Returns if the sinh bit-flag is set.
+    pub fn is_sinh(&self) -> bool {
+        self.0 & (Sinh as u64) != 0
+    }
+
+    /// Sets the minh bit-flag (inhibit counter in M-mode).
+    pub fn set_minh(self) -> Self {
+        PmuCounterConfigFlags(self.0 | (Minh as u64))
+    }
+
+    /// Returns if the minh bit-flag is set.
+    pub fn is_minh(&self) -> bool {
+        self.0 & (Minh as u64) != 0
+    }
+}
+
+/// This encapsulates the bit-fields for PMU start_flags parameter as described in the SBI documentation
+/// for sbi_pmu_counter_start
+#[derive(Copy, Clone, Debug, Default)]
+pub struct PmuCounterStartFlags(u64);
+
+impl PmuCounterStartFlags {
+    /// Constructs a new PmuCounterStartFlags from a valid passed-in value.
+    pub fn from_raw_value(value: u64) -> Result<Self> {
+        match value {
+            0 | 1 => Ok(PmuCounterStartFlags(value)),
+            _ => Err(Error::InvalidParam),
+        }
+    }
+
+    /// Returns the raw value of the inner bit-flag field.
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+
+    /// Sets the set_init_value bit-flag (set initial counter value).
+    pub fn set_init_value(self) -> Self {
+        PmuCounterStartFlags(self.0 | 1)
+    }
+
+    /// Returns if set_init_value bit-flag is set.
+    pub fn is_init_value(&self) -> bool {
+        self.0 & 1 != 0
+    }
+}
+
+/// This encapsulates the bit-fields for PMU stop_flags parameter as described in the SBI documentation
+/// for sbi_pmu_counter_stop
+#[derive(Copy, Clone, Debug, Default)]
+pub struct PmuCounterStopFlags(u64);
+
+impl PmuCounterStopFlags {
+    /// Constructs a new PmuCounterStopFlags from a valid passed-in value.
+    pub fn from_raw_value(value: u64) -> Result<Self> {
+        match value {
+            0 | 1 => Ok(PmuCounterStopFlags(value)),
+            _ => Err(Error::InvalidParam),
+        }
+    }
+
+    /// Returns the raw value of the inner bit-flag field.
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+
+    /// Sets the stop_reset bit-flag (resets the counter after stopping).
+    pub fn set_reset_flag(self) -> Self {
+        PmuCounterStopFlags(self.0 | 1)
+    }
+
+    /// Returns if the stop_reset bit flag is set.
+    pub fn is_reset_flag(&self) -> bool {
+        self.0 & 1 != 0
+    }
+}
+
+/// This encapsulates the counter information returned by the call to sbi_pmu_counter_get_info.
+#[derive(Copy, Clone, Debug)]
+pub struct PmuCounterInfo(u64);
+
+impl PmuCounterInfo {
+    /// Constructs a PmuCounterInfo from the passed in value.
+    pub fn new(value: u64) -> Self {
+        PmuCounterInfo(value)
+    }
+
+    /// Returns the inner value.
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+
+    /// Returns if the counter is a hardware counter.
+    pub fn is_hardware_counter(&self) -> bool {
+        self.0 & (1 << 63) == 0
+    }
+
+    /// Returns if the counter is a firmware counter.
+    pub fn is_firmware_counter(&self) -> bool {
+        !self.is_hardware_counter()
+    }
+
+    /// Returns the 12-bit CSR number associated with the counter.
+    pub fn get_csr(&self) -> u64 {
+        self.0 & 0xFFF
+    }
+
+    /// Returns the counter width (one less than number of CSR-bits).
+    pub fn get_counter_width(&self) -> u64 {
+        (self.0 >> 12) & 0x3F
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+/// Enumeration of the event types.
+pub enum PmuEventType {
+    /// Represents the hardware general events (type #0) in the SBI documentation.
+    Hardware(PmuHardware),
+    /// Represents the hardware cache events (type #1) in the SBI documentation.
+    Cache(PmuHwCacheParams),
+    /// Represents the firmware events (type #15) in the SBI documentation.
+    Firmware(PmuFirmware),
+}
+
+impl Default for PmuEventType {
+    fn default() -> Self {
+        Self::Hardware(PmuHardware::CpuCycles)
+    }
+}
+
+const EVENT_TYPE_SHIFT: u64 = 16;
+impl PmuEventType {
+    /// Returns the encoded representation of the type.
+    pub fn raw(&self) -> u64 {
+        const HARDWARE_CACHE_EVENT_TYPE: u64 = 1;
+        const FIRMWARE_EVENT_TYPE: u64 = 0xF;
+        use PmuEventType::*;
+        match self {
+            Hardware(p) => *p as u64,
+            Cache(p) => p.raw() | (HARDWARE_CACHE_EVENT_TYPE << EVENT_TYPE_SHIFT),
+            Firmware(p) => *p as u64 | (FIRMWARE_EVENT_TYPE << EVENT_TYPE_SHIFT),
+        }
+    }
+
+    /// Constructs PmuEventType from a valid passed-in value.
+    pub fn from_raw_value(value: u64) -> Result<Self> {
+        use PmuEventType::*;
+        const EVENT_TYPE_INVERSE_MASK: u64 = !(0xF << EVENT_TYPE_SHIFT);
+        match value >> EVENT_TYPE_SHIFT {
+            0 => Ok(Hardware(PmuHardware::from_raw_value(
+                value & EVENT_TYPE_INVERSE_MASK,
+            )?)),
+            1 => Ok(Cache(PmuHwCacheParams::from_raw_value(
+                value & EVENT_TYPE_INVERSE_MASK,
+            )?)),
+            0xF => Ok(Firmware(PmuFirmware::from_raw_value(
+                value & EVENT_TYPE_INVERSE_MASK,
+            )?)),
+            _ => Err(Error::InvalidParam),
+        }
+    }
+}
+
+/// Enumeration of the hardware event types.
+#[derive(Copy, Clone, Debug)]
+#[repr(u64)]
+pub enum PmuHardware {
+    /// Identifier for CPU cycle events.
+    CpuCycles = 1,
+    /// Identifier for retired instruction events.
+    Instructions = 2,
+    /// Identifier for cache hit events.
+    CacheReferences = 3,
+    /// Identifier for cache miss events.
+    CacheMisses = 4,
+    /// Identifier for branch instruction events.
+    BranchInstructions = 5,
+    /// Identifier for branch misprediction events.
+    BranchMisses = 6,
+    /// Identifier for bus cycle events.
+    BusCycles = 7,
+    /// Identifier for stalled front-end cycle events.
+    StalledCyclesFrontEnd = 8,
+    /// Identifier for stalled back-end cycle events.
+    StalledCyclesBackEnd = 9,
+    /// Identifier for reference CPU cycle  events.
+    ReferenceCpuCycles = 10,
+}
+
+impl PmuHardware {
+    /// Constructs PmuHardware from a valid passed-in value.
+    pub fn from_raw_value(value: u64) -> Result<Self> {
+        use PmuHardware::*;
+        match value {
+            1 => Ok(CpuCycles),
+            2 => Ok(Instructions),
+            3 => Ok(CacheReferences),
+            4 => Ok(CacheMisses),
+            5 => Ok(BranchInstructions),
+            6 => Ok(BranchMisses),
+            7 => Ok(BusCycles),
+            8 => Ok(StalledCyclesFrontEnd),
+            9 => Ok(StalledCyclesBackEnd),
+            10 => Ok(ReferenceCpuCycles),
+            _ => Err(Error::InvalidParam),
+        }
+    }
+}
+
+/// Enumeration of cache event types (for use with PmuHardware of type CacheReferences/CacheMisses).
+#[derive(Copy, Clone, Debug)]
+#[repr(u64)]
+pub enum PmuHwCache {
+    /// Identifier for first level data cache.
+    L1DataCache = 0,
+    /// Identifier for first level instruction cache.
+    L1InstructionCache = 1,
+    /// Identifier for last level cache.
+    LlCache = 2,
+    /// Identifier for data TLB cache.
+    DataTlbCache = 3,
+    /// Identifier for instruction TLB cache.
+    InstructionTlbCache = 4,
+    /// Identifier for branch predictor cache.
+    BranchPredictorCache = 5,
+    /// Identifier for NUMA node cache.
+    NumaNodeCache = 6,
+}
+
+impl PmuHwCache {
+    /// Constructs PmuHwCache from a valid passed-in value.
+    pub fn from_raw_value(value: u64) -> Result<Self> {
+        use PmuHwCache::*;
+        match value {
+            0 => Ok(L1DataCache),
+            1 => Ok(L1InstructionCache),
+            2 => Ok(LlCache),
+            3 => Ok(DataTlbCache),
+            4 => Ok(InstructionTlbCache),
+            5 => Ok(BranchPredictorCache),
+            6 => Ok(NumaNodeCache),
+            _ => Err(Error::InvalidParam),
+        }
+    }
+}
+
+/// Enumeration of cache op_ids (for use with PmuHardware of type CacheReferences/CacheMisses).
+#[derive(Copy, Clone, Debug)]
+#[repr(u64)]
+pub enum PmuHwCacheOpId {
+    /// Identifier for a cache read op_id.
+    Read = 0,
+    /// Identifier for a cache write op_id.
+    Write = 1,
+    /// Identifier for a cache prefetch op_id.
+    Prefetch = 2,
+}
+
+impl PmuHwCacheOpId {
+    /// Constructs PmuHwCacheOpId from a valid passed-in value.
+    pub fn from_raw_value(value: u64) -> Result<Self> {
+        use PmuHwCacheOpId::*;
+        match value {
+            0 => Ok(Read),
+            1 => Ok(Write),
+            2 => Ok(Prefetch),
+            _ => Err(Error::InvalidParam),
+        }
+    }
+}
+
+/// Enumeration of results returned by cache counter reads.
+#[derive(Copy, Clone, Debug)]
+#[repr(u64)]
+pub enum PmuHwCacheResultId {
+    /// Cache miss.
+    CacheMiss = 0,
+    /// Cache hit.
+    CacheHit = 1,
+}
+
+impl PmuHwCacheResultId {
+    /// Constructs PmuHwCacheResultId from a valid passed-in value.
+    pub fn from_raw_value(value: u64) -> Result<Self> {
+        use PmuHwCacheResultId::*;
+        match value {
+            0 => Ok(CacheMiss),
+            1 => Ok(CacheHit),
+            _ => Err(Error::InvalidParam),
+        }
+    }
+}
+
+/// Structure to encapsulate parameters for PmuHardware of type CacheReferences/CacheMisses).
+#[derive(Copy, Clone, Debug)]
+pub struct PmuHwCacheParams {
+    cache_id: PmuHwCache,
+    op_id: PmuHwCacheOpId,
+    result_id: PmuHwCacheResultId,
+}
+
+impl PmuHwCacheParams {
+    /// Constructs PmuHwCacheParams with the passed-in parameters.
+    pub fn new(cache_id: PmuHwCache, op_id: PmuHwCacheOpId, result_id: PmuHwCacheResultId) -> Self {
+        Self {
+            cache_id,
+            op_id,
+            result_id,
+        }
+    }
+
+    /// Constructs PmuHwCacheParams from a valid encoded value.
+    pub fn from_raw_value(value: u64) -> Result<Self> {
+        Ok(Self {
+            cache_id: PmuHwCache::from_raw_value(value >> 3)?,
+            op_id: PmuHwCacheOpId::from_raw_value((value >> 1) & 3)?,
+            result_id: PmuHwCacheResultId::from_raw_value(value & 1)?,
+        })
+    }
+
+    /// Returns the encoded value corresponding to the inner values.
+    pub fn raw(&self) -> u64 {
+        (self.result_id as u64) | ((self.op_id as u64) << 1) | ((self.cache_id as u64) << 3)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+#[repr(u64)]
+/// Enumeration of the firmware event types.
+pub enum PmuFirmware {
+    /// Misaligned load trap event.
+    MisalignedLoad = 0,
+    /// Misaligned store trap event.
+    MisalignedStore = 1,
+    /// Access load trap event.
+    AccessLoad = 2,
+    /// Access store trap event.
+    AccessStore = 3,
+    /// Illegal instruction trap event.
+    IllegalInstruction = 4,
+    /// Set timer event.
+    SetTimer = 5,
+    /// IPI sent event.
+    IpiSent = 6,
+    /// IPI received event.
+    IpiReceived = 7,
+    /// FENCE.I request sent event.
+    FenceISent = 8,
+    /// FENCE.I request received event.
+    FenceIReceived = 9,
+    /// SFENCE.VMA request sent event.
+    SfenceVmaSent = 10,
+    /// SFENCE.VMA request received event.
+    SfenceVmaReceived = 11,
+    /// SFENCE.ASID request sent event.
+    SfenceAsidSent = 12,
+    /// SFENCE.ASID request received event.
+    SfenceAsidReceived = 13,
+    /// HFENCE.GVMA request sent event.
+    HfenceGvmaSent = 14,
+    /// H
+    HfenceGvmaReceived = 15,
+    /// HFENCE.GVMA request sent event.
+    HfenceVmidSent = 16,
+    /// HFENCE.GVMA request received event.
+    HfenceVmidReceived = 17,
+    /// HFENCE.VVMA request sent event.
+    HfenceVvmaSent = 18,
+    /// HFEMA request received event.
+    HfenceVvmaReceived = 19,
+    /// HFENCE.ASID request sent event.
+    HfenceVvmaAsidSent = 20,
+    /// HFENCE.ASID request received event.
+    HfenceVvmaAsidReceived = 21,
+}
+
+impl PmuFirmware {
+    fn from_raw_value(value: u64) -> Result<Self> {
+        use PmuFirmware::*;
+        match value {
+            0 => Ok(MisalignedLoad),
+            1 => Ok(MisalignedStore),
+            2 => Ok(AccessLoad),
+            3 => Ok(AccessStore),
+            4 => Ok(IllegalInstruction),
+            5 => Ok(SetTimer),
+            6 => Ok(IpiSent),
+            7 => Ok(IpiReceived),
+            8 => Ok(FenceISent),
+            9 => Ok(FenceIReceived),
+            10 => Ok(SfenceVmaSent),
+            11 => Ok(SfenceVmaReceived),
+            12 => Ok(SfenceAsidSent),
+            13 => Ok(SfenceAsidReceived),
+            14 => Ok(HfenceGvmaSent),
+            15 => Ok(HfenceGvmaReceived),
+            16 => Ok(HfenceVmidSent),
+            17 => Ok(HfenceVmidReceived),
+            18 => Ok(HfenceVvmaSent),
+            19 => Ok(HfenceVvmaReceived),
+            20 => Ok(HfenceVvmaAsidSent),
+            21 => Ok(HfenceVvmaAsidReceived),
+            _ => Err(Error::InvalidParam),
+        }
+    }
+}
+
+impl PmuFunction {
+    /// Attempts to parse `Self` from the passed in `a0-a7`.
+    pub(crate) fn from_regs(args: &[u64]) -> Result<Self> {
+        use PmuFunction::*;
+        match args[6] {
+            0 => Ok(GetNumCounters),
+            1 => Ok(GetCounterInfo(args[0])),
+            2 => Ok(ConfigureMatchingCounters {
+                counter_index: args[0],
+                counter_mask: args[1],
+                config_flags: PmuCounterConfigFlags::from_raw_value(args[2])?,
+                event_type: PmuEventType::from_raw_value(args[3])?,
+                event_data: args[4],
+            }),
+            3 => Ok(StartCounters {
+                counter_index: args[0],
+                counter_mask: args[1],
+                start_flags: PmuCounterStartFlags::from_raw_value(args[2])?,
+                initial_value: args[3],
+            }),
+            4 => Ok(StopCounters {
+                counter_index: args[0],
+                counter_mask: args[1],
+                stop_flags: PmuCounterStopFlags::from_raw_value(args[2])?,
+            }),
+            5 => Ok(ReadFirmwareCounter(args[0])),
+            _ => Err(Error::NotSupported),
+        }
+    }
+}
+
+impl SbiFunction for PmuFunction {
+    fn a6(&self) -> u64 {
+        use PmuFunction::*;
+        match self {
+            GetNumCounters => 0,
+            GetCounterInfo(_) => 1,
+            ConfigureMatchingCounters {
+                counter_index: _,
+                counter_mask: _,
+                config_flags: _,
+                event_type: _,
+                event_data: _,
+            } => 2,
+            StartCounters {
+                counter_index: _,
+                counter_mask: _,
+                start_flags: _,
+                initial_value: _,
+            } => 3,
+            StopCounters {
+                counter_index: _,
+                counter_mask: _,
+                stop_flags: _,
+            } => 4,
+            ReadFirmwareCounter(_) => 5,
+        }
+    }
+
+    fn a5(&self) -> u64 {
+        0
+    }
+
+    fn a4(&self) -> u64 {
+        use PmuFunction::*;
+        match self {
+            ConfigureMatchingCounters {
+                counter_index: _,
+                counter_mask: _,
+                config_flags: _,
+                event_type: _,
+                event_data,
+            } => *event_data,
+            _ => 0,
+        }
+    }
+
+    fn a3(&self) -> u64 {
+        use PmuFunction::*;
+        match self {
+            ConfigureMatchingCounters {
+                counter_index: _,
+                counter_mask: _,
+                config_flags: _,
+                event_type,
+                event_data: _,
+            } => event_type.raw(),
+            StartCounters {
+                counter_index: _,
+                counter_mask: _,
+                start_flags: _,
+                initial_value,
+            } => *initial_value,
+            _ => 0,
+        }
+    }
+
+    fn a2(&self) -> u64 {
+        use PmuFunction::*;
+        match self {
+            ConfigureMatchingCounters {
+                counter_index: _,
+                counter_mask: _,
+                config_flags,
+                event_type: _,
+                event_data: _,
+            } => config_flags.raw(),
+            StartCounters {
+                counter_index: _,
+                counter_mask: _,
+                start_flags,
+                initial_value: _,
+            } => start_flags.raw(),
+            StopCounters {
+                counter_index: _,
+                counter_mask: _,
+                stop_flags,
+            } => stop_flags.raw(),
+            _ => 0,
+        }
+    }
+
+    fn a1(&self) -> u64 {
+        use PmuFunction::*;
+        match self {
+            ConfigureMatchingCounters {
+                counter_index: _,
+                counter_mask,
+                config_flags: _,
+                event_type: _,
+                event_data: _,
+            } => *counter_mask,
+            StartCounters {
+                counter_index: _,
+                counter_mask,
+                start_flags: _,
+                initial_value: _,
+            } => *counter_mask,
+            StopCounters {
+                counter_index: _,
+                counter_mask,
+                stop_flags: _,
+            } => *counter_mask,
+            _ => 0,
+        }
+    }
+
+    fn a0(&self) -> u64 {
+        use PmuFunction::*;
+        match self {
+            GetCounterInfo(counter_index) => *counter_index,
+            ConfigureMatchingCounters {
+                counter_index,
+                counter_mask: _,
+                config_flags: _,
+                event_type: _,
+                event_data: _,
+            } => *counter_index,
+            StartCounters {
+                counter_index,
+                counter_mask: _,
+                start_flags: _,
+                initial_value: _,
+            } => *counter_index,
+            StopCounters {
+                counter_index,
+                counter_mask: _,
+                stop_flags: _,
+            } => *counter_index,
+            ReadFirmwareCounter(counter_index) => *counter_index,
+            _ => 0,
+        }
+    }
+
+    fn result(&self, a0: u64, a1: u64) -> Result<u64> {
+        match a0 {
+            0 => Ok(a1),
+            e => Err(Error::from_code(e as i64)),
+        }
+    }
+}

--- a/sbi/src/sbi.rs
+++ b/sbi/src/sbi.rs
@@ -29,6 +29,10 @@ pub use state::*;
 mod tsm;
 pub use tsm::*;
 
+// The PMU SBI extension
+mod pmu;
+pub use pmu::*;
+
 /// Interfaces for invoking SBI functionality.
 pub mod api;
 
@@ -106,6 +110,8 @@ pub enum SbiMessage {
     Tee(TeeFunction),
     /// The extension for getting attestation evidences and extending measurements.
     Attestation(AttestationFunction),
+    /// The extension for getting performance counter state.
+    Pmu(PmuFunction),
 }
 
 impl SbiMessage {
@@ -120,6 +126,7 @@ impl SbiMessage {
             EXT_RESET => ResetFunction::from_regs(args).map(SbiMessage::Reset),
             EXT_TEE => TeeFunction::from_regs(args).map(SbiMessage::Tee),
             EXT_ATTESTATION => AttestationFunction::from_regs(args).map(SbiMessage::Attestation),
+            EXT_PMU => PmuFunction::from_regs(args).map(SbiMessage::Pmu),
             _ => Err(Error::NotSupported),
         }
     }
@@ -133,6 +140,7 @@ impl SbiMessage {
             SbiMessage::Reset(_) => EXT_RESET,
             SbiMessage::Tee(_) => EXT_TEE,
             SbiMessage::Attestation(_) => EXT_ATTESTATION,
+            SbiMessage::Pmu(_) => EXT_PMU,
         }
     }
 
@@ -145,6 +153,7 @@ impl SbiMessage {
             SbiMessage::Reset(_) => 0,
             SbiMessage::Tee(f) => f.a6(),
             SbiMessage::Attestation(f) => f.a6(),
+            SbiMessage::Pmu(f) => f.a6(),
         }
     }
 
@@ -152,6 +161,7 @@ impl SbiMessage {
     pub fn a5(&self) -> u64 {
         match self {
             SbiMessage::Tee(f) => f.a5(),
+            SbiMessage::Pmu(f) => f.a5(),
             _ => 0,
         }
     }
@@ -160,6 +170,7 @@ impl SbiMessage {
     pub fn a4(&self) -> u64 {
         match self {
             SbiMessage::Tee(f) => f.a4(),
+            SbiMessage::Pmu(f) => f.a4(),
             _ => 0,
         }
     }
@@ -169,6 +180,7 @@ impl SbiMessage {
         match self {
             SbiMessage::Tee(f) => f.a3(),
             SbiMessage::Attestation(f) => f.a3(),
+            SbiMessage::Pmu(f) => f.a3(),
             _ => 0,
         }
     }
@@ -179,6 +191,7 @@ impl SbiMessage {
             SbiMessage::HartState(f) => f.a2(),
             SbiMessage::Tee(f) => f.a2(),
             SbiMessage::Attestation(f) => f.a2(),
+            SbiMessage::Pmu(f) => f.a2(),
             _ => 0,
         }
     }
@@ -190,6 +203,7 @@ impl SbiMessage {
             SbiMessage::HartState(f) => f.a1(),
             SbiMessage::Tee(f) => f.a1(),
             SbiMessage::Attestation(f) => f.a1(),
+            SbiMessage::Pmu(f) => f.a1(),
             _ => 0,
         }
     }
@@ -202,6 +216,7 @@ impl SbiMessage {
             SbiMessage::HartState(f) => f.a0(),
             SbiMessage::Tee(f) => f.a0(),
             SbiMessage::Attestation(f) => f.a0(),
+            SbiMessage::Pmu(f) => f.a0(),
             _ => 0,
         }
     }

--- a/sbi/src/sbi.rs
+++ b/sbi/src/sbi.rs
@@ -283,3 +283,8 @@ pub unsafe fn ecall_send(msg: &SbiMessage) -> Result<u64> {
 
     msg.result(a0, a1)
 }
+
+#[cfg(not(any(target_arch = "riscv64", target_os = "none")))]
+unsafe fn ecall_send(_msg: &SbiMessage) -> Result<u64> {
+    panic!("ecall_send called");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@
     allocator_api,
     alloc_error_handler,
     lang_items,
+    if_let_guard,
     asm_const,
     const_ptr_offset_from,
     ptr_sub_ptr,
@@ -34,7 +35,7 @@ mod vm_id;
 mod vm_pages;
 
 use device_tree::{DeviceTree, Fdt};
-use drivers::{imsic::Imsic, iommu::Iommu, pci::PcieRoot, CpuInfo};
+use drivers::{imsic::Imsic, iommu::Iommu, pci::PcieRoot, pmu::PmuInfo, CpuInfo};
 use host_vm_loader::HostVmLoader;
 use hyp_alloc::HypAlloc;
 use page_tracking::*;
@@ -521,6 +522,12 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
             println!("Failed to probe IOMMU: {:?}", e);
         }
     };
+
+    // Get platform PMU counter information
+    let result = PmuInfo::init();
+    if result.is_err() {
+        println!("PmuInfo::init() failed with {:?}", result);
+    }
 
     // Now load the host VM.
     let host = HostVmLoader::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,8 @@ use riscv_page_tables::*;
 use riscv_pages::*;
 use riscv_regs::{hedeleg, henvcfg, hideleg, hie, satp, scounteren};
 use riscv_regs::{
-    Exception, Interrupt, LocalRegisterCopy, ReadWriteable, SatpHelpers, Writeable, CSR,
+    Exception, Interrupt, LocalRegisterCopy, ReadWriteable, SatpHelpers, Writeable, CSR, CSR_CYCLE,
+    CSR_TIME,
 };
 use s_mode_utils::abort::abort;
 use smp::PerCpu;
@@ -390,8 +391,9 @@ pub fn setup_csrs() {
     hie.modify(Interrupt::VirtualSupervisorExternal.to_hie_field().unwrap());
     CSR.hie.set(hie.get());
 
-    // Make counters available to guests.
-    CSR.hcounteren.set(0xffff_ffff_ffff_ffff);
+    // TODO: Handle virtualization of timer/htimedelta (see issue #46)
+    // Enable access to timer for now.
+    CSR.hcounteren.set(1 << (CSR_TIME - CSR_CYCLE));
 
     // Make the basic counters available to any of our U-mode tasks.
     let mut scounteren = LocalRegisterCopy::<u64, scounteren::Register>::new(0);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -637,7 +637,9 @@ impl<T: GuestStagePagingMode> Vm<T, VmStateFinalized> {
             SbiMessage::Attestation(attestation_func) => {
                 self.handle_attestation_msg(attestation_func, active_vcpu.active_pages())
             }
-            SbiMessage::Pmu(_) => EcallAction::Continue(SbiReturn::from(Err(SbiError::NotSupported))),
+            SbiMessage::Pmu(_) => {
+                EcallAction::Continue(SbiReturn::from(Err(SbiError::NotSupported)))
+            }
         }
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -637,6 +637,7 @@ impl<T: GuestStagePagingMode> Vm<T, VmStateFinalized> {
             SbiMessage::Attestation(attestation_func) => {
                 self.handle_attestation_msg(attestation_func, active_vcpu.active_pages())
             }
+            SbiMessage::Pmu(_) => EcallAction::Continue(SbiReturn::from(Err(SbiError::NotSupported))),
         }
     }
 

--- a/test-workloads/Cargo.toml
+++ b/test-workloads/Cargo.toml
@@ -11,3 +11,4 @@ der = "0.6.0"
 device_tree = { path = "../device-tree" }
 s_mode_utils = { path = "../s-mode-utils" }
 sbi = { path = "../sbi" }
+riscv_regs = { path = "../riscv-regs" }


### PR DESCRIPTION
This patch series adds PMU counter support.
1) The first commit adds PMU SBI extension types
2) The second commit adds convenience wrappers for the SBI calls
3) The third commit adds a PMU driver
4) The fourth implements a pass-through layer for PMU SBI calls
5) The fifth commit adds some counter booking 
6) The sixth commit adds rudimentary support for counter save and restore
7) The seventh commit adds PMU counter virtualization for HW counters
8) The final commit adds test functionality