### PR TITLE
Add missing extensions to the attestation certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,10 @@ dependencies = [
  "digest 0.10.3",
  "ed25519",
  "ed25519-dalek",
+ "flagset",
  "generic-array",
  "lazy_static",
- "spin 0.5.2",
+ "spin 0.9.3",
  "spki",
 ]
 
@@ -117,6 +118,7 @@ checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
 dependencies = [
  "const-oid",
  "der_derive",
+ "flagset",
 ]
 
 [[package]]
@@ -219,6 +221,12 @@ dependencies = [
  "static_assertions",
  "unsafe_unwrap",
 ]
+
+[[package]]
+name = "flagset"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda653ca797810c02f7ca4b804b40b8b95ae046eb989d356bce17919a8c25499"
 
 [[package]]
 name = "generic-array"

--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -7,10 +7,11 @@ edition = "2021"
 [dependencies]
 arrayvec = { version = "0.7.2", default-features = false }
 const-oid = { version = "0.9.0", features = ["db"] }
-der = { version = "0.6.0", features = ["derive", "oid"] }
+der = { version = "0.6.0", features = ["derive", "flagset", "oid"] }
 digest = {version = "0.10.3", default-features = false }
 ed25519 = { version = "1.5.2", default-features = false, features = ["pkcs8"] }
 ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend"] }
+flagset = "0.4.3"
 generic-array = "0.14.5"
 lazy_static = { version = "1.4.0", default-features = false, features = ["spin_no_std"] }
 spin = { version = "*", default-features = false }

--- a/attestation/src/extensions/pkix.rs
+++ b/attestation/src/extensions/pkix.rs
@@ -8,6 +8,11 @@
 pub mod name;
 
 mod authkeyid;
+/// keyUsage X.509 extension module.
+/// This extension describes the intended usage for the subject public key
+/// information (a.k.a. the public key) a certificate is bound to: Key
+/// agreement, key wrapping, certificate signing authority, etc.
+pub mod keyusage;
 
 use crate::attr::AttributeTypeAndValue;
 

--- a/attestation/src/extensions/pkix.rs
+++ b/attestation/src/extensions/pkix.rs
@@ -7,7 +7,10 @@
 
 pub mod name;
 
-mod authkeyid;
+/// authorityKeyIdentifier extension module.
+/// This extension provides a means of identifying the public key corresponding
+/// to the private key used to sign a certificate.
+pub mod authkeyid;
 
 /// basiConstraints X.509 extension module.
 /// This extension identifies wether the subject of a certificate is a CA.

--- a/attestation/src/extensions/pkix.rs
+++ b/attestation/src/extensions/pkix.rs
@@ -8,10 +8,16 @@
 pub mod name;
 
 mod authkeyid;
+
+/// basiConstraints X.509 extension module.
+/// This extension identifies wether the subject of a certificate is a CA.
+pub mod basicconstraints;
+
 /// keyUsage X.509 extension module.
 /// This extension describes the intended usage for the subject public key
 /// information (a.k.a. the public key) a certificate is bound to: Key
 /// agreement, key wrapping, certificate signing authority, etc.
+/// keyUsage extension module
 pub mod keyusage;
 
 use crate::attr::AttributeTypeAndValue;

--- a/attestation/src/extensions/pkix/authkeyid.rs
+++ b/attestation/src/extensions/pkix/authkeyid.rs
@@ -1,4 +1,7 @@
 // Copyright (c) 2021 The RustCrypto Project Developers
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
 
 use super::name::GeneralNames;
 
@@ -6,6 +9,8 @@ use const_oid::db::rfc5280::ID_CE_AUTHORITY_KEY_IDENTIFIER;
 use const_oid::{AssociatedOid, ObjectIdentifier};
 use der::asn1::{OctetStringRef, UIntRef};
 use der::Sequence;
+
+pub(crate) const AUTH_KEY_ID_EXTENSION_LEN: usize = 32;
 
 /// AuthorityKeyIdentifier as defined in [RFC 5280 Section 4.2.1.1].
 ///

--- a/attestation/src/extensions/pkix/basicconstraints.rs
+++ b/attestation/src/extensions/pkix/basicconstraints.rs
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 The RustCrypto Project Developers
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use const_oid::{db::rfc5280::ID_CE_BASIC_CONSTRAINTS, AssociatedOid, ObjectIdentifier};
+use der::Sequence;
+
+pub(crate) const BASIC_CONSTRAINTS_EXTENSION_LEN: usize = 16;
+
+/// BasicConstraints as defined in [RFC 5280 Section 4.2.1.9].
+///
+/// ```text
+/// BasicConstraints ::= SEQUENCE {
+///     cA                      BOOLEAN DEFAULT FALSE,
+///     pathLenConstraint       INTEGER (0..MAX) OPTIONAL
+/// }
+/// ```
+///
+/// [RFC 5280 Section 4.2.1.9]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.9
+#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+#[allow(missing_docs)]
+pub struct BasicConstraints {
+    #[asn1(default = "Default::default")]
+    pub ca: bool,
+    pub path_len_constraint: Option<u8>,
+}
+
+impl AssociatedOid for BasicConstraints {
+    const OID: ObjectIdentifier = ID_CE_BASIC_CONSTRAINTS;
+}

--- a/attestation/src/extensions/pkix/keyusage.rs
+++ b/attestation/src/extensions/pkix/keyusage.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 The RustCrypto Project Developers
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use const_oid::db::rfc5280::ID_CE_KEY_USAGE;
+use const_oid::AssociatedOid;
+use der::asn1::ObjectIdentifier;
+use flagset::{flags, FlagSet};
+
+pub(crate) const KEY_VALUE_EXTENSION_LEN: usize = 8;
+
+flags! {
+    /// Key usage flags as defined in [RFC 5280 Section 4.2.1.3].
+    ///
+    /// ```text
+    /// KeyUsage ::= BIT STRING {
+    ///      digitalSignature        (0),
+    ///      nonRepudiation          (1),  -- recent editions of X.509 have
+    ///                                    -- renamed this bit to contentCommitment
+    ///      keyEncipherment         (2),
+    ///      dataEncipherment        (3),
+    ///      keyAgreement            (4),
+    ///      keyCertSign             (5),
+    ///      cRLSign                 (6),
+    ///      encipherOnly            (7),
+    ///      decipherOnly            (8)
+    /// }
+    /// ```
+    ///
+    /// [RFC 5280 Section 4.2.1.3]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3
+    #[allow(missing_docs)]
+    pub enum KeyUsageFlags: u16 {
+        DigitalSignature = 1 << 0,
+        NonRepudiation = 1 << 1,
+        KeyEncipherment = 1 << 2,
+        DataEncipherment = 1 << 3,
+        KeyAgreement = 1 << 4,
+        KeyCertSign = 1 << 5,
+        CRLSign = 1 << 6,
+        EncipherOnly = 1 << 7,
+        DecipherOnly = 1 << 8,
+    }
+}
+
+/// KeyUsage as defined in [RFC 5280 Section 4.2.1.3].
+///
+/// [RFC 5280 Section 4.2.1.3]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct KeyUsage(pub FlagSet<KeyUsageFlags>);
+
+impl AssociatedOid for KeyUsage {
+    const OID: ObjectIdentifier = ID_CE_KEY_USAGE;
+}
+
+impl_newtype!(KeyUsage, FlagSet<KeyUsageFlags>);
+
+impl KeyUsage {
+    /// Build a KeyUsage from a set of KeyUsageFlags
+    pub fn new(flags: impl Into<FlagSet<KeyUsageFlags>>) -> KeyUsage {
+        KeyUsage(flags.into())
+    }
+}


### PR DESCRIPTION
This PR adds 3 attestation relevant extensions to the generated attestation certificate:
* `basicConstraints` to clearly state that the CSR provided key can not be directly used for CA purposes (It is not derived from the platform's attestation key)
* `keyUsage` to identify how the CSR provided key can be used (key wrapping and key exchange)
* `authorityKeyIdentifier` to identify which public key is used to sign the certificate.