### PR TITLE
Use Makefile targets from the gh workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,14 +23,14 @@ jobs:
     - name: Install rustfmt
       run: rustup component add rustfmt
     - name: Build
-      run: cargo build --verbose
+      run: make salus
     - name: Build tellus
-      run: cargo build --package test_workloads --bin tellus --verbose
+      run: make tellus
     - name: Build guestvm
-      run: cargo build --package test_workloads --bin guestvm --verbose
+      run: make guestvm
     - name: Lint
-      run: cargo clippy -- -D warnings  -Wmissing-docs
+      run: make lint
     - name: Format
-      run: cargo fmt -- --check --config format_code_in_doc_comments=true
+      run: make format
     - name: Run tests
       run: make check

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ifdef LOCAL_PATH
 LOCAL_PATH:=${LOCAL_PATH}/
 endif
 
-HOST_TRIPLET := $(shell cargo -Vv | grep '^host:' | awk ' { print $$2; } ') 
+HOST_TRIPLET := $(shell cargo -Vv | grep '^host:' | awk ' { print $$2; } ')
 
 all: salus tellus guestvm
 
@@ -64,3 +64,14 @@ run_linux: salus
 		     -kernel target/riscv64gc-unknown-none-elf/release/salus \
 		     -device guest-loader,kernel=../linux/arch/riscv/boot/Image,addr=0xc0200000 \
 		     -append "console=ttyS0 earlycon=sbi keep_bootcon bootmem_debug"
+
+.PHONY: lint
+lint:
+	cargo clippy -- -D warnings  -Wmissing-docs
+
+.PHONY: format
+format:
+	cargo fmt -- --check --config format_code_in_doc_comments=true
+
+.PHONY: ci
+ci: salus guestvm tellus lint format check

--- a/page-tracking/src/lib.rs
+++ b/page-tracking/src/lib.rs
@@ -22,7 +22,7 @@
 //!                                  -------> `SequentialPages` for hypervisor setup
 
 #![no_std]
-#![feature(allocator_api, let_chains, try_reserve_kind)]
+#![feature(allocator_api, try_reserve_kind)]
 
 extern crate alloc;
 

--- a/riscv-page-tables/src/lib.rs
+++ b/riscv-page-tables/src/lib.rs
@@ -27,7 +27,6 @@
 //! address translation). Interacting directly with memory currently mapped to a VM will lead to
 //! pain so the interfaces don't support that.
 #![no_std]
-#![feature(let_chains)]
 
 extern crate alloc;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@
     lang_items,
     asm_const,
     const_ptr_offset_from,
-    let_chains,
     ptr_sub_ptr
 )]
 


### PR DESCRIPTION
So that we can run said workflow locally through `make ci`.

This PR also fixes a 1.64.0 new warning.