### PR TITLE
Use the Global allocator for boot-time dynamic memory allocation

### DIFF
--- a/device-tree/src/serialize.rs
+++ b/device-tree/src/serialize.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::DeviceTree;
-use core::{alloc::Allocator, mem};
+use core::mem;
 
 const FDT_ALIGN: usize = 4;
 
@@ -206,13 +206,13 @@ impl<'a> FdtWriter<'a> {
 
 /// Helper for serializing a `DeviceTree` object to an FDT binary, as specified in v0.3 of the
 /// Devicetree Specification.
-pub struct DeviceTreeSerializer<'a, A: Allocator + Clone> {
+pub struct DeviceTreeSerializer<'a> {
     layout: FdtLayout,
-    tree: &'a DeviceTree<A>,
+    tree: &'a DeviceTree,
 }
 
-impl<'a, A: Allocator + Clone> DeviceTreeSerializer<'a, A> {
-    fn get_layout(tree: &DeviceTree<A>) -> FdtLayout {
+impl<'a> DeviceTreeSerializer<'a> {
+    fn get_layout(tree: &DeviceTree) -> FdtLayout {
         let mut struct_size = 0;
         let mut strings_size = 0;
         for node in tree.iter() {
@@ -234,7 +234,7 @@ impl<'a, A: Allocator + Clone> DeviceTreeSerializer<'a, A> {
     }
 
     /// Creates a new serializer using the given tree.
-    pub fn new(tree: &'a DeviceTree<A>) -> Self {
+    pub fn new(tree: &'a DeviceTree) -> Self {
         Self {
             layout: Self::get_layout(tree),
             tree,
@@ -309,12 +309,11 @@ impl<'a, A: Allocator + Clone> DeviceTreeSerializer<'a, A> {
 mod tests {
     use super::*;
     use crate::Fdt;
-    use alloc::alloc::Global;
     use alloc::vec;
 
-    fn stub_tree() -> DeviceTree<Global> {
+    fn stub_tree() -> DeviceTree {
         // Create a tree with basic 'memory' and 'chosen' nodes.
-        let mut tree = DeviceTree::new(Global);
+        let mut tree = DeviceTree::new();
         let root = tree.add_node("", None).unwrap();
         {
             let node = tree.get_mut_node(root).unwrap();

--- a/drivers/src/imsic.rs
+++ b/drivers/src/imsic.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use arrayvec::{ArrayString, ArrayVec};
-use core::{alloc::Allocator, fmt, marker::PhantomData};
+use core::{fmt, marker::PhantomData};
 use device_tree::{DeviceTree, DeviceTreeResult};
 use page_tracking::HwMemMap;
 use riscv_pages::*;
@@ -339,7 +339,7 @@ impl Imsic {
     /// -------------------------------------------------------------
     ///
     /// For more details about the system IMSIC layout, see the AIA specification.
-    pub fn probe_from<A: Allocator + Clone>(dt: &DeviceTree<A>, mem_map: &mut HwMemMap) {
+    pub fn probe_from(dt: &DeviceTree, mem_map: &mut HwMemMap) {
         // If both M and S level IMSICs are present in the device-tree the M-level IMSIC should
         // have its status set to "disabled" by firmware.
         let imsic_node = dt
@@ -574,9 +574,9 @@ impl Imsic {
     /// files dedicated to the host VM should be mapped to the supervisor interrupt file location in
     /// the guest physical address space. The caller is also responsible for masking guest interrupt
     /// files that are inaccessible to the host VM in HGEIE and other CSRs.
-    pub fn add_host_imsic_node<A: Allocator + Clone>(
+    pub fn add_host_imsic_node(
         &self,
-        dt: &mut DeviceTree<A>,
+        dt: &mut DeviceTree,
         guest_base_addr: GuestPhysAddr,
     ) -> DeviceTreeResult<()> {
         let imsic = self.inner.lock();

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -30,7 +30,7 @@ pub use imsic::{
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::{alloc::Global, vec::Vec};
+    use alloc::vec::Vec;
     use device_tree::DeviceTree;
     use page_tracking::{HwMemMap, HwMemMapBuilder, HwMemRegionType};
     use riscv_pages::{DeviceMemType, PageAddr, PageSize, RawAddr};
@@ -42,9 +42,9 @@ mod tests {
     const GUEST_BITS: u32 = 3;
     const GROUP_SHIFT: u32 = 24;
 
-    fn stub_tree() -> DeviceTree<Global> {
+    fn stub_tree() -> DeviceTree {
         // Create a tree with a couple of CPUs.
-        let mut tree = DeviceTree::new(Global);
+        let mut tree = DeviceTree::new();
         let root = tree.add_node("", None).unwrap();
         let root_node = tree.get_mut_node(root).unwrap();
         root_node

--- a/drivers/src/pci/root.rs
+++ b/drivers/src/pci/root.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use arrayvec::ArrayVec;
-use core::alloc::Allocator;
 use device_tree::DeviceTree;
 use page_tracking::HwMemMap;
 use riscv_pages::{DeviceMemType, PageAddr, PageSize, RawAddr, SupervisorPageAddr};
@@ -117,10 +116,7 @@ impl From<U64Cell> for u64 {
 
 impl PcieRoot {
     /// Creates a `PcieRoot` singleton by finding a supported configuration in the passed `DeviceTree`.
-    pub fn probe_from<A: Allocator + Clone>(
-        dt: &DeviceTree<A>,
-        mem_map: &mut HwMemMap,
-    ) -> Result<()> {
+    pub fn probe_from(dt: &DeviceTree, mem_map: &mut HwMemMap) -> Result<()> {
         let pci_node = dt
             .iter()
             .find(|n| n.compatible(["pci-host-ecam-generic"]) && !n.disabled())

--- a/hyp-alloc/src/hyp_alloc.rs
+++ b/hyp-alloc/src/hyp_alloc.rs
@@ -98,7 +98,7 @@ unsafe impl Sync for HypAlloc {}
 // Safety: HypAlloc uniquely owns the memory it manages, so we can safely transfer it between threads.
 unsafe impl Send for HypAlloc {}
 
-unsafe impl<'a> Allocator for &'a HypAlloc {
+unsafe impl Allocator for HypAlloc {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         let align = layout.align();
         let size = layout.size();

--- a/hyp-alloc/src/hyp_alloc.rs
+++ b/hyp-alloc/src/hyp_alloc.rs
@@ -92,6 +92,12 @@ impl HypAlloc {
     }
 }
 
+// Safety: HypAlloc is synchronized internally via a mutex, so it is safe to share a reference to it
+// between threads.
+unsafe impl Sync for HypAlloc {}
+// Safety: HypAlloc uniquely owns the memory it manages, so we can safely transfer it between threads.
+unsafe impl Send for HypAlloc {}
+
 unsafe impl<'a> Allocator for &'a HypAlloc {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         let align = layout.align();

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@
     slice_ptr_get
 )]
 
-use alloc::alloc::Global;
 use core::alloc::{Allocator, GlobalAlloc, Layout};
 use core::ptr::NonNull;
 
@@ -293,9 +292,9 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
 
     // Create a heap for boot-time memory allocations.
     create_heap(&mut mem_map);
-    let hyp_dt = DeviceTree::from(&hyp_fdt, Global).expect("Failed to construct device-tree");
 
-    // Discover supported CPU extensions.
+    // Discover the CPU topology.
+    let hyp_dt = DeviceTree::from(&hyp_fdt).expect("Failed to construct device-tree");
     CpuInfo::parse_from(&hyp_dt);
     let cpu_info = CpuInfo::get();
     if cpu_info.has_sstc() {


### PR DESCRIPTION
Dynamic memory allocation is going to be helpful for PCI enumeration and I'm finding the type bleed from using a custom `Allocator` to be a bit messy. We can get almost exactly the same behavior by forwarding the `Global` allocator to our custom `HypAlloc`, so let's do that instead.

Patches 1-3 are prep work for `HypAlloc`, including adding a `seal()` method to prevent further allocations.

Patch 4 implements the `GlobalAlloc` trait to forward allocations to the `HypAlloc` instance we create at startup. We use `seal()` to prevent allocations post-startup.

Patch 5 switches `DeviceTree` over to `Global` since it's something we only ever construct at boot-time.

Note that fallible allocation methods like `try_reserve()` (which we should continue to use exclusively when making dynamic memory allocations) still work as expected with `GlobalAlloc`.