### PR TITLE
PCI bus assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "arrayvec",
  "data_model",
  "device_tree",
+ "hyp_alloc",
  "page_tracking",
  "riscv_pages",
  "riscv_regs",

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 arrayvec = { version = "0.7.2", default-features = false }
 data_model = { path = "../data-model" }
 device_tree = { path = "../device-tree" }
+hyp_alloc = { path = "../hyp-alloc" }
 page_tracking = { path = "../page-tracking" }
 riscv_pages = { path = "../riscv-pages" }
 riscv_regs = { path = "../riscv-regs" }

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -5,7 +5,7 @@
 //! # Hardware drivers
 
 #![no_std]
-#![feature(allocator_api, int_log)]
+#![feature(allocator_api, int_log, result_option_inspect)]
 
 extern crate alloc;
 

--- a/drivers/src/pci/address.rs
+++ b/drivers/src/pci/address.rs
@@ -48,6 +48,16 @@ macro_rules! address_type {
             pub fn bits(&self) -> u32 {
                 self.0
             }
+
+            /// Returns the maximum possible value for this address component.
+            pub fn max() -> Self {
+                Self(Self::MAX_VAL)
+            }
+
+            /// Returns the next value for this address component.
+            pub fn next(&self) -> Option<Self> {
+                Self::try_from(self.0 + 1).ok()
+            }
         }
 
         unsigned_conversions!($T, u8, u16, u32, u64);

--- a/drivers/src/pci/bus.rs
+++ b/drivers/src/pci/bus.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use alloc::vec::Vec;
+
+use super::address::*;
+use super::config_space::PciConfigSpace;
+use super::device::PciDeviceType;
+use super::error::*;
+use super::root::{PciDeviceArena, PciDeviceId};
+
+struct BusDevice(Address, PciDeviceId);
+
+/// Represents a PCI bus.
+pub struct PciBus {
+    _bus_range: BusRange,
+    devices: Vec<BusDevice>,
+}
+
+impl PciBus {
+    /// Creates a `PciBus` by enumerating `bus_num` in `config_space`. Devices discovered while
+    /// enumerating the bus are addeded to `device_arena`.
+    pub fn enumerate(
+        config_space: &PciConfigSpace,
+        bus_num: Bus,
+        device_arena: &mut PciDeviceArena,
+    ) -> Result<Self> {
+        let bus_config = config_space
+            .bus(bus_num)
+            .ok_or(Error::OutOfBoundsBusNumber(bus_num))?;
+        let mut devices = Vec::new();
+        for dev in bus_config.devices() {
+            for header in dev.functions() {
+                // Unwrap ok, if we have a header the config space for the corresponding function
+                // must exist.
+                let func_config = config_space.config_space_for(header.address()).unwrap();
+                let pci_dev = PciDeviceType::new(func_config, header.clone())?;
+                let id = device_arena
+                    .try_insert(pci_dev)
+                    .map_err(|_| Error::AllocError)?;
+                let entry = BusDevice(header.address(), id);
+                devices.try_reserve(1).map_err(|_| Error::AllocError)?;
+                devices.push(entry);
+            }
+        }
+
+        // TODO: Recursively enumerate any bridges on this bus.
+
+        Ok(Self {
+            _bus_range: BusRange {
+                start: bus_num,
+                end: bus_num,
+            },
+            devices,
+        })
+    }
+
+    /// Returns an iterator over the device IDs on this bus.
+    pub fn devices(&self) -> impl ExactSizeIterator<Item = PciDeviceId> + '_ {
+        self.devices.iter().map(|bd| bd.1)
+    }
+}

--- a/drivers/src/pci/config_space.rs
+++ b/drivers/src/pci/config_space.rs
@@ -38,19 +38,22 @@ impl PciConfigSpace {
         }
     }
 
-    /// Returns the top-level bus.
-    pub fn root_bus(&self) -> BusConfig {
+    /// Returns the `BusConfig` for the bus at `bus_num`.
+    pub fn bus(&self, bus_num: Bus) -> Option<BusConfig> {
+        if bus_num < self.bus_range.start || bus_num > self.bus_range.end {
+            return None;
+        }
+
         let header_addr = Address::new(
             self.segment,
-            self.bus_range.start,
+            bus_num,
             Device::default(),
             Function::default(),
         );
-
-        BusConfig {
+        Some(BusConfig {
             config_space: self,
             addr: header_addr,
-        }
+        })
     }
 
     /// Returns the configuration space for the function at the given address if the address is

--- a/drivers/src/pci/device.rs
+++ b/drivers/src/pci/device.rs
@@ -1,0 +1,102 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::address::*;
+use super::bus::PciBus;
+use super::config_space::PciFuncConfigSpace;
+use super::error::*;
+use super::header::*;
+
+/// Common functionality implemented by PCI devices, regardless of type.
+pub trait PciDevice {
+    /// Returns the config space header for this device.
+    fn header(&self) -> &Header;
+
+    /// Returns the PCI bus address of this device.
+    fn address(&self) -> Address {
+        self.header().address()
+    }
+}
+
+/// Represents a PCI endpoint.
+pub struct PciEndpoint {
+    _func_config: PciFuncConfigSpace,
+    header: Header,
+}
+
+impl PciEndpoint {
+    /// Creates a new `PciEndpoint` using `func_config`.
+    fn new(func_config: PciFuncConfigSpace, header: Header) -> Result<Self> {
+        Ok(Self {
+            _func_config: func_config,
+            header,
+        })
+    }
+}
+
+impl PciDevice for PciEndpoint {
+    fn header(&self) -> &Header {
+        &self.header
+    }
+}
+
+/// Represents a PCI bridge.
+pub struct PciBridge {
+    _func_config: PciFuncConfigSpace,
+    header: Header,
+    _bus_range: BusRange,
+    child_bus: Option<PciBus>,
+}
+
+impl PciBridge {
+    /// Creates a new `PciBridge` using `func_config`. Downstream buses are initially unenumerated.
+    fn new(func_config: PciFuncConfigSpace, header: Header) -> Result<Self> {
+        Ok(Self {
+            _func_config: func_config,
+            header,
+            _bus_range: BusRange::default(),
+            child_bus: None,
+        })
+    }
+
+    /// Returns the secondary bus directly downstream of this bridge.
+    pub fn child_bus(&self) -> Option<&PciBus> {
+        self.child_bus.as_ref()
+    }
+}
+
+impl PciDevice for PciBridge {
+    fn header(&self) -> &Header {
+        &self.header
+    }
+}
+
+/// The top-level PCI device types.
+pub enum PciDeviceType {
+    /// A function endpoint (type 0) device.
+    Endpoint(PciEndpoint),
+    /// A bridge (type 1) device.
+    Bridge(PciBridge),
+}
+
+impl PciDeviceType {
+    /// Creates a `PciDeviceType` from a function config space and config space header.
+    pub fn new(func_config: PciFuncConfigSpace, header: Header) -> Result<Self> {
+        match header.header_type() {
+            HeaderType::Endpoint => Ok(PciDeviceType::Endpoint(PciEndpoint::new(
+                func_config,
+                header,
+            )?)),
+            HeaderType::PciBridge => {
+                Ok(PciDeviceType::Bridge(PciBridge::new(func_config, header)?))
+            }
+            h => Err(Error::UnsupportedHeaderType(header.address(), h)),
+        }
+    }
+}
+
+// PciEndpoint and PciBridge hold raw pointers to their config spaces. Access to that config space is
+// done through their respective interfaces which allow them to be shared and sent between threads.
+unsafe impl Send for PciDeviceType {}
+unsafe impl Sync for PciDeviceType {}

--- a/drivers/src/pci/device.rs
+++ b/drivers/src/pci/device.rs
@@ -43,21 +43,38 @@ impl PciDevice for PciEndpoint {
 
 /// Represents a PCI bridge.
 pub struct PciBridge {
-    _func_config: PciFuncConfigSpace,
+    func_config: PciFuncConfigSpace,
     header: Header,
-    _bus_range: BusRange,
+    bus_range: BusRange,
     child_bus: Option<PciBus>,
 }
 
 impl PciBridge {
     /// Creates a new `PciBridge` using `func_config`. Downstream buses are initially unenumerated.
-    fn new(func_config: PciFuncConfigSpace, header: Header) -> Result<Self> {
+    fn new(mut func_config: PciFuncConfigSpace, header: Header) -> Result<Self> {
+        // Prevent config cycles from passing beyond this bridge until we're ready to enumreate.
+        func_config.write_dword(HeaderWord::BusNumber, 0);
         Ok(Self {
-            _func_config: func_config,
+            func_config,
             header,
-            _bus_range: BusRange::default(),
+            bus_range: BusRange::default(),
             child_bus: None,
         })
+    }
+
+    /// Configures the secondary and subordinate bus numbers of the bridge such that configuration
+    /// cycles from `range.start` to `range.end` (inclusive) will be forwarded downstream.
+    pub fn assign_bus_range(&mut self, range: BusRange) {
+        let bus_dword =
+            self.address().bus().bits() | (range.start.bits() << 8) | (range.end.bits() << 16);
+        self.func_config
+            .write_dword(HeaderWord::BusNumber, bus_dword);
+        self.bus_range = range;
+    }
+
+    /// Sets the bus that is directly downstream of this bridge.
+    pub fn set_child_bus(&mut self, bus: PciBus) {
+        self.child_bus = Some(bus)
     }
 
     /// Returns the secondary bus directly downstream of this bridge.

--- a/drivers/src/pci/error.rs
+++ b/drivers/src/pci/error.rs
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::address::Address;
+use super::address::{Address, Bus};
+use super::header::HeaderType;
 
 /// Errors resulting from interacting with PCI devices.
 #[derive(Clone, Copy, Debug)]
@@ -34,7 +35,11 @@ pub enum Error {
     /// The device tree provided an invalid bus number in the `bus-range` property.
     InvalidBusNumber(u32),
     /// Invalid value in a PCI header at `address`.
-    UnknownHeaderType(Address),
+    UnsupportedHeaderType(Address, HeaderType),
+    /// Bus is not within the bounds of a config space.
+    OutOfBoundsBusNumber(Bus),
+    /// Failed to allocate memory.
+    AllocError,
 }
 
 /// Holds results for PCI operations.

--- a/drivers/src/pci/error.rs
+++ b/drivers/src/pci/error.rs
@@ -40,6 +40,8 @@ pub enum Error {
     OutOfBoundsBusNumber(Bus),
     /// Failed to allocate memory.
     AllocError,
+    /// Ran out of bus numbers while assigning buses.
+    OutOfBuses,
 }
 
 /// Holds results for PCI operations.

--- a/drivers/src/pci/error.rs
+++ b/drivers/src/pci/error.rs
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::address::Address;
+
+/// Errors resulting from interacting with PCI devices.
+#[derive(Clone, Copy, Debug)]
+pub enum Error {
+    /// The PCI configuration space provided by device tree isn't aligned to 4k.
+    ConfigSpaceMisaligned(u64),
+    /// The PCI configuration size provided by device tree isn't divisible by 4k.
+    ConfigSpaceNotPageMultiple(u64),
+    /// A PCI BAR resource provided by the device tree isn't aligned to 4k.
+    BarSpaceMisaligned(u64),
+    /// A PCI BAR resource provided by the device tree isn't divisible by 4k.
+    BarSpaceNotPageMultiple(u64),
+    /// The device tree contained an MMIO region that overlaps with other memory regions.
+    InvalidMmioRegion(page_tracking::MemMapError),
+    /// The device tree entry for the PCI host didn't provide a base register for Configuration
+    /// Space.
+    NoConfigBase,
+    /// No compatible PCI host controller found in the device tree.
+    NoCompatibleHostNode,
+    /// The device tree entry for the PCI host didn't provide a size register for Configuration
+    /// Space.
+    NoConfigSize,
+    /// The device tree entry for the PCI host didn't provide a `reg` property.
+    NoRegProperty,
+    /// The device tree entry for the PCI host didn't provide a `ranges` property.
+    NoRangesProperty,
+    /// Too many PCI resource ranges were specified in the device tree's `ranges` property.
+    TooManyBarSpaces,
+    /// The device tree provided an invalid bus number in the `bus-range` property.
+    InvalidBusNumber(u32),
+    /// Invalid value in a PCI header at `address`.
+    UnknownHeaderType(Address),
+}
+
+/// Holds results for PCI operations.
+pub type Result<T> = core::result::Result<T, Error>;

--- a/drivers/src/pci/header.rs
+++ b/drivers/src/pci/header.rs
@@ -63,6 +63,8 @@ pub enum HeaderWord {
     Class = 2,
     /// Header type (and other legacy bits).
     Type = 3,
+    /// Primary/secondary/subordinate bus numbers (type 1 headers only).
+    BusNumber = 6,
 }
 
 /// The header for a PCI function in configuration space.

--- a/drivers/src/pci/mod.rs
+++ b/drivers/src/pci/mod.rs
@@ -3,11 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod address;
+mod bus;
 mod config_space;
+mod device;
 mod error;
 mod header;
 mod root;
 
+pub use device::PciDevice;
 pub use error::Error as PciError;
 pub use error::Result as PciResult;
 pub use root::{PciBarSpace, PciBarType, PcieRoot};

--- a/drivers/src/pci/mod.rs
+++ b/drivers/src/pci/mod.rs
@@ -4,7 +4,10 @@
 
 mod address;
 mod config_space;
+mod error;
 mod header;
 mod root;
 
+pub use error::Error as PciError;
+pub use error::Result as PciResult;
 pub use root::{PciBarSpace, PciBarType, PcieRoot};

--- a/drivers/src/pci/root.rs
+++ b/drivers/src/pci/root.rs
@@ -10,42 +10,8 @@ use spin::Once;
 
 use super::address::*;
 use super::config_space::PciConfigSpace;
+use super::error::*;
 use super::header::*;
-
-/// Errors resulting enumerating the PCIe hierarchy.
-#[derive(Debug)]
-pub enum Error {
-    /// The PCI configuration space provided by device tree isn't aligned to 4k.
-    ConfigSpaceMisaligned(u64),
-    /// The PCI configuration size provided by device tree isn't divisible by 4k.
-    ConfigSpaceNotPageMultiple(u64),
-    /// A PCI BAR resource provided by the device tree isn't aligned to 4k.
-    BarSpaceMisaligned(u64),
-    /// A PCI BAR resource provided by the device tree isn't divisible by 4k.
-    BarSpaceNotPageMultiple(u64),
-    /// The device tree contained an MMIO region that overlaps with other memory regions.
-    InvalidMmioRegion(page_tracking::MemMapError),
-    /// The device tree entry for the PCI host didn't provide a base register for Configuration
-    /// Space.
-    NoConfigBase,
-    /// No compatible PCI host controller found in the device tree.
-    NoCompatibleHostNode,
-    /// The device tree entry for the PCI host didn't provide a size register for Configuration
-    /// Space.
-    NoConfigSize,
-    /// The device tree entry for the PCI host didn't provide a `reg` property.
-    NoRegProperty,
-    /// The device tree entry for the PCI host didn't provide a `ranges` property.
-    NoRangesProperty,
-    /// Too many PCI resource ranges were specified in the device tree's `ranges` property.
-    TooManyBarSpaces,
-    /// The device tree provided an invalid bus number in the `bus-range` property.
-    InvalidBusNumber(u32),
-    /// Invalid value in a PCI header at `address`.
-    UnknownHeaderType(Address),
-}
-/// Holds results for PCI probing from device tree.
-pub type Result<T> = core::result::Result<T, Error>;
 
 // The maximum number of BAR resources we support at the root complex.
 const MAX_BAR_SPACES: usize = 4;

--- a/drivers/src/pci/root.rs
+++ b/drivers/src/pci/root.rs
@@ -243,11 +243,11 @@ impl PcieRoot {
         for dev in bus.devices() {
             for header in dev.functions() {
                 match header.header_type() {
-                    Some(HeaderType::Endpoint) => f(&header),
+                    HeaderType::Endpoint => f(&header),
                     // TODO: Assign and enumerate child busses.
-                    Some(HeaderType::PciBridge) => f(&header),
-                    Some(HeaderType::CardBusBridge) => (),
-                    None => return Err(Error::UnknownHeaderType(header.address())),
+                    HeaderType::PciBridge => f(&header),
+                    HeaderType::CardBusBridge => (),
+                    _ => return Err(Error::UnknownHeaderType(header.address())),
                 }
             }
         }

--- a/hyp-alloc/src/arena.rs
+++ b/hyp-alloc/src/arena.rs
@@ -21,6 +21,11 @@ pub struct ArenaId<T> {
     phantom: PhantomData<*const T>,
 }
 
+// ArenaId<T> is trivially Send/Sync since it's just an integer. Access to the T it refers to must
+// be done through the Arena<T> interface, which itself is only Send/Sync if T is Send/Sync.
+unsafe impl<T> Send for ArenaId<T> {}
+unsafe impl<T> Sync for ArenaId<T> {}
+
 impl<T> Clone for ArenaId<T> {
     fn clone(&self) -> Self {
         ArenaId {

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,10 +327,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     PcieRoot::probe_from(&hyp_dt, &mut mem_map).expect("Failed to set up PCIe");
     PcieRoot::get()
         .for_each_device(|header| {
-            println!(
-                "found func {header} type: {}",
-                header.header_type().unwrap()
-            );
+            println!("found func {header} type: {}", header.header_type());
         })
         .expect("pci scan failure");
 


### PR DESCRIPTION
This series implements PCI bus enumeration and assignment. Patches 1-3 are a bit of minor prep work, patch 4 introduces the data structures we'll use to hold the software state of the PCI hierarchy, and patch 5 does the actual bus assignment.

With this series, we can enumerate a (mostly) complete PCI hierarchy. Using this QEMU device config:

```
   -fsdev local,id=root,path=/rivos/sysroot/riscv/,security_model=none \
   -device virtio-9p-pci,fsdev=root,mount_tag=lroot \
   -fsdev local,id=workspace,path=/workspace,security_model=none \
   -device virtio-9p-pci,fsdev=workspace,mount_tag=lworkspace \
   -device pcie-root-port,id=rp1,bus=pcie.0,chassis=1,addr=4.0,multifunction=on \
   -netdev user,id=usernet,hostfwd=tcp:127.0.0.1:7722-0.0.0.0:22 \
   -device virtio-net-pci,netdev=usernet,bus=rp1 \
   -device pcie-root-port,id=rp2,bus=pcie.0,chassis=2,addr=4.1 \
   -device virtio-net-pci,bus=rp2 \
   -device pcie-root-port,id=rp3,bus=pcie.0,chassis=3,addr=8.0 \
```

Salus will enumerate the devices like this:

```
found func Address: 0-0-0-0 Vendor: 1B36 Device: 8 Class: 6 SubClass: 0 type: Endpoint
found func Address: 0-0-1-0 Vendor: 1AF4 Device: 1009 Class: 0 SubClass: 2 type: Endpoint
found func Address: 0-0-2-0 Vendor: 1AF4 Device: 1009 Class: 0 SubClass: 2 type: Endpoint
found func Address: 0-0-4-0 Vendor: 1B36 Device: C Class: 6 SubClass: 4 type: PciBridge
found func Address: 0-1-0-0 Vendor: 1AF4 Device: 1041 Class: 2 SubClass: 0 type: Endpoint
found func Address: 0-0-4-1 Vendor: 1B36 Device: C Class: 6 SubClass: 4 type: PciBridge
found func Address: 0-2-0-0 Vendor: 1AF4 Device: 1041 Class: 2 SubClass: 0 type: Endpoint
found func Address: 0-0-8-0 Vendor: 1B36 Device: C Class: 6 SubClass: 4 type: PciBridge
```

