### PR TITLE
Derive the TVM CDI and attestation keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,9 @@ dependencies = [
  "ed25519-dalek",
  "flagset",
  "generic-array",
+ "hex",
  "hkdf",
+ "hmac",
  "lazy_static",
  "spin 0.9.3",
  "spki",
@@ -244,6 +246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,7 +462,9 @@ dependencies = [
  "device_tree",
  "digest 0.10.3",
  "drivers",
+ "ed25519-dalek",
  "generic-array",
+ "hkdf",
  "hyp_alloc",
  "memoffset",
  "page_tracking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "ed25519-dalek",
  "flagset",
  "generic-array",
+ "hkdf",
  "lazy_static",
  "spin 0.9.3",
  "spki",
@@ -158,6 +159,7 @@ checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -239,6 +241,24 @@ checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ der = "0.6.0"
 device_tree = { path = "./device-tree" }
 digest = {version = "0.10.3", default-features = false }
 drivers = { path = "./drivers" }
+ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend"] }
 generic-array = "0.14.5"
+hkdf = "0.12.3"
 hyp_alloc = { path = "./hyp-alloc" }
 memoffset = { version = ">=0.6.5", features = ["unstable_const"] }
 page_tracking = { path = "./page-tracking" }

--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -14,5 +14,5 @@ ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_
 flagset = "0.4.3"
 generic-array = "0.14.5"
 lazy_static = { version = "1.4.0", default-features = false, features = ["spin_no_std"] }
-spin = { version = "*", default-features = false }
+spin = { version = "*", default-features = false, features = ["rwlock"] }
 spki = "0.6.0"

--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -13,7 +13,9 @@ ed25519 = { version = "1.5.2", default-features = false, features = ["pkcs8"] }
 ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend"] }
 flagset = "0.4.3"
 generic-array = "0.14.5"
+hex = { version = "0.4.3", default-features = false }
 hkdf = "0.12.3"
+hmac = "0.12.1"
 lazy_static = { version = "1.4.0", default-features = false, features = ["spin_no_std"] }
 spin = { version = "*", default-features = false, features = ["rwlock"] }
 spki = "0.6.0"

--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -13,6 +13,7 @@ ed25519 = { version = "1.5.2", default-features = false, features = ["pkcs8"] }
 ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend"] }
 flagset = "0.4.3"
 generic-array = "0.14.5"
+hkdf = "0.12.3"
 lazy_static = { version = "1.4.0", default-features = false, features = ["spin_no_std"] }
 spin = { version = "*", default-features = false, features = ["rwlock"] }
 spki = "0.6.0"

--- a/attestation/src/certificate.rs
+++ b/attestation/src/certificate.rs
@@ -7,7 +7,7 @@ use const_oid::AssociatedOid;
 use der::asn1::{BitStringRef, OctetStringRef, SequenceOf, SetOf, UIntRef, Utf8StringRef};
 use der::{AnyRef, Decode, Encode};
 use der::{Enumerated, Sequence};
-use ed25519_dalek::{Keypair, Signer};
+use ed25519_dalek::Signer;
 use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
 
 use crate::{
@@ -18,7 +18,7 @@ use crate::{
         pkix::keyusage::{KeyUsage, KeyUsageFlags, KEY_VALUE_EXTENSION_LEN},
         Extension, Extensions,
     },
-    measurement::{AttestationManager, MAX_TCB_INFO_EXTN_LEN},
+    measurement::{AttestationManager, CDI_ID_LEN, MAX_TCB_INFO_EXTN_LEN},
     name::{Name, RdnSequence, RelativeDistinguishedName},
     request::CertReq,
     time::{Time, Validity},
@@ -129,24 +129,26 @@ impl<'a> Certificate<'a> {
     /// Build a certificate from a CSR.
     ///
     /// @csr: The CSR input
-    /// @cdi_id: The CDI identifier of the certificate issuer (e.g. the TSM).
-    /// @key_pair: The ED25519 key pair generated from the CDI.
     /// @attestation_mgr: The attestation manager to provide the DiceTcbInfo extension
     /// @certificate_buffer: A buffer to hold the DER encoded certificate data.
-    pub fn from_csr<D: digest::Digest>(
+    pub fn from_csr<D: digest::Digest, H: hkdf::HmacImpl<D>>(
         csr: &CertReq<'a>,
-        cdi_id: &'a [u8],
-        key_pair: &'a [u8],
-        attestation_mgr: &AttestationManager<D>,
+        attestation_mgr: &AttestationManager<D, H>,
         certificate_buf: &'a mut [u8],
     ) -> Result<&'a [u8]> {
+        let key_pair = attestation_mgr.csr_key_pair()?;
+        let mut cdi_id_bytes = [0u8; CDI_ID_LEN];
+        let mut cdi_id = [0u8; CDI_ID_LEN * 2];
+        crate::kdf::derive_cdi_id::<D, H>(key_pair.public.as_bytes(), &mut cdi_id_bytes)?;
+        hex::encode_to_slice(cdi_id_bytes, &mut cdi_id).map_err(Error::InvalidCdiId)?;
+
         // The serial number is the CDI ID
-        let serial_number = UIntRef::new(cdi_id).map_err(Error::InvalidDer)?;
+        let serial_number = UIntRef::new(&cdi_id).map_err(Error::InvalidDer)?;
 
         // Issuer contains one ATV for one RDN: `SN=<CDI_ID>`
         let issuer_atv = AttributeTypeAndValue {
             oid: const_oid::db::rfc4519::SN,
-            value: AnyRef::from(Utf8StringRef::new(cdi_id).map_err(Error::InvalidDer)?),
+            value: AnyRef::from(Utf8StringRef::new(&cdi_id).map_err(Error::InvalidDer)?),
         };
         let mut atv_set = SetOf::<AttributeTypeAndValue, MAX_CERT_ATV>::new();
         atv_set.add(issuer_atv).map_err(Error::InvalidDer)?;
@@ -220,7 +222,7 @@ impl<'a> Certificate<'a> {
         // This is a non-critical but mandatory extension when using the
         // DiceTcbinfo extension.
         let auth_key_id = AuthorityKeyIdentifier {
-            key_identifier: Some(OctetStringRef::new(cdi_id).map_err(Error::InvalidDer)?),
+            key_identifier: Some(OctetStringRef::new(&cdi_id).map_err(Error::InvalidDer)?),
             authority_cert_issuer: None,
             authority_cert_serial_number: None,
         };
@@ -253,12 +255,11 @@ impl<'a> Certificate<'a> {
         };
 
         // We can now sign the TBS and generate the actual certificate
-        let key = Keypair::from_bytes(key_pair).map_err(|_| Error::InvalidKey)?;
         let mut tbs_bytes_buffer = [0u8; MAX_CERT_LEN];
         let tbs_bytes = tbs_certificate
             .encode_to_slice(&mut tbs_bytes_buffer)
             .map_err(Error::InvalidDer)?;
-        let signature = key.sign(tbs_bytes).to_bytes();
+        let signature = key_pair.sign(tbs_bytes).to_bytes();
 
         let certificate = Certificate {
             tbs_certificate,

--- a/attestation/src/extensions/pkix/authkeyid.rs
+++ b/attestation/src/extensions/pkix/authkeyid.rs
@@ -10,7 +10,7 @@ use const_oid::{AssociatedOid, ObjectIdentifier};
 use der::asn1::{OctetStringRef, UIntRef};
 use der::Sequence;
 
-pub(crate) const AUTH_KEY_ID_EXTENSION_LEN: usize = 32;
+pub(crate) const AUTH_KEY_ID_EXTENSION_LEN: usize = 64;
 
 /// AuthorityKeyIdentifier as defined in [RFC 5280 Section 4.2.1.1].
 ///

--- a/attestation/src/kdf.rs
+++ b/attestation/src/kdf.rs
@@ -1,0 +1,100 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use digest::Digest;
+use hkdf::{Hkdf, HmacImpl};
+
+use crate::{Error, Result};
+
+// From the OpenDice implementation.
+pub(crate) const ID_SALT: [u8; 64] = [
+    0xDB, 0xDB, 0xAE, 0xBC, 0x80, 0x20, 0xDA, 0x9F, 0xF0, 0xDD, 0x5A, 0x24, 0xC8, 0x3A, 0xA5, 0xA5,
+    0x42, 0x86, 0xDF, 0xC2, 0x63, 0x03, 0x1E, 0x32, 0x9B, 0x4D, 0xA1, 0x48, 0x43, 0x06, 0x59, 0xFE,
+    0x62, 0xCD, 0xB5, 0xB7, 0xE1, 0xE0, 0x0F, 0xC6, 0x80, 0x30, 0x67, 0x11, 0xEB, 0x44, 0x4A, 0xF7,
+    0x72, 0x09, 0x35, 0x94, 0x96, 0xFC, 0xFF, 0x1D, 0xB9, 0x52, 0x0B, 0xA5, 0x1C, 0x7B, 0x29, 0xEA,
+];
+
+// From the OpenDice implementation
+pub(crate) const ASYM_SALT: [u8; 64] = [
+    0x63, 0xB6, 0xA0, 0x4D, 0x2C, 0x07, 0x7F, 0xC1, 0x0F, 0x63, 0x9F, 0x21, 0xDA, 0x79, 0x38, 0x44,
+    0x35, 0x6C, 0xC2, 0xB0, 0xB4, 0x41, 0xB3, 0xA7, 0x71, 0x24, 0x03, 0x5C, 0x03, 0xF8, 0xE1, 0xBE,
+    0x60, 0x35, 0xD3, 0x1F, 0x28, 0x28, 0x21, 0xA7, 0x45, 0x0A, 0x02, 0x22, 0x2A, 0xB1, 0xB3, 0xCF,
+    0xF1, 0x67, 0x9B, 0x05, 0xAB, 0x1C, 0xA5, 0xD1, 0xAF, 0xFB, 0x78, 0x9C, 0xCD, 0x2B, 0x0B, 0x3B,
+];
+
+// Generic HKDF-based derivation function
+fn kdf<D: Digest, H: HmacImpl<D>>(
+    input_key_material: &[u8],
+    salt: &[u8],
+    info: &[&[u8]],
+    output_key_material: &mut [u8],
+) -> Result<()> {
+    let kdf = Hkdf::<D, H>::new(Some(salt), input_key_material);
+    kdf.expand_multi_info(info, output_key_material)
+        .map_err(Error::InvalidCdiExpansion)
+}
+
+pub(crate) fn extract_cdi<D: Digest, H: HmacImpl<D>>(cdi: &[u8], new_cdi: &mut [u8]) -> Result<()> {
+    let kdf = Hkdf::<D, H>::new(None, cdi);
+    kdf.expand(&[0u8; 0], new_cdi)
+        .map_err(Error::InvalidCdiExpansion)
+}
+
+// Derive the next layer CDI from the current CDI.
+// @id is the ID the next layer CDI will be bound to (e.g. "CDI_Sealing").
+// @info is the HKDF expansion additional context information.
+// @salt is either a fixed salt or the current layer TCI. If None is passed,
+// ID_SALT will be used.
+pub(crate) fn derive_next_cdi<D: Digest, H: HmacImpl<D>>(
+    current_cdi: &[u8],
+    id: &str,
+    info: Option<&[u8]>,
+    salt: Option<&[u8]>,
+    next_cdi: &mut [u8],
+) -> Result<()> {
+    kdf::<D, H>(
+        current_cdi,
+        salt.unwrap_or(&ID_SALT),
+        &[id.as_bytes(), info.unwrap_or(&[0u8; 0])],
+        next_cdi,
+    )
+}
+
+// Derive the attestation CDI from the current CDI.
+pub(crate) fn derive_attestation_cdi<D: Digest, H: HmacImpl<D>>(
+    cdi: &[u8],
+    info: Option<&[u8]>,
+    salt: Option<&[u8]>,
+    cdi_attest: &mut [u8],
+) -> Result<()> {
+    derive_next_cdi::<D, H>(cdi, "CDI_Attestation", info, salt, cdi_attest)
+}
+
+// Derive the sealing CDI from the current CDI.
+pub(crate) fn derive_sealing_cdi<D: Digest, H: HmacImpl<D>>(
+    cdi: &[u8],
+    info: Option<&[u8]>,
+    salt: Option<&[u8]>,
+    cdi_sealing: &mut [u8],
+) -> Result<()> {
+    derive_next_cdi::<D, H>(cdi, "CDI_Sealing", info, salt, cdi_sealing)
+}
+
+// Extract and expand a private key from a CDI.
+pub(crate) fn derive_secret_key<D: Digest, H: HmacImpl<D>>(
+    cdi: &[u8],
+    secret_key: &mut [u8],
+) -> Result<()> {
+    kdf::<D, H>(cdi, &ASYM_SALT, &[b"Key_Pair"], secret_key)
+}
+
+// Extract and expand an authority ID from a public key.
+// The public key should be created from a private key bound to the CDI this ID
+// relates to, e.g. a private key created with `derive_secret_key()`.
+pub(crate) fn derive_cdi_id<D: Digest, H: HmacImpl<D>>(
+    public_key: &[u8],
+    cdi_id: &mut [u8],
+) -> Result<()> {
+    kdf::<D, H>(public_key, &ID_SALT, &[b"CDI_ID"], cdi_id)
+}

--- a/attestation/src/lib.rs
+++ b/attestation/src/lib.rs
@@ -82,7 +82,7 @@ pub enum Error {
     MissingCdi,
 
     /// Next layer CDI is already built
-    NextCDIAlreadyExists
+    NextCDIAlreadyExists,
 }
 
 /// Custom attestation result.

--- a/attestation/src/lib.rs
+++ b/attestation/src/lib.rs
@@ -55,7 +55,7 @@ pub enum Error {
     InvalidTcbInfoExtensionDer(der::Error),
 
     /// Invalid Key bytes
-    InvalidKey,
+    InvalidKey(ed25519_dalek::SignatureError),
 
     /// Unsupported signing algorithm
     UnsupportedAlgorithm(const_oid::ObjectIdentifier),
@@ -71,6 +71,18 @@ pub enum Error {
 
     /// Failed to expand the CDI
     InvalidCdiExpansion(hkdf::InvalidLength),
+
+    /// Invalid CDI ID
+    InvalidCdiId(hex::FromHexError),
+
+    /// Derived Key is too short
+    DerivedKeyTooShort,
+
+    /// Missing CDI
+    MissingCdi,
+
+    /// Next layer CDI is already built
+    NextCDIAlreadyExists
 }
 
 /// Custom attestation result.

--- a/attestation/src/lib.rs
+++ b/attestation/src/lib.rs
@@ -68,6 +68,9 @@ pub enum Error {
 
     /// Invalid data digest
     InvalidDigest(der::Error),
+
+    /// Failed to expand the CDI
+    InvalidCdiExpansion(hkdf::InvalidLength),
 }
 
 /// Custom attestation result.
@@ -150,6 +153,8 @@ mod attr;
 pub mod certificate;
 /// x.509 certificate extensions
 pub mod extensions;
+/// Key Derivation Function module
+mod kdf;
 /// TCB layer measurement module
 pub mod measurement;
 mod name;

--- a/src/host_vm_loader.rs
+++ b/src/host_vm_loader.rs
@@ -378,6 +378,6 @@ impl<T: GuestStagePageTable> HostVmLoader<T> {
                 .unwrap(),
             self.guest_ram_base.checked_increment(FDT_OFFSET).unwrap(),
         );
-        self.vm.finalize()
+        self.vm.finalize().unwrap()
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -240,9 +240,10 @@ impl<T: GuestStagePageTable> Vm<T, VmStateInitializing> {
             vm_pages,
             guests: None,
             attestation_mgr: AttestationSha384::new(
-                // Fake compound device identifier (DICE CDI)
+                // Fake compound device identifiers (DICE CDI)
                 // TODO Get the CDI from e.g. the TSM driver.
-                b"THISISARANDOMCDI",
+                b"RANDOMATTESTATIONCDI",
+                b"RANDOMSEALINGCDI",
                 vm_id,
                 const_oid::db::rfc5912::ID_SHA_384,
             )

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -226,11 +226,19 @@ impl<T: GuestStagePageTable, S> Vm<T, S> {
 impl<T: GuestStagePageTable> Vm<T, VmStateInitializing> {
     /// Create a new guest using the given initial page table and vCPU tracking table.
     pub fn new(vm_pages: VmPages<T, VmStateInitializing>, vcpus: VmCpus) -> Self {
+        let vm_id = vm_pages.page_owner_id().raw();
         Self {
             vcpus,
             vm_pages,
             guests: None,
-            attestation_mgr: AttestationSha384::default(),
+            attestation_mgr: AttestationSha384::new(
+                // Fake compound device identifier (DICE CDI)
+                // TODO Get the CDI from e.g. the TSM driver.
+                b"THISISARANDOMCDI",
+                vm_id,
+                const_oid::db::rfc5912::ID_SHA_384,
+            )
+            .expect("Failed to create attestation manager"),
         }
     }
 
@@ -1112,22 +1120,6 @@ impl<T: GuestStagePageTable> Vm<T, VmStateFinalized> {
         cert_len: usize,
         active_pages: &ActiveVmPages<T>,
     ) -> EcallResult<u64> {
-        // Random ed25519 key pair.
-        // TODO: Derive the Salus attestation key pair from the previous layer (e.g. the TSM driver)
-        // public key and measurements
-        // (KeyPair(Salus) = ASYM_KDF(Key(TSM driver), Hash(measurements)))
-        let key_pair: [u8; 64] = [
-            239, 85, 17, 235, 167, 103, 34, 62, 7, 10, 32, 146, 113, 39, 96, 174, 3, 219, 232, 166,
-            240, 121, 167, 13, 98, 238, 122, 116, 193, 114, 215, 213, 175, 181, 75, 166, 224, 164,
-            140, 146, 53, 120, 10, 37, 104, 94, 136, 225, 249, 102, 171, 160, 97, 132, 15, 71, 35,
-            56, 0, 74, 130, 168, 225, 71,
-        ];
-
-        // Fake device identifier (DICE CDI)
-        // TODO: Derive the Salus CDI from the public part of its key pair.
-        // CDI(Salus) = KDF(N, PubKey(Salus), SALT, "ID")
-        let cdi: &[u8] = b"THISISARANDOMCDI";
-
         if csr_len > MAX_CSR_LEN {
             return Err(EcallError::Sbi(SbiError::InvalidParam));
         }
@@ -1151,14 +1143,8 @@ impl<T: GuestStagePageTable> Vm<T, VmStateFinalized> {
 
         let cert_gpa = RawAddr::guest(cert_addr, self.vm_pages.page_owner_id());
         let mut cert_bytes_buffer = [0u8; MAX_CERT_LEN];
-        let cert_bytes = Certificate::from_csr(
-            &csr,
-            cdi,
-            &key_pair,
-            &self.attestation_mgr,
-            &mut cert_bytes_buffer,
-        )
-        .map_err(|_| EcallError::Sbi(SbiError::InvalidParam))?;
+        let cert_bytes = Certificate::from_csr(&csr, &self.attestation_mgr, &mut cert_bytes_buffer)
+            .map_err(|_| EcallError::Sbi(SbiError::InvalidParam))?;
         let cert_bytes_len = cert_bytes.len();
 
         // Check that the guest gave us enough space

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -41,6 +41,7 @@ pub enum Error {
     InvalidMapRegion,
     SharedPageNotMapped,
     Measurement(attestation::Error),
+    VmCreationFailed(crate::vm::Error),
 }
 
 pub type Result<T> = core::result::Result<T, Error>;
@@ -803,7 +804,8 @@ impl<T: GuestStagePageTable> VmPages<T, VmStateFinalized> {
             Vm::new(
                 VmPages::new(guest_root, region_vec, self.nesting + 1),
                 VmCpus::new(id, vcpu_pages, self.page_tracker.clone()).unwrap(),
-            ),
+            )
+            .map_err(Error::VmCreationFailed)?,
             box_page,
         ))
     }

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -323,16 +323,17 @@ impl<'a, T: GuestStagePageTable, S> VmPagesMapper<'a, T, S> {
 
 impl<'a, T: GuestStagePageTable> VmPagesMapper<'a, T, VmStateInitializing> {
     /// Maps a page into the guest's address space and measures it.
-    pub fn map_page_with_measurement<S, M, D>(
+    pub fn map_page_with_measurement<S, M, D, H>(
         &self,
         to_addr: GuestPageAddr,
         page: Page<S>,
-        measurement: &AttestationManager<D>,
+        measurement: &AttestationManager<D, H>,
     ) -> Result<()>
     where
         S: Mappable<M>,
         M: MeasureRequirement,
         D: digest::Digest,
+        H: hkdf::HmacImpl<D>,
     {
         measurement
             .extend_msmt_register(
@@ -470,14 +471,14 @@ impl<'a, T: GuestStagePageTable> ActiveVmPages<'a, T> {
 
     /// Copies `count` pages from `src_addr` in the current guest to the converted pages starting at
     /// `from_addr`. The pages are then mapped into the child's address space at `to_addr`.
-    pub fn copy_and_add_data_pages_builder<D: digest::Digest>(
+    pub fn copy_and_add_data_pages_builder<D: digest::Digest, H: hkdf::HmacImpl<D>>(
         &self,
         src_addr: GuestPageAddr,
         from_addr: GuestPageAddr,
         count: u64,
         to: &VmPages<T, VmStateInitializing>,
         to_addr: GuestPageAddr,
-        measurement: &AttestationManager<D>,
+        measurement: &AttestationManager<D, H>,
     ) -> Result<u64> {
         let converted_pages = self.get_converted_pages(from_addr, count)?;
         let mapper = to.map_pages(to_addr, count)?;


### PR DESCRIPTION
This PR uses a currently artificial TSM Compound Device Identifier (CDI) to derive a TVM specific CDI and an attestation key pair. The latter is used to signed TVM originated Certificate Signing Request (CSR) certificates carrying the TVM attestation evidence.

The TSM CDI will eventually be received from the TSM driver, as the TSM underlying DICE TCB layer (The TSM driver is responsible for building and creating the TSM CDI).

Patches 1 and 2 are minor build and constant definition fixes.
Patch 3 adds the key/CDI derivation feature to the the attestation manager and passes a TVM unique identifier (Its `PageOwnerId`) to the VM constructor for the attestation manager to use when generating TVM specific CDI and key pairs.