### PR TITLE
Basic PCI config space emulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "const-field-offset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6d40fc2c8e0109d6e423fb4c8b6a373c56b4576ca2e0d3e216a7796861fbd0"
+dependencies = [
+ "const-field-offset-macro",
+ "field-offset",
+]
+
+[[package]]
+name = "const-field-offset-macro"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f7f71b9a791f0a0fcadab1293bbac19b6872756ca78b630c3d89f6aa93daff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,9 +191,11 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "assertions",
+ "const-field-offset",
  "data_model",
  "device_tree",
  "hyp_alloc",
+ "memoffset",
  "page_tracking",
  "riscv_pages",
  "riscv_regs",
@@ -224,9 +247,19 @@ dependencies = [
  "memoffset",
  "num-derive",
  "num-traits",
- "rustc_version",
+ "rustc_version 0.2.3",
  "static_assertions",
  "unsafe_unwrap",
+]
+
+[[package]]
+name = "field-offset"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e1c54951450cbd39f3dbcf1005ac413b49487dabf18a720ad2383eccfeffb92"
+dependencies = [
+ "memoffset",
+ "rustc_version 0.3.3",
 ]
 
 [[package]]
@@ -347,6 +380,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,7 +481,16 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -494,7 +545,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -502,6 +562,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "sha2"
@@ -614,6 +683,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
 
 [[package]]
 name = "unicode-xid"

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -8,9 +8,11 @@ edition = "2021"
 [dependencies]
 arrayvec = { version = "0.7.2", default-features = false }
 assertions = { path = "../assertions" }
+const-field-offset = { version = "0.1.2" }
 data_model = { path = "../data-model" }
 device_tree = { path = "../device-tree" }
 hyp_alloc = { path = "../hyp-alloc" }
+memoffset = { version = ">=0.6.5", features = ["unstable_const"] }
 page_tracking = { path = "../page-tracking" }
 riscv_pages = { path = "../riscv-pages" }
 riscv_regs = { path = "../riscv-regs" }

--- a/drivers/src/pci/address.rs
+++ b/drivers/src/pci/address.rs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// PCI addresses are composed of a segment, bus, device, and function. Each of those components will
-// implement the `AddressComponent` type.
-trait AddressComponent {
+/// PCI addresses are composed of a segment, bus, device, and function. Each of those components will
+/// implement the `AddressComponent` type.
+pub trait AddressComponent {
     const SHIFT: u32;
     const BITS: u32;
     const MAX_VAL: u32 = (1 << Self::BITS) - 1;

--- a/drivers/src/pci/device.rs
+++ b/drivers/src/pci/device.rs
@@ -3,13 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt;
+use core::mem::size_of;
 use core::ptr::NonNull;
 
 use tock_registers::interfaces::{Readable, Writeable};
+use tock_registers::LocalRegisterCopy;
 
 use super::address::*;
 use super::bus::PciBus;
 use super::error::*;
+use super::mmio_builder::{MmioReadBuilder, MmioWriteBuilder};
 use super::registers::*;
 
 /// The Vendor Id from the PCI header.
@@ -146,19 +149,142 @@ impl core::fmt::Display for PciDeviceInfo {
     }
 }
 
+// Macro that itself defines a `span!()` macro for the given struct field which evaluates to a
+// const range pattern which can be used in `match` expressions. Note that the type of the field
+// must also be specified, though its cross-checked against the actual field span in a unit test.
+//
+// This is as hairy as it is because of the limitations of match arm range patterns and constant
+// expressions in Rust. Ideally we would be able to reuse `memoffset::span_of()!` to implmenet this,
+// however it's currently not possible to use `span_of!()`/`offset_of!()` in const expressions, see
+// https://github.com/Gilnaa/memoffset/issues/4#issuecomment-1069658383.
+//
+// TODO: Replace this with `span_of!()` when it's possible to use it in const expressions.
+macro_rules! define_field_span {
+    ($st:ident, $field:tt, $field_type:ty) => {
+        pub mod $field {
+            use super::$st;
+
+            pub const START_OFFSET: usize = $st::FIELD_OFFSETS.$field.get_byte_offset();
+            pub const END_OFFSET: usize = START_OFFSET + core::mem::size_of::<$field_type>() - 1;
+
+            macro_rules! span {
+                () => {
+                    $field::START_OFFSET..=$field::END_OFFSET
+                };
+            }
+
+            #[cfg(test)]
+            mod tests {
+                use memoffset::span_of;
+
+                #[test]
+                fn check_field_span() {
+                    let actual_span = span_of!(super::$st, $field);
+                    assert_eq!(super::START_OFFSET, actual_span.start);
+                    assert_eq!(super::END_OFFSET, actual_span.end - 1);
+                }
+            }
+
+            pub(crate) use span;
+        }
+    };
+}
+
+mod common_offsets {
+    use super::CommonRegisters;
+
+    define_field_span!(CommonRegisters, vendor_id, u16);
+    define_field_span!(CommonRegisters, dev_id, u16);
+    define_field_span!(CommonRegisters, command, u16);
+    define_field_span!(CommonRegisters, status, u16);
+    define_field_span!(CommonRegisters, rev_id, u8);
+    define_field_span!(CommonRegisters, prog_if, u8);
+    define_field_span!(CommonRegisters, subclass, u8);
+    define_field_span!(CommonRegisters, class, u8);
+    define_field_span!(CommonRegisters, header_type, u8);
+}
+
+mod endpoint_offsets {
+    use super::EndpointRegisters;
+
+    define_field_span!(EndpointRegisters, bar, [u32; 6]);
+    define_field_span!(EndpointRegisters, subsys_vendor_id, u16);
+    define_field_span!(EndpointRegisters, subsys_id, u16);
+    define_field_span!(EndpointRegisters, cap_ptr, u8);
+}
+
+mod bridge_offsets {
+    use super::BridgeRegisters;
+
+    define_field_span!(BridgeRegisters, bar, [u32; 2]);
+    define_field_span!(BridgeRegisters, pri_bus, u8);
+    define_field_span!(BridgeRegisters, sec_bus, u8);
+    define_field_span!(BridgeRegisters, sub_bus, u8);
+    define_field_span!(BridgeRegisters, io_base, u8);
+    define_field_span!(BridgeRegisters, io_limit, u8);
+    define_field_span!(BridgeRegisters, sec_status, u16);
+    define_field_span!(BridgeRegisters, mem_base, u16);
+    define_field_span!(BridgeRegisters, mem_limit, u16);
+    define_field_span!(BridgeRegisters, pref_base, u16);
+    define_field_span!(BridgeRegisters, pref_limit, u16);
+    define_field_span!(BridgeRegisters, pref_base_upper, u32);
+    define_field_span!(BridgeRegisters, pref_limit_upper, u32);
+    define_field_span!(BridgeRegisters, io_base_upper, u16);
+    define_field_span!(BridgeRegisters, io_limit_upper, u16);
+    define_field_span!(BridgeRegisters, cap_ptr, u8);
+    define_field_span!(BridgeRegisters, bridge_control, u16);
+}
+
 /// Represents a PCI endpoint.
 pub struct PciEndpoint {
-    _registers: &'static mut EndpointRegisters,
+    registers: &'static mut EndpointRegisters,
     info: PciDeviceInfo,
 }
 
 impl PciEndpoint {
     /// Creates a new `PciEndpoint` using the config space at `registers`.
     fn new(registers: &'static mut EndpointRegisters, info: PciDeviceInfo) -> Result<Self> {
-        Ok(Self {
-            _registers: registers,
-            info,
-        })
+        Ok(Self { registers, info })
+    }
+
+    // Emulate a read from the endpoint-specific registers of this device's config space.
+    fn emulate_config_read(&self, op: &mut MmioReadBuilder) {
+        use endpoint_offsets::*;
+        match op.offset() {
+            bar::span!() => {
+                let index = (op.offset() - bar::START_OFFSET) / size_of::<u32>();
+                op.push_dword(self.registers.bar[index].get());
+            }
+            subsys_vendor_id::span!() => {
+                op.push_word(self.registers.subsys_vendor_id.get());
+            }
+            subsys_id::span!() => {
+                op.push_word(self.registers.subsys_id.get());
+            }
+            cap_ptr::span!() => {
+                // TODO: Point to virtualized capabilites.
+                op.push_byte(0);
+            }
+            _ => {
+                // No INTx, cardbus, etc.
+                op.push_byte(0);
+            }
+        }
+    }
+
+    // Emulate a write to the endpoint-specific registers of this device's config space.
+    fn emulate_config_write(&mut self, op: &mut MmioWriteBuilder) {
+        use endpoint_offsets::*;
+        match op.offset() {
+            bar::span!() => {
+                let index = (op.offset() - bar::START_OFFSET) / size_of::<u32>();
+                let reg = op.pop_dword(self.registers.bar[index].get());
+                self.registers.bar[index].set(reg);
+            }
+            _ => {
+                op.pop_byte();
+            }
+        }
     }
 }
 
@@ -168,6 +294,8 @@ pub struct PciBridge {
     info: PciDeviceInfo,
     bus_range: BusRange,
     child_bus: Option<PciBus>,
+    virtual_primary_bus: Bus,
+    virtual_bus_reset: u16,
 }
 
 impl PciBridge {
@@ -183,6 +311,8 @@ impl PciBridge {
             info,
             bus_range: BusRange::default(),
             child_bus: None,
+            virtual_primary_bus: Bus::default(),
+            virtual_bus_reset: 0,
         })
     }
 
@@ -204,6 +334,175 @@ impl PciBridge {
     /// Returns the secondary bus directly downstream of this bridge.
     pub fn child_bus(&self) -> Option<&PciBus> {
         self.child_bus.as_ref()
+    }
+
+    // Emulate a read from the bridge-specific registers of this device's config space.
+    fn emulate_config_read(&self, op: &mut MmioReadBuilder) {
+        use bridge_offsets::*;
+        match op.offset() {
+            bar::span!() => {
+                let index = (op.offset() - bar::START_OFFSET) / size_of::<u32>();
+                op.push_dword(self.registers.bar[index].get());
+            }
+            pri_bus::span!() => {
+                op.push_byte(self.virtual_primary_bus.bits() as u8);
+            }
+            sec_bus::span!() => {
+                let bus_num = self.child_bus.as_ref().unwrap().virtual_secondary_bus_num();
+                op.push_byte(bus_num.bits() as u8);
+            }
+            sub_bus::span!() => {
+                let bus_num = self
+                    .child_bus
+                    .as_ref()
+                    .unwrap()
+                    .virtual_subordinate_bus_num();
+                op.push_byte(bus_num.bits() as u8);
+            }
+            io_base::span!() => {
+                op.push_byte(self.registers.io_base.get());
+            }
+            io_limit::span!() => {
+                op.push_byte(self.registers.io_limit.get());
+            }
+            sec_status::span!() => {
+                op.push_word(self.registers.sec_status.readable_bits());
+            }
+            mem_base::span!() => {
+                op.push_word(self.registers.mem_base.get());
+            }
+            mem_limit::span!() => {
+                op.push_word(self.registers.mem_limit.get());
+            }
+            pref_base::span!() => {
+                op.push_word(self.registers.pref_base.get());
+            }
+            pref_limit::span!() => {
+                op.push_word(self.registers.pref_limit.get());
+            }
+            pref_base_upper::span!() => {
+                op.push_dword(self.registers.pref_base_upper.get());
+            }
+            pref_limit_upper::span!() => {
+                op.push_dword(self.registers.pref_limit_upper.get());
+            }
+            io_base_upper::span!() => {
+                op.push_word(self.registers.io_base_upper.get());
+            }
+            io_limit_upper::span!() => {
+                op.push_word(self.registers.io_limit_upper.get());
+            }
+            cap_ptr::span!() => {
+                // TODO: Point to virtualized capabilites.
+                op.push_byte(0);
+            }
+            bridge_control::span!() => {
+                let mut reg = LocalRegisterCopy::<u16, BridgeControl::Register>::new(
+                    self.registers.bridge_control.readable_bits(),
+                );
+                reg.modify(BridgeControl::SecondaryBusReset.val(self.virtual_bus_reset));
+                op.push_word(reg.get());
+            }
+            _ => {
+                // No INTx, cardbus, etc.
+                op.push_byte(0);
+            }
+        }
+    }
+
+    // Emulate a write to the bridge-specific registers of this device's config space.
+    fn emulate_config_write(&mut self, op: &mut MmioWriteBuilder) {
+        use bridge_offsets::*;
+        match op.offset() {
+            bar::span!() => {
+                let index = (op.offset() - bar::START_OFFSET) / size_of::<u32>();
+                let reg = op.pop_dword(self.registers.bar[index].get());
+                self.registers.bar[index].set(reg);
+            }
+            pri_bus::span!() => {
+                // The primary bus register doesn't do anything on PCIe, but we emulate one here to
+                // be spec compliant.
+                self.virtual_primary_bus = Bus::try_from(op.pop_byte()).unwrap();
+            }
+            sec_bus::span!() => {
+                let bus_num = Bus::try_from(op.pop_byte()).unwrap();
+                self.child_bus
+                    .as_mut()
+                    .unwrap()
+                    .set_virtual_secondary_bus_num(bus_num);
+            }
+            sub_bus::span!() => {
+                let bus_num = Bus::try_from(op.pop_byte()).unwrap();
+                self.child_bus
+                    .as_mut()
+                    .unwrap()
+                    .set_virtual_subordinate_bus_num(bus_num);
+            }
+            io_base::span!() => {
+                self.registers.io_base.set(op.pop_byte());
+            }
+            io_limit::span!() => {
+                self.registers.io_limit.set(op.pop_byte());
+            }
+            sec_status::span!() => {
+                let reg = LocalRegisterCopy::<u16, SecondaryStatus::Register>::new(
+                    op.pop_word(self.registers.sec_status.non_clearable_bits()),
+                );
+                self.registers.sec_status.set(reg.writeable_bits());
+            }
+            mem_base::span!() => {
+                self.registers
+                    .mem_base
+                    .set(op.pop_word(self.registers.mem_base.get()));
+            }
+            mem_limit::span!() => {
+                self.registers
+                    .mem_limit
+                    .set(op.pop_word(self.registers.mem_limit.get()));
+            }
+            pref_base::span!() => {
+                self.registers
+                    .pref_base
+                    .set(op.pop_word(self.registers.pref_base.get()));
+            }
+            pref_limit::span!() => {
+                self.registers
+                    .pref_limit
+                    .set(op.pop_word(self.registers.pref_limit.get()));
+            }
+            pref_base_upper::span!() => {
+                self.registers
+                    .pref_base_upper
+                    .set(op.pop_dword(self.registers.pref_base_upper.get()));
+            }
+            pref_limit_upper::span!() => {
+                self.registers
+                    .pref_limit_upper
+                    .set(op.pop_dword(self.registers.pref_limit_upper.get()));
+            }
+            io_base_upper::span!() => {
+                self.registers
+                    .io_base_upper
+                    .set(op.pop_word(self.registers.io_base_upper.get()));
+            }
+            io_limit_upper::span!() => {
+                self.registers
+                    .io_limit_upper
+                    .set(op.pop_word(self.registers.io_limit_upper.get()));
+            }
+            bridge_control::span!() => {
+                let reg = LocalRegisterCopy::<u16, BridgeControl::Register>::new(
+                    op.pop_word(self.registers.bridge_control.get()),
+                );
+                // TODO: We virtualize the secondary bus reset bit for now. Implement a VM-triggered
+                // reset if necessary and it's safe to do so.
+                self.virtual_bus_reset = reg.read(BridgeControl::SecondaryBusReset);
+                self.registers.bridge_control.set(reg.writeable_bits());
+            }
+            _ => {
+                op.pop_byte();
+            }
+        }
     }
 }
 
@@ -246,6 +545,129 @@ impl PciDevice {
         match self {
             PciDevice::Endpoint(ep) => &ep.info,
             PciDevice::Bridge(bridge) => &bridge.info,
+        }
+    }
+
+    /// Emulates a read from the configuration space of this device at `offset`.
+    pub fn emulate_config_read(&self, offset: usize, len: usize) -> u32 {
+        let mut op = MmioReadBuilder::new(offset, len);
+        while !op.done() {
+            let regs = self.common_registers();
+            let info = self.info();
+            use common_offsets::*;
+            match op.offset() {
+                vendor_id::span!() => {
+                    op.push_word(info.vendor_id().0);
+                }
+                dev_id::span!() => {
+                    op.push_word(info.device_id().0);
+                }
+                command::span!() => {
+                    op.push_word(regs.command.readable_bits());
+                }
+                status::span!() => {
+                    op.push_word(regs.status.readable_bits());
+                }
+                rev_id::span!() => {
+                    op.push_byte(regs.rev_id.get());
+                }
+                prog_if::span!() => {
+                    op.push_byte(regs.prog_if.get());
+                }
+                subclass::span!() => {
+                    op.push_byte(info.subclass().0);
+                }
+                class::span!() => {
+                    op.push_byte(info.class().0);
+                }
+                header_type::span!() => {
+                    op.push_byte(regs.header_type.get());
+                }
+                PCI_TYPE_HEADER_START..=PCI_TYPE_HEADER_END => {
+                    self.emulate_type_specific_read(&mut op);
+                }
+                offset => {
+                    if offset <= PCI_COMMON_HEADER_END {
+                        // Everything else in the common part of the header is unimplemented and we can
+                        // safely return 0.
+                        op.push_byte(0);
+                    } else {
+                        // Make everything beyond the standard header appear unimplemented.
+                        //
+                        // TODO: Capabilities.
+                        op.push_dword(!0x0);
+                    }
+                }
+            };
+        }
+        op.result()
+    }
+
+    /// Emulates a write to the configuration space of this device at `offset`.
+    pub fn emulate_config_write(&mut self, offset: usize, value: u32, len: usize) {
+        let mut op = MmioWriteBuilder::new(offset, value, len);
+        while !op.done() {
+            let regs = self.common_registers_mut();
+            use common_offsets::*;
+            match op.offset() {
+                command::span!() => {
+                    let mut reg = LocalRegisterCopy::<u16, Command::Register>::new(
+                        op.pop_word(regs.command.get()),
+                    );
+                    // TODO: No DMA until the IOMMU is enabled.
+                    reg.modify(Command::BusMasterEnable.val(0));
+                    regs.command.set(reg.writeable_bits());
+                }
+                status::span!() => {
+                    // Make sure we only write the RW1C bits if the write operation covers that byte.
+                    let reg = LocalRegisterCopy::<u16, Status::Register>::new(
+                        op.pop_word(regs.status.non_clearable_bits()),
+                    );
+                    regs.status.set(reg.writeable_bits());
+                }
+                PCI_TYPE_HEADER_START..=PCI_TYPE_HEADER_END => {
+                    self.emulate_type_specific_write(&mut op);
+                }
+                _ => {
+                    // We don't allow writes to other bits of the common header and everything beyond
+                    // it is unimplemented for now.
+                    //
+                    // TODO: Capabilities.
+                    op.pop_byte();
+                }
+            }
+        }
+    }
+
+    // Returns a reference to the common portion of this device's PCI header.
+    fn common_registers(&self) -> &CommonRegisters {
+        match self {
+            PciDevice::Endpoint(ep) => &ep.registers.common,
+            PciDevice::Bridge(bridge) => &bridge.registers.common,
+        }
+    }
+
+    // Returns a mutable reference to the common portion of this device's PCI header.
+    fn common_registers_mut(&mut self) -> &mut CommonRegisters {
+        match self {
+            PciDevice::Endpoint(ep) => &mut ep.registers.common,
+            PciDevice::Bridge(bridge) => &mut bridge.registers.common,
+        }
+    }
+
+    // Emulates a read from the type-specific registers of this device.
+    fn emulate_type_specific_read(&self, read_op: &mut MmioReadBuilder) {
+        match self {
+            PciDevice::Endpoint(ep) => ep.emulate_config_read(read_op),
+            PciDevice::Bridge(bridge) => bridge.emulate_config_read(read_op),
+        }
+    }
+
+    // Emulates a write to the type-specific registers of this device.
+    fn emulate_type_specific_write(&mut self, write_op: &mut MmioWriteBuilder) {
+        match self {
+            PciDevice::Endpoint(ep) => ep.emulate_config_write(write_op),
+            PciDevice::Bridge(bridge) => bridge.emulate_config_write(write_op),
         }
     }
 }

--- a/drivers/src/pci/error.rs
+++ b/drivers/src/pci/error.rs
@@ -49,6 +49,12 @@ pub enum Error {
     AllocError,
     /// Ran out of bus numbers while assigning buses.
     OutOfBuses,
+    /// Unsupported size or alignment in emulated config space access.
+    UnsupportedConfigAccess,
+    /// Offset in emulated config space is invalid.
+    InvalidConfigOffset,
+    /// The device targetted by the emulated config space access does not exist.
+    DeviceNotFound(Address),
 }
 
 /// Holds results for PCI operations.

--- a/drivers/src/pci/mmio_builder.rs
+++ b/drivers/src/pci/mmio_builder.rs
@@ -1,0 +1,218 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helpers for PCI configuration space emulation.
+
+#![allow(dead_code)]
+
+use core::cmp::min;
+use core::mem::size_of;
+
+// Returns a bit mask covering the specified number of bytes.
+fn byte_mask(bytes: usize) -> u32 {
+    ((1u64 << (bytes * 8)) - 1) as u32
+}
+
+// Returns the bytes in the specified range in `val`.
+fn select_bytes(val: u32, offset: usize, len: usize) -> u32 {
+    (val >> (offset * 8)) & byte_mask(len)
+}
+
+// Updates the bytes in `dest` in the specified range with `src`.
+fn update_bytes(dest: u32, offset: usize, len: usize, src: u32) -> u32 {
+    let mask = byte_mask(len) << (offset * 8);
+    dest & !mask | ((src << (offset * 8)) & mask)
+}
+
+/// A builder for emulated MMIO config space read operations.
+///
+/// In order to support partial accesses to word or dword registers, pushing a word or dword when
+/// we're unaligned results in pushing only the bytes between the offset within the word/dword and
+/// the end of the word/dword. For example, pushing a word register when `self.offset` is 1 results
+/// in only the upper byte of the word being pushed into the result.
+pub struct MmioReadBuilder {
+    offset: usize,
+    len: usize,
+    written: usize,
+    result: u32,
+}
+
+impl MmioReadBuilder {
+    /// Creates a new `MmioReadBuilder` for a read of `len` bytes at `offset`.
+    pub fn new(offset: usize, len: usize) -> Self {
+        Self {
+            offset,
+            len,
+            written: 0,
+            result: 0,
+        }
+    }
+
+    /// Returns the current offset of the read.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Returns if the read is completed.
+    pub fn done(&self) -> bool {
+        self.written == self.len
+    }
+
+    /// Push a byte register to this builder.
+    pub fn push_byte(&mut self, value: u8) {
+        self.result |= (value as u32) << (self.written * 8);
+        self.written += 1;
+        self.offset += 1;
+    }
+
+    /// Push a word register to this builder. We only push a subset of the word if we're unaligned
+    /// or the remaining number of bytes is less than the size of a word.
+    pub fn push_word(&mut self, value: u16) {
+        let offset_in_word = self.offset & 0x1;
+        let to_write = min(size_of::<u16>() - offset_in_word, self.len - self.written);
+        let value = select_bytes(value as u32, offset_in_word, to_write);
+        self.result |= value << (self.written * 8);
+        self.written += to_write;
+        self.offset += to_write;
+    }
+
+    /// Push a dword register to this builder. We only push a subset of the dword if we're unaligned
+    /// or the remaining number of bytes is less than the size of a dword.
+    pub fn push_dword(&mut self, value: u32) {
+        let offset_in_dword = self.offset & 0x3;
+        let to_write = min(size_of::<u32>() - offset_in_dword, self.len - self.written);
+        let value = select_bytes(value, offset_in_dword, to_write);
+        self.result |= value << (self.written * 8);
+        self.written += to_write;
+        self.offset += to_write;
+    }
+
+    /// Consumes this `MmioReadBuilder`, returning the result of the read as a dword value.
+    pub fn result(self) -> u32 {
+        self.result
+    }
+}
+
+/// A builder for emulated MMIO config space write operations.
+///
+/// Like `MmioReadBuilder`, we need to support partial accesses to word or dword registers. This is
+/// done by performing a read-modify-write operation on a source word/dword with only the bytes that
+/// were popped. For example, popping a dword register when `self.offset` is 2 only updates upper word
+/// in the dword.
+pub struct MmioWriteBuilder {
+    offset: usize,
+    len: usize,
+    read: usize,
+    value: u32,
+}
+
+impl MmioWriteBuilder {
+    /// Creates a new `MmioWriteBuilder` for a `len` bytes write of `value` at `offset`.
+    pub fn new(offset: usize, value: u32, len: usize) -> Self {
+        Self {
+            offset,
+            len,
+            read: 0,
+            value,
+        }
+    }
+
+    /// Returns the current offset of the write.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Returns if the write is completed.
+    pub fn done(&self) -> bool {
+        self.read == self.len
+    }
+
+    /// Pops a byte register from this builder.
+    pub fn pop_byte(&mut self) -> u8 {
+        let result = (self.value >> (self.read * 8)) as u8;
+        self.read += 1;
+        self.offset += 1;
+        result
+    }
+
+    /// Pops a word register from this builder, returning `dest` updated with the bytes that were
+    /// popped.
+    pub fn pop_word(&mut self, dest: u16) -> u16 {
+        let offset_in_word = self.offset & 0x1;
+        let to_read = min(size_of::<u16>() - offset_in_word, self.len - self.read);
+        let result = update_bytes(
+            dest as u32,
+            offset_in_word,
+            to_read,
+            self.value >> (self.read * 8),
+        );
+        self.read += to_read;
+        self.offset += to_read;
+        result as u16
+    }
+
+    /// Pops a dword register from this builder, returning `dest` updated with the bytes that were
+    /// popped.
+    pub fn pop_dword(&mut self, dest: u32) -> u32 {
+        let offset_in_dword = self.offset & 0x3;
+        let to_read = min(size_of::<u32>() - offset_in_dword, self.len - self.read);
+        let result = update_bytes(
+            dest,
+            offset_in_dword,
+            to_read,
+            self.value >> (self.read * 8),
+        );
+        self.read += to_read;
+        self.offset += to_read;
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mmio_builder() {
+        let mut op = MmioReadBuilder::new(0, 4);
+        op.push_byte(0xaa);
+        op.push_byte(0xbb);
+        op.push_word(0x1122);
+        assert!(op.done());
+        assert_eq!(op.result(), 0x1122bbaa);
+
+        let mut op = MmioReadBuilder::new(1, 1);
+        op.push_word(0xbeef);
+        assert!(op.done());
+        assert_eq!(op.result(), 0xbe);
+
+        let mut op = MmioReadBuilder::new(2, 2);
+        op.push_dword(0xdeadbeef);
+        assert!(op.done());
+        assert_eq!(op.result(), 0xdead);
+
+        let mut op = MmioReadBuilder::new(3, 1);
+        op.push_dword(0xfeedface);
+        assert!(op.done());
+        assert_eq!(op.result(), 0xfe);
+
+        let mut op = MmioWriteBuilder::new(0, 0xdeadbeef, 4);
+        assert_eq!(op.pop_byte(), 0xef);
+        assert_eq!(op.pop_byte(), 0xbe);
+        assert_eq!(op.pop_word(0), 0xdead);
+        assert!(op.done());
+
+        let mut op = MmioWriteBuilder::new(1, 0x99, 1);
+        assert_eq!(op.pop_word(0xabcd), 0x99cd);
+        assert!(op.done());
+
+        let mut op = MmioWriteBuilder::new(2, 0x42, 1);
+        assert_eq!(op.pop_dword(0xf00ff00f), 0xf042f00f);
+        assert!(op.done());
+
+        let mut op = MmioWriteBuilder::new(2, 0xfeed, 2);
+        assert_eq!(op.pop_dword(0xdeadbeef), 0xfeedbeef);
+        assert!(op.done());
+    }
+}

--- a/drivers/src/pci/mmio_builder.rs
+++ b/drivers/src/pci/mmio_builder.rs
@@ -4,8 +4,6 @@
 
 //! Helpers for PCI configuration space emulation.
 
-#![allow(dead_code)]
-
 use core::cmp::min;
 use core::mem::size_of;
 

--- a/drivers/src/pci/mod.rs
+++ b/drivers/src/pci/mod.rs
@@ -7,6 +7,7 @@ mod bus;
 mod config_space;
 mod device;
 mod error;
+mod mmio_builder;
 mod registers;
 mod root;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ mod vm_id;
 mod vm_pages;
 
 use device_tree::{DeviceTree, Fdt};
-use drivers::{pci::PciDevice, pci::PcieRoot, CpuInfo, Imsic};
+use drivers::{pci::PcieRoot, CpuInfo, Imsic};
 use host_vm_loader::HostVmLoader;
 use hyp_alloc::HypAlloc;
 use page_tracking::*;
@@ -325,7 +325,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
 
     // Probe for a PCI bus.
     PcieRoot::probe_from(&hyp_dt, &mut mem_map).expect("Failed to set up PCIe");
-    PcieRoot::get().for_each_device(|dev: &dyn PciDevice| {
+    PcieRoot::get().for_each_device(|dev| {
         println!(
             "found func {} type: {}",
             dev.info(),


### PR DESCRIPTION
This series enables basic PCI config space emulation, enough for a Linux host VM to enumerate a PCI hierarchy and assign resources. Notably missing are any form interrupt support (needs virtualized capabilites + IOMMU) and the ability for devices to do DMA (needs IOMMU). In general we pass through as much control as possible, with the main exception being bus number assignments since we need to keep requester IDs stable for the IOMMU. Instead, we virtualize the bus number assignments to the host VM and then use these assignments to do the reverse mapping from MMIO trap offset to device.

- Patch 1 is a minor change to avoid dynamic dispatch for `PciDevice`.
- Patch 2 adds helpers for emulating config space reads/writes.
- Patch 3 implements the config space emulation.