### PR TITLE
Add hpmcounter CSR accessors

### DIFF
--- a/drivers/src/imsic.rs
+++ b/drivers/src/imsic.rs
@@ -9,7 +9,7 @@ use page_tracking::HwMemMap;
 use riscv_pages::*;
 #[cfg(all(target_arch = "riscv64", target_os = "none"))]
 use riscv_regs::Readable;
-use riscv_regs::{sie, stopei, Writeable, CSR};
+use riscv_regs::{sie, stopei, RiscvCsrInterface, Writeable, CSR};
 use spin::{Mutex, Once};
 
 use crate::{CpuId, CpuInfo, MAX_CPUS};

--- a/riscv-regs/src/csrs/csr_access.rs
+++ b/riscv-regs/src/csrs/csr_access.rs
@@ -12,6 +12,70 @@ use tock_registers::fields::Field;
 use tock_registers::interfaces::{Readable, Writeable};
 use tock_registers::RegisterLongName;
 
+/// Trait defining the possible operations on a RISC-V CSR.
+pub trait RiscvCsrInterface {
+    type R: RegisterLongName;
+
+    /// Reads the contents of a CSR.
+    ///
+    /// This method corresponds to the RISC-V `CSRR rd, csr`
+    /// instruction where `rd = out(reg) <return value>`.
+    fn get_value(&self) -> u64;
+
+    /// Writes the value of a CSR.
+    ///
+    /// This method corresponds to the RISC-V `CSRW csr, rs`
+    /// instruction where `rs = in(reg) val_to_set`.
+    fn set_value(&self, val_to_set: u64);
+
+    /// Atomically swap the contents of a CSR
+    ///
+    /// Reads the current value of a CSR and replaces it with the
+    /// specified value in a single instruction, returning the
+    /// previous value.
+    ///
+    /// This method corresponds to the RISC-V `CSRRW rd, csr, rs1`
+    /// instruction where `rs1 = in(reg) value_to_set` and `rd =
+    /// out(reg) <return value>`.
+    fn atomic_replace(&self, val_to_set: u64) -> u64;
+
+    /// Atomically read a CSR and set bits specified in a bitmask
+    ///
+    /// This method corresponds to the RISC-V `CSRRS rd, csr, rs1`
+    /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
+    /// <return value>`.
+    fn read_and_set_bits(&self, bitmask: u64) -> u64;
+
+    /// Atomically read a CSR and set bits specified in a bitmask
+    ///
+    /// This method corresponds to the RISC-V `CSRRS rd, csr, rs1`
+    /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
+    /// <return value>`.
+    fn read_and_clear_bits(&self, bitmask: u64) -> u64;
+
+    /// Atomically read field and set all bits to 1
+    ///
+    /// This method corresponds to the RISC-V `CSRRS rd, csr, rs1`
+    /// instruction, where `rs1` is the bitmask described by the
+    /// [`Field`].
+    ///
+    /// The previous value of the field is returned.
+    fn read_and_set_field(&self, field: Field<u64, Self::R>) -> u64 {
+        field.read(self.read_and_set_bits(field.mask << field.shift))
+    }
+
+    /// Atomically read field and set all bits to 0
+    ///
+    /// This method corresponds to the RISC-V `CSRRC rd, csr, rs1`
+    /// instruction, where `rs1` is the bitmask described by the
+    /// [`Field`].
+    ///
+    /// The previous value of the field is returned.
+    fn read_and_clear_field(&self, field: Field<u64, Self::R>) -> u64 {
+        field.read(self.read_and_clear_bits(field.mask << field.shift))
+    }
+}
+
 /// Read/Write registers.
 #[derive(Copy, Clone)]
 pub struct ReadWriteRiscvCsr<R: RegisterLongName, const V: u16> {
@@ -26,23 +90,43 @@ impl<R: RegisterLongName, const V: u16> ReadWriteRiscvCsr<R, V> {
             associated_register: PhantomData,
         }
     }
+}
 
-    // Special methods only available on RISC-V CSRs, not found in the
-    // usual tock-registers interface, others implemented through the
-    // respective [`Readable`] and [`Writeable`] trait implementations
+impl<R: RegisterLongName, const V: u16> RiscvCsrInterface for ReadWriteRiscvCsr<R, V> {
+    type R = R;
 
-    /// Atomically swap the contents of a CSR
-    ///
-    /// Reads the current value of a CSR and replaces it with the
-    /// specified value in a single instruction, returning the
-    /// previous value.
-    ///
-    /// This method corresponds to the RISC-V `CSRRW rd, csr, rs1`
-    /// instruction where `rs1 = in(reg) value_to_set` and `rd =
-    /// out(reg) <return value>`.
     #[cfg(all(target_arch = "riscv64", target_os = "none"))]
     #[inline]
-    pub fn atomic_replace(&self, val_to_set: u64) -> u64 {
+    fn get_value(&self) -> u64 {
+        let r: u64;
+        unsafe {
+            asm!("csrr {rd}, {csr}", rd = out(reg) r, csr = const V);
+        }
+        r
+    }
+
+    // Mock implementations for tests on Travis-CI.
+    #[cfg(not(any(target_arch = "riscv64", target_os = "none")))]
+    fn get_value(&self) -> u64 {
+        unimplemented!("reading RISC-V CSR {}", V)
+    }
+
+    #[cfg(all(target_arch = "riscv64", target_os = "none"))]
+    #[inline]
+    fn set_value(&self, val_to_set: u64) {
+        unsafe {
+            asm!("csrw {csr}, {rs}", rs = in(reg) val_to_set, csr = const V);
+        }
+    }
+
+    #[cfg(not(any(target_arch = "riscv64", target_os = "none")))]
+    fn set_value(&self, _val_to_set: u64) {
+        unimplemented!("writing RISC-V CSR {}", V)
+    }
+
+    #[cfg(all(target_arch = "riscv64", target_os = "none"))]
+    #[inline]
+    fn atomic_replace(&self, val_to_set: u64) -> u64 {
         let r: u64;
         unsafe {
             asm!("csrrw {rd}, {csr}, {rs1}",
@@ -52,30 +136,15 @@ impl<R: RegisterLongName, const V: u16> ReadWriteRiscvCsr<R, V> {
         }
         r
     }
-
-    /// Atomically swap the contents of a CSR
-    ///
-    /// Reads the current value of a CSR and replaces it with the
-    /// specified value in a single instruction, returning the
-    /// previous value.
-    ///
-    /// This method corresponds to the RISC-V `CSRRW rd, csr, rs1`
-    /// instruction where `rs1 = in(reg) value_to_set` and `rd =
-    /// out(reg) <return value>`.
     // Mock implementations for tests on Travis-CI.
     #[cfg(not(any(target_arch = "riscv64", target_os = "none")))]
-    pub fn atomic_replace(&self, _value_to_set: u64) -> u64 {
+    fn atomic_replace(&self, _value_to_set: u64) -> u64 {
         unimplemented!("RISC-V CSR {} Atomic Read/Write", V)
     }
 
-    /// Atomically read a CSR and set bits specified in a bitmask
-    ///
-    /// This method corresponds to the RISC-V `CSRRS rd, csr, rs1`
-    /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
-    /// <return value>`.
     #[cfg(all(target_arch = "riscv64", target_os = "none"))]
     #[inline]
-    pub fn read_and_set_bits(&self, bitmask: u64) -> u64 {
+    fn read_and_set_bits(&self, bitmask: u64) -> u64 {
         let r: u64;
         unsafe {
             asm!("csrrs {rd}, {csr}, {rs1}",
@@ -86,14 +155,9 @@ impl<R: RegisterLongName, const V: u16> ReadWriteRiscvCsr<R, V> {
         r
     }
 
-    /// Atomically read a CSR and set bits specified in a bitmask
-    ///
-    /// This method corresponds to the RISC-V `CSRRS rd, csr, rs1`
-    /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
-    /// <return value>`.
     // Mock implementations for tests on Travis-CI.
     #[cfg(not(any(target_arch = "riscv64", target_os = "none")))]
-    pub fn read_and_set_bits(&self, bitmask: u64) -> u64 {
+    fn read_and_set_bits(&self, bitmask: u64) -> u64 {
         unimplemented!(
             "RISC-V CSR {} Atomic Read and Set Bits, bitmask {:04x}",
             V,
@@ -101,14 +165,9 @@ impl<R: RegisterLongName, const V: u16> ReadWriteRiscvCsr<R, V> {
         )
     }
 
-    /// Atomically read a CSR and clear bits specified in a bitmask
-    ///
-    /// This method corresponds to the RISC-V `CSRRC rd, csr, rs1`
-    /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
-    /// <return value>`.
     #[cfg(all(target_arch = "riscv64", target_os = "none"))]
     #[inline]
-    pub fn read_and_clear_bits(&self, bitmask: u64) -> u64 {
+    fn read_and_clear_bits(&self, bitmask: u64) -> u64 {
         let r: u64;
         unsafe {
             asm!("csrrc {rd}, {csr}, {rs1}",
@@ -119,64 +178,25 @@ impl<R: RegisterLongName, const V: u16> ReadWriteRiscvCsr<R, V> {
         r
     }
 
-    /// Atomically read a CSR and clear bits specified in a bitmask
-    ///
-    /// This method corresponds to the RISC-V `CSRRC rd, csr, rs1`
-    /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
-    /// <return value>`.
     // Mock implementations for tests on Travis-CI.
     #[cfg(not(any(target_arch = "riscv64", target_os = "none")))]
-    pub fn read_and_clear_bits(&self, bitmask: u64) -> u64 {
+    fn read_and_clear_bits(&self, bitmask: u64) -> u64 {
         unimplemented!(
             "RISC-V CSR {} Atomic Read and Clear Bits, bitmask {:04x}",
             V,
             bitmask
         )
     }
-
-    /// Atomically read field and set all bits to 1
-    ///
-    /// This method corresponds to the RISC-V `CSRRS rd, csr, rs1`
-    /// instruction, where `rs1` is the bitmask described by the
-    /// [`Field`].
-    ///
-    /// The previous value of the field is returned.
-    #[inline]
-    pub fn read_and_set_field(&self, field: Field<u64, R>) -> u64 {
-        field.read(self.read_and_set_bits(field.mask << field.shift))
-    }
-
-    /// Atomically read field and set all bits to 0
-    ///
-    /// This method corresponds to the RISC-V `CSRRC rd, csr, rs1`
-    /// instruction, where `rs1` is the bitmask described by the
-    /// [`Field`].
-    ///
-    /// The previous value of the field is returned.
-    #[inline]
-    pub fn read_and_clear_field(&self, field: Field<u64, R>) -> u64 {
-        field.read(self.read_and_clear_bits(field.mask << field.shift))
-    }
 }
 
+// The Readable and Writeable traits aren't object-safe so unfortunately we can't implement them
+// for RiscvCsrInterface.
 impl<R: RegisterLongName, const V: u16> Readable for ReadWriteRiscvCsr<R, V> {
     type T = u64;
     type R = R;
 
-    #[cfg(all(target_arch = "riscv64", target_os = "none"))]
-    #[inline]
     fn get(&self) -> u64 {
-        let r: u64;
-        unsafe {
-            asm!("csrr {rd}, {csr}", rd = out(reg) r, csr = const V);
-        }
-        r
-    }
-
-    // Mock implementations for tests on Travis-CI.
-    #[cfg(not(any(target_arch = "riscv64", target_os = "none")))]
-    fn get(&self) -> u64 {
-        unimplemented!("reading RISC-V CSR {}", V)
+        self.get_value()
     }
 }
 
@@ -184,16 +204,7 @@ impl<R: RegisterLongName, const V: u16> Writeable for ReadWriteRiscvCsr<R, V> {
     type T = u64;
     type R = R;
 
-    #[cfg(all(target_arch = "riscv64", target_os = "none"))]
-    #[inline]
     fn set(&self, val_to_set: u64) {
-        unsafe {
-            asm!("csrw {csr}, {rs}", rs = in(reg) val_to_set, csr = const V);
-        }
-    }
-
-    #[cfg(not(any(target_arch = "riscv64", target_os = "none")))]
-    fn set(&self, _val_to_set: u64) {
-        unimplemented!("writing RISC-V CSR {}", V)
+        self.set_value(val_to_set);
     }
 }

--- a/riscv-regs/src/csrs/defs.rs
+++ b/riscv-regs/src/csrs/defs.rs
@@ -403,3 +403,10 @@ register_bitfields![u64,
         delta OFFSET(0) NUMBITS(64) [],
     ]
 ];
+
+// Performance counter registers.
+register_bitfields![u64,
+    pub hpmcounter [
+        value OFFSET(0) NUMBITS(64) [],
+    ]
+];

--- a/riscv-regs/src/csrs/mod.rs
+++ b/riscv-regs/src/csrs/mod.rs
@@ -66,6 +66,8 @@ pub struct CSR {
     pub vstopei: ReadWriteRiscvCsr<stopei::Register, 0x25c>,
     pub vsatp: ReadWriteRiscvCsr<satp::Register, CSR_VSATP>,
     pub vstopi: ReadWriteRiscvCsr<stopi::Register, 0xeb0>,
+
+    pub hpmcounter: [&'static dyn RiscvCsrInterface<R = hpmcounter::Register>; 32],
 }
 
 // Define the "addresses" of each CSR register.
@@ -115,4 +117,40 @@ pub const CSR: &CSR = &CSR {
     vstopei: ReadWriteRiscvCsr::new(),
     vsatp: ReadWriteRiscvCsr::new(),
     vstopi: ReadWriteRiscvCsr::new(),
+
+    // TODO: Use a procedural macro to generate these.
+    hpmcounter: [
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc00>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc01>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc02>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc03>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc04>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc05>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc06>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc07>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc08>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc09>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc0a>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc0b>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc0c>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc0d>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc0e>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc0f>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc10>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc11>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc12>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc13>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc14>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc15>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc16>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc17>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc18>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc19>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc1a>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc1b>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc1c>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc1d>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc1e>::new(),
+        &ReadWriteRiscvCsr::<hpmcounter::Register, 0xc1f>::new(),
+    ],
 };

--- a/riscv-regs/src/csrs/mod.rs
+++ b/riscv-regs/src/csrs/mod.rs
@@ -8,6 +8,7 @@ pub mod csr_access;
 pub mod defs;
 pub mod traps;
 
+pub use csr_access::RiscvCsrInterface;
 pub use tock_registers::interfaces::ReadWriteable;
 pub use tock_registers::interfaces::Readable;
 pub use tock_registers::interfaces::Writeable;

--- a/src/trap.rs
+++ b/src/trap.rs
@@ -7,7 +7,8 @@ use core::mem::size_of;
 use drivers::{Imsic, ImsicInterruptId};
 use memoffset::offset_of;
 use riscv_regs::{
-    sie, GeneralPurposeRegisters, GprIndex, Interrupt, Readable, Trap, Writeable, CSR,
+    sie, GeneralPurposeRegisters, GprIndex, Interrupt, Readable, RiscvCsrInterface, Trap,
+    Writeable, CSR,
 };
 
 use crate::print_util::*;

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -15,7 +15,7 @@ use riscv_page_tables::{
 use riscv_pages::*;
 use riscv_regs::{
     hgatp, hstatus, DecodedInstruction, Exception, LocalRegisterCopy, PrivilegeLevel, Readable,
-    Writeable, CSR,
+    RiscvCsrInterface, Writeable, CSR,
 };
 use spin::Mutex;
 


### PR DESCRIPTION
We'd like to access these via an index at runtime since it's a bank of 32 identically-formatted registers, however this is kind of a pain due to the CSR number being encoded as part of the instruction (i.e. there's no indirection via a register). 

This series attempts to make `hpmcounter` CSR accesses a little more ergonomic by introducing a trait representing a CSR (patch 1) and then using that trait object to create an array of `hpmcounter` CSRs that we can index into at runtime (patch 2).

There's still some code duplication in the CSR instantiation, but that appears unavoidable without the use of procedural macros, so I'm leaving that as a future exercise.