### PR TITLE
More complete PCI capability emulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ dependencies = [
  "const-field-offset",
  "data_model",
  "device_tree",
+ "enum_dispatch",
  "hyp_alloc",
  "memoffset",
  "page_tracking",
@@ -230,6 +231,18 @@ name = "endian-type-rs"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6419a5c75e40011b9fe0174db3fe24006ab122fbe1b7e9cc5974b338a755c76"
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb359f1476bf611266ac1f5355bc14aeca37b299d0ebccc038ee7058891c9cb"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "fallible-iterator"
@@ -363,6 +376,12 @@ checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -11,6 +11,7 @@ assertions = { path = "../assertions" }
 const-field-offset = { version = "0.1.2" }
 data_model = { path = "../data-model" }
 device_tree = { path = "../device-tree" }
+enum_dispatch = { version = "0.3.8" }
 hyp_alloc = { path = "../hyp-alloc" }
 memoffset = { version = ">=0.6.5", features = ["unstable_const"] }
 page_tracking = { path = "../page-tracking" }

--- a/drivers/src/pci/error.rs
+++ b/drivers/src/pci/error.rs
@@ -61,6 +61,10 @@ pub enum Error {
     MsiNot64BitCapable,
     /// The device has a vendor capability structure with an invalid length field.
     InvalidVendorCapabilityLength(usize),
+    /// The device has an unsupported PCI Express capability version.
+    UnsupportedExpressCapabilityVersion(u8),
+    /// The PCI Express device has an unsupported/unknwon device type.
+    UnsupportedExpressDevice(u8),
 }
 
 /// Holds results for PCI operations.

--- a/drivers/src/pci/error.rs
+++ b/drivers/src/pci/error.rs
@@ -57,6 +57,8 @@ pub enum Error {
     DeviceNotFound(Address),
     /// Too many capabilities were found for a PCI device.
     TooManyCapabilities,
+    /// The device has MSI support, but is not 64-bit capable.
+    MsiNot64BitCapable,
 }
 
 /// Holds results for PCI operations.

--- a/drivers/src/pci/error.rs
+++ b/drivers/src/pci/error.rs
@@ -59,6 +59,8 @@ pub enum Error {
     TooManyCapabilities,
     /// The device has MSI support, but is not 64-bit capable.
     MsiNot64BitCapable,
+    /// The device has a vendor capability structure with an invalid length field.
+    InvalidVendorCapabilityLength(usize),
 }
 
 /// Holds results for PCI operations.

--- a/drivers/src/pci/registers.rs
+++ b/drivers/src/pci/registers.rs
@@ -252,6 +252,16 @@ pub struct VendorCapabilityHeader {
     _vendor_specific: u8,
 }
 
+/// Bridge subsystem vendor ID capability.
+#[repr(C)]
+#[derive(FieldOffsets)]
+pub struct BridgeSubsystemRegisters {
+    pub header: CapabilityHeader,
+    _reserved: u16,
+    pub ssvid: ReadOnly<u16>,
+    pub ssid: ReadOnly<u16>,
+}
+
 /// Trait for specifying various mask values for a register.
 ///
 /// TODO: Make the `*_mask()` functions const values.

--- a/drivers/src/pci/registers.rs
+++ b/drivers/src/pci/registers.rs
@@ -205,6 +205,8 @@ pub struct CapabilityHeader {
 pub const PCI_CAPS_START: usize = PCI_TYPE_HEADER_END + 1;
 /// End byte offset of the standard PCI configuration space.
 pub const PCI_CONFIG_SPACE_END: usize = 0xff;
+/// The maximum number of bytes that can be occupied by PCI capability structures.
+pub const PCI_MAX_CAP_LENGTH: usize = PCI_CONFIG_SPACE_END - PCI_CAPS_START + 1;
 
 /// PCI power management capability.
 #[repr(C)]
@@ -239,6 +241,15 @@ pub struct MsiXRegisters {
     pub msg_control: ReadWrite<u16, MsiXMessageControl::Register>,
     pub table_offset: ReadOnly<u32>,
     pub pba_offset: ReadOnly<u32>,
+}
+
+/// Vendor-specific capability. These capabilities are dynamically-sized.
+#[repr(C)]
+#[derive(FieldOffsets)]
+pub struct VendorCapabilityHeader {
+    pub header: CapabilityHeader,
+    pub cap_length: ReadOnly<u8>,
+    _vendor_specific: u8,
 }
 
 /// Trait for specifying various mask values for a register.


### PR DESCRIPTION
This series adds support for emulating the small set of capabilities we expect to find with QEMU-emulated devices (including `virtio`): MSI(-X), PCIe, PMC, vendor-specific, and bridge SSVID. We use the `enum_dispatch` crate to dispatch calls to the type-specific capability implementations in order to avoid dynamic memory allocation (`Box<dyn Trait>`) and too much code repetition.

With these changes, a Linux host VM is able to fully probe a basic PCI hierarchy.