### PR TITLE
fdt-rs: Use version from Rivos github

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 [[package]]
 name = "fdt-rs"
 version = "0.4.3"
-source = "git+https://github.com/dgreid/fdt-rs?branch=rivos/main#4aa8151b64656c8e4283e76bde536eb2937fe15c"
+source = "git+https://github.com/rivosinc/fdt-rs?branch=rivos/main#4aa8151b64656c8e4283e76bde536eb2937fe15c"
 dependencies = [
  "endian-type-rs",
  "fallible-iterator",

--- a/device-tree/Cargo.toml
+++ b/device-tree/Cargo.toml
@@ -8,9 +8,7 @@ hyp_alloc = { path = "../hyp-alloc" }
 
 # TODO - vendor fdt-rs or find a better solution with fewer dependencies.
 # use the fdt-rs crate without default features to allow nostd
-# TODO - Use fdt-rs from rivos gitlab once permissions from a CI capable of
-# building rust are figured out.
 [dependencies.fdt-rs]
-git = "https://github.com/dgreid/fdt-rs"
+git = "https://github.com/rivosinc/fdt-rs"
 branch = "rivos/main"
 default-features = false


### PR DESCRIPTION
Instead of pulling from my personal github on every build, pull from
the newly created(but identical) fork at `github.com/rivosinc/fdt-rs`.

Signed-off-by: Dylan Reid <dgreid@rivosinc.com>