### PR TITLE
Prevent VMs from creating PCI address aliases

### DIFF
--- a/drivers/src/pci/error.rs
+++ b/drivers/src/pci/error.rs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use riscv_pages::SupervisorPageAddr;
+
 use super::address::{Address, Bus};
 use super::device::HeaderType;
 use super::resource::PciResourceType;
@@ -69,6 +71,10 @@ pub enum Error {
     Invalid64BitBarIndex,
     /// The device has a non-power-of-2 sized BAR.
     InvalidBarSize(u64),
+    /// A BAR or bridge window is programmed with an invalid address.
+    InvalidBarAddress(u64),
+    /// A VM has programmed a BAR or bridge window to cover a page it does not own.
+    UnownedBarPage(SupervisorPageAddr),
 }
 
 /// Holds results for PCI operations.

--- a/drivers/src/pci/error.rs
+++ b/drivers/src/pci/error.rs
@@ -65,6 +65,10 @@ pub enum Error {
     UnsupportedExpressCapabilityVersion(u8),
     /// The PCI Express device has an unsupported/unknwon device type.
     UnsupportedExpressDevice(u8),
+    /// The device has a 64-bit BAR at an odd-numbered index.
+    Invalid64BitBarIndex,
+    /// The device has a non-power-of-2 sized BAR.
+    InvalidBarSize(u64),
 }
 
 /// Holds results for PCI operations.

--- a/drivers/src/pci/error.rs
+++ b/drivers/src/pci/error.rs
@@ -4,7 +4,7 @@
 
 use super::address::{Address, Bus};
 use super::device::HeaderType;
-use super::root::PciBarType;
+use super::resource::PciResourceType;
 
 /// Errors resulting from interacting with PCI devices.
 #[derive(Clone, Copy, Debug)]
@@ -14,9 +14,9 @@ pub enum Error {
     /// The PCI configuration size provided by device tree isn't divisible by 4k.
     ConfigSpaceNotPageMultiple(u64),
     /// A PCI BAR resource provided by the device tree isn't aligned to 4k.
-    BarSpaceMisaligned(u64),
+    ResourceMisaligned(u64),
     /// A PCI BAR resource provided by the device tree isn't divisible by 4k.
-    BarSpaceNotPageMultiple(u64),
+    ResourceNotPageMultiple(u64),
     /// The device tree contained an MMIO region that overlaps with other memory regions.
     InvalidMmioRegion(page_tracking::MemMapError),
     /// The device tree entry for the PCI host didn't provide a base register for Configuration
@@ -31,10 +31,10 @@ pub enum Error {
     NoRegProperty,
     /// The device tree entry for the PCI host didn't provide a `ranges` property.
     NoRangesProperty,
-    /// Too many PCI resource ranges were specified in the device tree's `ranges` property.
-    TooManyBarSpaces,
     /// Multiple PCI resources of the given type were specified in the device tree.
-    DuplicateBarSpace(PciBarType),
+    DuplicateResource(PciResourceType),
+    /// Attempt to claim a resource that has already been taken.
+    ResourceTaken,
     /// The device tree provided an invalid bus number in the `bus-range` property.
     InvalidBusNumber(u32),
     /// No 'msi-parent' device tree property was specified in the device tree.

--- a/drivers/src/pci/mmio_builder.rs
+++ b/drivers/src/pci/mmio_builder.rs
@@ -6,6 +6,10 @@
 
 use core::cmp::min;
 use core::mem::size_of;
+use page_tracking::PageTracker;
+use riscv_pages::PageOwnerId;
+
+use super::resource::PciRootResources;
 
 // Returns a bit mask covering the specified number of bytes.
 fn byte_mask(bytes: usize) -> u32 {
@@ -21,6 +25,16 @@ fn select_bytes(val: u32, offset: usize, len: usize) -> u32 {
 fn update_bytes(dest: u32, offset: usize, len: usize, src: u32) -> u32 {
     let mask = byte_mask(len) << (offset * 8);
     dest & !mask | ((src << (offset * 8)) & mask)
+}
+
+/// Context for an emulated MMIO operation.
+pub struct MmioEmulationContext<'root> {
+    /// Global page-tracking table.
+    pub page_tracker: PageTracker,
+    /// ID of the VM making the access.
+    pub guest_id: PageOwnerId,
+    /// The PCI root complex resources.
+    pub resources: &'root PciRootResources,
 }
 
 /// A builder for emulated MMIO config space read operations.

--- a/drivers/src/pci/mod.rs
+++ b/drivers/src/pci/mod.rs
@@ -10,9 +10,11 @@ mod device;
 mod error;
 mod mmio_builder;
 mod registers;
+mod resource;
 mod root;
 
 pub use device::{PciDevice, PciDeviceInfo};
 pub use error::Error as PciError;
 pub use error::Result as PciResult;
-pub use root::{PciBarPage, PciBarPageIter, PciBarSpaceIter, PciBarType, PcieRoot};
+pub use resource::PciResourceType;
+pub use root::{PciBarPage, PciBarPageIter, PciResourceIter, PcieRoot};

--- a/drivers/src/pci/registers.rs
+++ b/drivers/src/pci/registers.rs
@@ -107,6 +107,10 @@ register_bitfields![u16,
         LinkSpeed OFFSET(0) NUMBITS(4),
         LinkWidth OFFSET(4) NUMBITS(6),
     ],
+
+    pub MemWindow [
+        Address OFFSET(4) NUMBITS(12) [],
+    ],
 ];
 
 register_bitfields![u8,
@@ -122,6 +126,10 @@ register_bitfields![u8,
         CompletionCode OFFSET(0) NUMBITS(3) [],
         Start OFFSET(6) NUMBITS(1) [],
         Capable OFFSET(7) NUMBITS(1) [],
+    ],
+
+    pub IoWindow [
+        Address OFFSET(4) NUMBITS(4) [],
     ],
 ];
 
@@ -206,13 +214,13 @@ pub struct BridgeRegisters {
     pub sec_bus: ReadWrite<u8>,
     pub sub_bus: ReadWrite<u8>,
     pub sec_lat: ReadWrite<u8>,
-    pub io_base: ReadWrite<u8>,
-    pub io_limit: ReadWrite<u8>,
+    pub io_base: ReadWrite<u8, IoWindow::Register>,
+    pub io_limit: ReadWrite<u8, IoWindow::Register>,
     pub sec_status: ReadWrite<u16, SecondaryStatus::Register>,
-    pub mem_base: ReadWrite<u16>,
-    pub mem_limit: ReadWrite<u16>,
-    pub pref_base: ReadWrite<u16>,
-    pub pref_limit: ReadWrite<u16>,
+    pub mem_base: ReadWrite<u16, MemWindow::Register>,
+    pub mem_limit: ReadWrite<u16, MemWindow::Register>,
+    pub pref_base: ReadWrite<u16, MemWindow::Register>,
+    pub pref_limit: ReadWrite<u16, MemWindow::Register>,
     pub pref_base_upper: ReadWrite<u32>,
     pub pref_limit_upper: ReadWrite<u32>,
     pub io_base_upper: ReadWrite<u16>,

--- a/drivers/src/pci/registers.rs
+++ b/drivers/src/pci/registers.rs
@@ -172,12 +172,15 @@ pub struct CommonRegisters {
 /// End byte offset of the common part of a PCI header.
 pub const PCI_COMMON_HEADER_END: usize = 0xf;
 
+/// Number of BAR registers in a PCI endpoint header.
+pub const PCI_ENDPOINT_BARS: usize = 6;
+
 /// Endpoint (type 0) PCI configuration registers.
 #[repr(C)]
 #[derive(FieldOffsets)]
 pub struct EndpointRegisters {
     pub common: CommonRegisters,
-    pub bar: [ReadWrite<u32, BaseAddress::Register>; 6],
+    pub bar: [ReadWrite<u32, BaseAddress::Register>; PCI_ENDPOINT_BARS],
     pub cardbus: ReadOnly<u32>,
     pub subsys_vendor_id: ReadOnly<u16>,
     pub subsys_id: ReadOnly<u16>,
@@ -190,12 +193,15 @@ pub struct EndpointRegisters {
     pub max_lat: ReadOnly<u8>,
 }
 
+/// Number of BAR registers in a PCI bridge header.
+pub const PCI_BRIDGE_BARS: usize = 2;
+
 /// Bridge (type 1) PCI configuration registers.
 #[repr(C)]
 #[derive(FieldOffsets)]
 pub struct BridgeRegisters {
     pub common: CommonRegisters,
-    pub bar: [ReadWrite<u32, BaseAddress::Register>; 2],
+    pub bar: [ReadWrite<u32, BaseAddress::Register>; PCI_BRIDGE_BARS],
     pub pri_bus: ReadWrite<u8>,
     pub sec_bus: ReadWrite<u8>,
     pub sub_bus: ReadWrite<u8>,

--- a/drivers/src/pci/resource.rs
+++ b/drivers/src/pci/resource.rs
@@ -1,0 +1,180 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use arrayvec::ArrayVec;
+use riscv_pages::SupervisorPageAddr;
+
+use super::error::*;
+
+/// PCI BAR resource types.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PciResourceType {
+    /// IO port space.
+    IoPort = 0,
+    /// 32-bit non-prefetchable memory space.
+    Mem32 = 1,
+    /// 32-bit prefetchable memory space.
+    PrefetchableMem32 = 2,
+    /// 64-bit non-prefetchable memory space. 64-bit memory spaces are supposed to be prefetchable,
+    /// but many device trees (including from QEMU) don't set the prefetch bit.
+    Mem64 = 3,
+    /// 64-bit prefetchable memory space.
+    PrefetchableMem64 = 4,
+}
+
+/// The number of different PCI resource types.
+pub const MAX_RESOURCE_TYPES: usize = PciResourceType::PrefetchableMem64 as usize + 1;
+
+// Format of the first PCI address cell which specifies the type of the resource.
+const PCI_ADDR_PREFETCH_BIT: u32 = 1 << 30;
+const PCI_ADDR_SPACE_CODE_SHIFT: u32 = 24;
+const PCI_ADDR_SPACE_CODE_MASK: u32 = 0x3;
+
+impl PciResourceType {
+    /// Return the resource type corresponding to the raw `index`.
+    pub fn from_index(index: usize) -> Option<Self> {
+        use PciResourceType::*;
+        match index {
+            0 => Some(IoPort),
+            1 => Some(Mem32),
+            2 => Some(PrefetchableMem32),
+            3 => Some(Mem64),
+            4 => Some(PrefetchableMem64),
+            _ => None,
+        }
+    }
+
+    /// Reads a PCI BAR resource type from the first cell in a PCI address range.
+    pub fn from_dt_cell(cell: u32) -> Option<Self> {
+        let prefetchable = (cell & PCI_ADDR_PREFETCH_BIT) != 0;
+        use PciResourceType::*;
+        match (cell >> PCI_ADDR_SPACE_CODE_SHIFT) & PCI_ADDR_SPACE_CODE_MASK {
+            0x0 => {
+                // Config space. Ignore it since we already got it from 'reg'.
+                None
+            }
+            0x1 => Some(IoPort),
+            0x2 => {
+                if prefetchable {
+                    Some(PrefetchableMem32)
+                } else {
+                    Some(Mem32)
+                }
+            }
+            0x3 => {
+                if prefetchable {
+                    Some(PrefetchableMem64)
+                } else {
+                    Some(Mem64)
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    /// Returns the PCI address cell used to encode this resource type.
+    pub fn to_dt_cell(self) -> u32 {
+        use PciResourceType::*;
+        match self {
+            IoPort => 0x1 << PCI_ADDR_SPACE_CODE_SHIFT,
+            Mem32 => 0x2 << PCI_ADDR_SPACE_CODE_SHIFT,
+            PrefetchableMem32 => (0x2 << PCI_ADDR_SPACE_CODE_SHIFT) | PCI_ADDR_PREFETCH_BIT,
+            Mem64 => 0x3 << PCI_ADDR_SPACE_CODE_SHIFT,
+            PrefetchableMem64 => (0x3 << PCI_ADDR_SPACE_CODE_SHIFT) | PCI_ADDR_PREFETCH_BIT,
+        }
+    }
+}
+
+/// Describes a single PCI root resource.
+#[derive(Debug)]
+pub struct PciRootResource {
+    addr: SupervisorPageAddr,
+    size: u64,
+    taken: bool,
+    pci_addr: u64,
+}
+
+impl PciRootResource {
+    /// Creates a new root resource with the given address and size.
+    pub fn new(addr: SupervisorPageAddr, size: u64, pci_addr: u64) -> Self {
+        Self {
+            addr,
+            size,
+            taken: false,
+            pci_addr,
+        }
+    }
+
+    /// Returns the CPU physical address of the resource.
+    pub fn addr(&self) -> SupervisorPageAddr {
+        self.addr
+    }
+
+    /// Returns the size of the resource.
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+
+    /// Returns the PCI bus address of the resource.
+    pub fn pci_addr(&self) -> u64 {
+        self.pci_addr
+    }
+
+    /// Marks the resource as having been exclusively allocated.
+    pub fn take(&mut self) -> Result<()> {
+        if self.taken {
+            return Err(Error::ResourceTaken);
+        }
+        self.taken = true;
+        Ok(())
+    }
+}
+
+// We only allow at most one resource of each type at the root complex.
+const MAX_ROOT_RESOURCES: usize = MAX_RESOURCE_TYPES;
+
+/// The PCI resources for a root complex.
+pub struct PciRootResources {
+    resources: ArrayVec<Option<PciRootResource>, MAX_ROOT_RESOURCES>,
+}
+
+impl PciRootResources {
+    /// Creates an initially-empty `PciRootResources`.
+    pub fn new() -> Self {
+        let mut resources = ArrayVec::new();
+        for _ in 0..resources.capacity() {
+            resources.push(None);
+        }
+        Self { resources }
+    }
+
+    /// Inserts the specified resource if a resource of the same type does not exist already.
+    pub fn insert(
+        &mut self,
+        resource_type: PciResourceType,
+        resource: PciRootResource,
+    ) -> Result<()> {
+        if self.resources[resource_type as usize].is_some() {
+            return Err(Error::DuplicateResource(resource_type));
+        }
+        self.resources[resource_type as usize] = Some(resource);
+        Ok(())
+    }
+
+    /// Returns a reference to the resource with the given type.
+    pub fn get(&self, resource_type: PciResourceType) -> Option<&PciRootResource> {
+        self.resources[resource_type as usize].as_ref()
+    }
+
+    /// Returns a mutable reference to the resource with the given type.
+    pub fn get_mut(&mut self, resource_type: PciResourceType) -> Option<&mut PciRootResource> {
+        self.resources[resource_type as usize].as_mut()
+    }
+}
+
+impl Default for PciRootResources {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/host_vm_loader.rs
+++ b/src/host_vm_loader.rs
@@ -288,13 +288,13 @@ impl<T: GuestStagePageTable> HostVmLoader<T> {
 
         // Identity-map the PCIe BAR resources.
         let pci = PcieRoot::get();
-        for (res_type, range) in pci.bar_spaces() {
+        for (res_type, range) in pci.resources() {
             let gpa =
                 PageAddr::new(RawAddr::guest(range.base().bits(), PageOwnerId::host())).unwrap();
             // TODO: PCI resources should have their own region type.
             self.vm
                 .add_confidential_memory_region(gpa, range.length_bytes());
-            let pages = pci.take_bar_space(res_type).unwrap();
+            let pages = pci.take_resource(res_type).unwrap();
             self.vm.add_pages(gpa, pages);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -334,6 +334,15 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
             dev.has_msix(),
             dev.is_pcie(),
         );
+
+        for bar in dev.bar_info().bars() {
+            println!(
+                "BAR{:}: type {:?}, size 0x{:x}",
+                bar.index(),
+                bar.bar_type(),
+                bar.size()
+            );
+        }
     });
 
     // Set up per-CPU memory and boot the secondary CPUs.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1492,9 +1492,11 @@ impl<T: GuestStagePageTable> HostVm<T, VmStateFinalized> {
             Load32 | Load32U | Store32 => 4,
             Load64 | Store64 => 8,
         };
+        let page_tracker = self.inner.page_tracker();
+        let guest_id = self.inner.page_owner_id();
         match op {
             Load8 | Load8U | Load16 | Load16U | Load32 | Load32U | Load64 => {
-                let val = pci.emulate_config_read(offset, width);
+                let val = pci.emulate_config_read(offset, width, page_tracker, guest_id);
                 self.inner
                     .set_vcpu_reg(vcpu_id, TvmCpuRegister::MmioLoadValue, val)
                     .map_err(|_| MmioEmulationError::AccessingVCpuReg)?;
@@ -1504,7 +1506,7 @@ impl<T: GuestStagePageTable> HostVm<T, VmStateFinalized> {
                     .inner
                     .get_vcpu_reg(vcpu_id, TvmCpuRegister::MmioStoreValue)
                     .map_err(|_| MmioEmulationError::AccessingVCpuReg)?;
-                pci.emulate_config_write(offset, val, width);
+                pci.emulate_config_write(offset, val, width, page_tracker, guest_id);
             }
         }
 


### PR DESCRIPTION
In order to support the IOMMU in Salus we'll need to "hide" the IOMMU PCI device from VMs. While we can prevent VMs from being able to access the memory we assign the IOMMU by not mapping those physical addresses into its address space, our current policy of allowing VMs to write whatever they want to BAR registers allows a VM to create an alias between the memory assigned to the IOMMU and another device. This series addresses this vulnerability by only allowing enabled BAR / bridge window assignments to map physical addresses that are owned by the VM.

- Patches 1 and 3 are minor refactorings.
- Patch 2 probes the sizes of device BARs during bus enumeration.
- Patch 4 checks BARs / bridge window assignments on writes to `COMMAND`
- Patch 5 prevents changes to BARs / bridge windows after they're enabled.