### PR TITLE
Probe for an IOMMU device

### DIFF
--- a/drivers/src/iommu/error.rs
+++ b/drivers/src/iommu/error.rs
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::pci::PciError;
+
+/// Errors resulting from interacting with the IOMMU.
+#[derive(Clone, Copy, Debug)]
+pub enum Error {
+    /// Error encountered while probing and enabling the IOMMU PCI device.
+    ProbingIommu(PciError),
+    /// Couldn't find the IOMMU registers BAR.
+    MissingRegisters,
+    /// Unexpected IOMMU register set size.
+    InvalidRegisterSize(u64),
+    /// IOMMU register set is misaligned.
+    MisalignedRegisters,
+    /// Missing required G-stage translation support.
+    MissingGStageSupport,
+    /// Missing required MSI translation support.
+    MissingMsiSupport,
+}
+
+/// Holds results for IOMMU operations.
+pub type Result<T> = core::result::Result<T, Error>;

--- a/drivers/src/iommu/main.rs
+++ b/drivers/src/iommu/main.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use spin::Once;
+use tock_registers::interfaces::Readable;
+
+use super::error::{Error, Result};
+use super::registers::*;
+use crate::pci::{DeviceId, PciArenaId, PcieRoot, VendorId};
+
+/// IOMMU device. Responsible for managing address translation for PCI devices.
+pub struct Iommu {
+    _arena_id: PciArenaId,
+    registers: &'static mut IommuRegisters,
+}
+
+// The global IOMMU singleton.
+static IOMMU: Once<Iommu> = Once::new();
+
+// Identifiers from the QEMU RFC implementation.
+const IOMMU_VENDOR_ID: u16 = 0x1efd;
+const IOMMU_DEVICE_ID: u16 = 0x8001;
+
+impl Iommu {
+    /// Probes for the IOMMU device on the given PCI root.
+    pub fn probe_from(pci: &PcieRoot) -> Result<()> {
+        let arena_id = pci
+            .take_and_enable_hypervisor_device(
+                VendorId::new(IOMMU_VENDOR_ID),
+                DeviceId::new(IOMMU_DEVICE_ID),
+            )
+            .map_err(Error::ProbingIommu)?;
+        let dev = pci.get_device(arena_id).unwrap().lock();
+
+        // IOMMU registers are in BAR0.
+        let bar = dev.bar_info().get(0).ok_or(Error::MissingRegisters)?;
+        // Unwrap ok: we've already determined BAR0 is valid.
+        let pci_addr = dev.get_bar_addr(0).unwrap();
+        let regs_base = pci.pci_to_physical_addr(pci_addr).unwrap();
+        let regs_size = bar.size();
+        if regs_size < core::mem::size_of::<IommuRegisters>() as u64 {
+            return Err(Error::InvalidRegisterSize(regs_size));
+        }
+        if regs_base.bits() % core::mem::size_of::<IommuRegisters>() as u64 != 0 {
+            return Err(Error::MisalignedRegisters);
+        }
+        // Safety: We've taken unique ownership of the IOMMU PCI device and have verified that
+        // BAR0 points to a suitably sized and aligned register set.
+        let registers = unsafe { (regs_base.bits() as *mut IommuRegisters).as_mut().unwrap() };
+
+        // We need support for Sv48x4 G-stage translation and MSI page-tables at minimum.
+        if !registers.capabilities.is_set(Capabilities::Sv48x4) {
+            return Err(Error::MissingGStageSupport);
+        }
+        if !registers.capabilities.is_set(Capabilities::MsiFlat) {
+            return Err(Error::MissingMsiSupport);
+        }
+
+        let iommu = Iommu {
+            _arena_id: arena_id,
+            registers,
+        };
+        IOMMU.call_once(|| iommu);
+        Ok(())
+    }
+
+    /// Gets a reference to the `Iommu` singleton. Panics if `Iommu::probe_from()` has not yet
+    /// been called to initialize it.
+    pub fn get() -> &'static Self {
+        IOMMU.get().unwrap()
+    }
+
+    /// Returns the version of this IOMMU device.
+    pub fn version(&self) -> u64 {
+        self.registers.capabilities.read(Capabilities::Version)
+    }
+}
+
+// `Iommu` holds `UnsafeCell`s for register access. Access to these registers is guarded by the
+// `Iommu` interface which allow them to be shared and sent between threads.
+unsafe impl Send for Iommu {}
+unsafe impl Sync for Iommu {}

--- a/drivers/src/iommu/mod.rs
+++ b/drivers/src/iommu/mod.rs
@@ -1,0 +1,11 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+mod error;
+mod main;
+mod registers;
+
+pub use error::Error as IommuError;
+pub use error::Result as IommuResult;
+pub use main::Iommu;

--- a/drivers/src/iommu/registers.rs
+++ b/drivers/src/iommu/registers.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use assertions::const_assert;
+use tock_registers::register_bitfields;
+use tock_registers::registers::{ReadOnly, ReadWrite};
+
+// IOMMU register definitions; see https://github.com/riscv-non-isa/riscv-iommu.
+
+register_bitfields![u64,
+    pub Capabilities [
+        Version OFFSET(0) NUMBITS(8),
+        Sv32 OFFSET(8) NUMBITS(1),
+        Sv39 OFFSET(9) NUMBITS(1),
+        Sv48 OFFSET(10) NUMBITS(1),
+        Sv57 OFFSET(11) NUMBITS(1),
+        Sv32x4 OFFSET(16) NUMBITS(1),
+        Sv39x4 OFFSET(17) NUMBITS(1),
+        Sv48x4 OFFSET(18) NUMBITS(1),
+        Sv57x4 OFFSET(19) NUMBITS(1),
+        MsiFlat OFFSET(22) NUMBITS(1),
+        MsiMrif OFFSET(23) NUMBITS(1),
+    ],
+];
+
+/// The IOMMU register set.
+#[repr(C)]
+pub struct IommuRegisters {
+    pub capabilities: ReadOnly<u64, Capabilities::Register>,
+    pub fctrl: ReadWrite<u32>,
+    _reserved0: u32,
+    pub ddtp: ReadWrite<u64>,
+    pub cqb: ReadWrite<u64>,
+    pub cqh: ReadWrite<u32>,
+    pub cqt: ReadOnly<u32>,
+    pub fqb: ReadWrite<u64>,
+    pub fqh: ReadWrite<u32>,
+    pub fqt: ReadOnly<u32>,
+    pub pqb: ReadWrite<u64>,
+    pub pqh: ReadWrite<u32>,
+    pub pqt: ReadOnly<u32>,
+    pub cqcsr: ReadWrite<u32>,
+    pub fqcsr: ReadWrite<u32>,
+    pub pqcsr: ReadWrite<u32>,
+    pub ipsr: ReadWrite<u32>,
+    // Includes debug/performance counter registers which we don't care about at the moment.
+    _reserved1: [u32; 1002],
+}
+
+fn _assert_register_layout() {
+    const_assert!(core::mem::size_of::<IommuRegisters>() == 4096);
+}

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -18,6 +18,8 @@ extern crate std;
 pub mod cpu;
 /// Provides the driver for the IMSIC from the AIA spec.
 pub mod imsic;
+/// Provides the driver for the IOMMU from the proposed RISCV-IOMMU spec.
+pub mod iommu;
 /// Provides PCI bus scanning and device discovery.
 pub mod pci;
 

--- a/drivers/src/pci/bus.rs
+++ b/drivers/src/pci/bus.rs
@@ -9,14 +9,14 @@ use super::address::*;
 use super::config_space::PciConfigSpace;
 use super::device::PciDevice;
 use super::error::*;
-use super::root::{PciDeviceArena, PciDeviceId};
+use super::root::{PciArenaId, PciDeviceArena};
 
 /// A entry for a single device on a `PciBus`.
 pub struct BusDevice {
     /// The PCI bus address of the device.
     pub address: Address,
     /// The ID of the device in the `PciDeviceArena`.
-    pub id: PciDeviceId,
+    pub id: PciArenaId,
 }
 
 /// Represents a PCI bus.

--- a/drivers/src/pci/device.rs
+++ b/drivers/src/pci/device.rs
@@ -308,8 +308,8 @@ impl PciDeviceBarInfo {
         self.bars.iter()
     }
 
-    // Returns the `PciBarInfo` with the given BAR index.
-    fn get(&self, index: usize) -> Option<&PciBarInfo> {
+    /// Returns the `PciBarInfo` with the given BAR index.
+    pub fn get(&self, index: usize) -> Option<&PciBarInfo> {
         self.bars.iter().find(|b| b.index() == index)
     }
 
@@ -458,7 +458,7 @@ impl PciBridge {
 
     /// Configures the secondary and subordinate bus numbers of the bridge such that configuration
     /// cycles from `range.start` to `range.end` (inclusive) will be forwarded downstream.
-    pub fn assign_bus_range(&mut self, range: BusRange) {
+    pub(super) fn assign_bus_range(&mut self, range: BusRange) {
         self.registers.sub_bus.set(range.end.bits() as u8);
         self.registers.sec_bus.set(range.start.bits() as u8);
         let pri_bus = self.common.info.address().bus();
@@ -467,12 +467,12 @@ impl PciBridge {
     }
 
     /// Sets the bus that is directly downstream of this bridge.
-    pub fn set_child_bus(&mut self, bus: PciBus) {
+    pub(super) fn set_child_bus(&mut self, bus: PciBus) {
         self.child_bus = Some(bus)
     }
 
     /// Returns the secondary bus directly downstream of this bridge.
-    pub fn child_bus(&self) -> Option<&PciBus> {
+    pub(super) fn child_bus(&self) -> Option<&PciBus> {
         self.child_bus.as_ref()
     }
 
@@ -772,7 +772,7 @@ impl PciDevice {
     ///
     /// The caller must guarantee that `registers_ptr` points to a valid and uniquely-owned
     /// configuration space, and that it and `info` reference the same device.
-    pub unsafe fn new(
+    pub(super) unsafe fn new(
         registers_ptr: NonNull<CommonRegisters>,
         info: PciDeviceInfo,
     ) -> Result<Self> {
@@ -822,7 +822,7 @@ impl PciDevice {
     }
 
     /// Takes ownership over the device if it is not already owned.
-    pub fn take(&mut self, owner: PageOwnerId) -> Result<()> {
+    pub(super) fn take(&mut self, owner: PageOwnerId) -> Result<()> {
         if self.owner().is_some() {
             return Err(Error::DeviceOwned);
         }
@@ -831,7 +831,7 @@ impl PciDevice {
     }
 
     /// Emulates a read from the configuration space of this device at `offset`.
-    pub fn emulate_config_read(
+    pub(super) fn emulate_config_read(
         &self,
         offset: usize,
         len: usize,
@@ -900,7 +900,7 @@ impl PciDevice {
     }
 
     /// Emulates a write to the configuration space of this device at `offset`.
-    pub fn emulate_config_write(
+    pub(super) fn emulate_config_write(
         &mut self,
         offset: usize,
         value: u32,
@@ -956,8 +956,8 @@ impl PciDevice {
         }
     }
 
-    // Returns the PCI bus address programmed in the BAR at `bar_index`.
-    fn get_bar_addr(&self, index: usize) -> Result<u64> {
+    /// Returns the PCI bus address programmed in the BAR at `bar_index`.
+    pub fn get_bar_addr(&self, index: usize) -> Result<u64> {
         let bar = self
             .bar_info()
             .get(index)

--- a/drivers/src/pci/device.rs
+++ b/drivers/src/pci/device.rs
@@ -930,16 +930,14 @@ impl PciDevice {
 
                     // TODO: No DMA until the IOMMU is enabled.
                     reg.modify(Command::BusMasterEnable.val(0));
-                    self.common_registers_mut()
-                        .command
-                        .set(reg.writeable_bits());
+                    self.common_registers().command.set(reg.writeable_bits());
                 }
                 status::span!() => {
                     // Make sure we only write the RW1C bits if the write operation covers that byte.
                     let reg = LocalRegisterCopy::<u16, Status::Register>::new(
                         op.pop_word(self.common_registers().status.non_clearable_bits()),
                     );
-                    self.common_registers_mut().status.set(reg.writeable_bits());
+                    self.common_registers().status.set(reg.writeable_bits());
                 }
                 PCI_TYPE_HEADER_START..=PCI_TYPE_HEADER_END => {
                     self.emulate_type_specific_write(&mut op);
@@ -1029,14 +1027,6 @@ impl PciDevice {
         match self {
             PciDevice::Endpoint(ep) => &ep.registers.common,
             PciDevice::Bridge(bridge) => &bridge.registers.common,
-        }
-    }
-
-    // Returns a mutable reference to the common portion of this device's PCI header.
-    fn common_registers_mut(&mut self) -> &mut CommonRegisters {
-        match self {
-            PciDevice::Endpoint(ep) => &mut ep.registers.common,
-            PciDevice::Bridge(bridge) => &mut bridge.registers.common,
         }
     }
 

--- a/drivers/src/pci/device.rs
+++ b/drivers/src/pci/device.rs
@@ -25,14 +25,37 @@ use super::resource::*;
 pub struct VendorId(u16);
 
 impl VendorId {
+    /// Creates a new `VendorId` from the raw `id`.
+    pub fn new(id: u16) -> Self {
+        VendorId(id)
+    }
+
+    /// The invalid (not-present) `VendorId`.
     pub const fn invalid() -> Self {
         VendorId(0xffff)
+    }
+
+    /// Returns the raw `VendorId` value.
+    pub fn bits(&self) -> u16 {
+        self.0
     }
 }
 
 /// The Device Id from the PCI header.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default)]
 pub struct DeviceId(u16);
+
+impl DeviceId {
+    /// Creates a new `DeviceId` from the raw `id`.
+    pub fn new(id: u16) -> Self {
+        DeviceId(id)
+    }
+
+    /// Returns the raw `DeviceId` value.
+    pub fn bits(&self) -> u16 {
+        self.0
+    }
+}
 
 /// The Class of the device from the PCI Header.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default)]

--- a/drivers/src/pci/error.rs
+++ b/drivers/src/pci/error.rs
@@ -73,6 +73,8 @@ pub enum Error {
     InvalidBarSize(u64),
     /// A BAR or bridge window is programmed with an invalid address.
     InvalidBarAddress(u64),
+    /// The device does not have a BAR at the specified index.
+    BarNotPresent(usize),
     /// A VM has programmed a BAR or bridge window to cover a page it does not own.
     UnownedBarPage(SupervisorPageAddr),
     /// The PCI device is already owned.

--- a/drivers/src/pci/error.rs
+++ b/drivers/src/pci/error.rs
@@ -75,6 +75,10 @@ pub enum Error {
     InvalidBarAddress(u64),
     /// A VM has programmed a BAR or bridge window to cover a page it does not own.
     UnownedBarPage(SupervisorPageAddr),
+    /// The PCI device is already owned.
+    DeviceOwned,
+    /// The PCI device is not owned, or is owned by another VM.
+    DeviceNotOwned,
 }
 
 /// Holds results for PCI operations.

--- a/drivers/src/pci/error.rs
+++ b/drivers/src/pci/error.rs
@@ -37,6 +37,10 @@ pub enum Error {
     DuplicateResource(PciResourceType),
     /// Attempt to claim a resource that has already been taken.
     ResourceTaken,
+    /// Couldn't find a resource with the specified type.
+    ResourceNotFound(PciResourceType),
+    /// Unable to allocate a PCI resource.
+    OutOfResources,
     /// The device tree provided an invalid bus number in the `bus-range` property.
     InvalidBusNumber(u32),
     /// No 'msi-parent' device tree property was specified in the device tree.
@@ -56,7 +60,7 @@ pub enum Error {
     /// Offset in emulated config space is invalid.
     InvalidConfigOffset,
     /// The device targetted by the emulated config space access does not exist.
-    DeviceNotFound(Address),
+    DeviceNotPresent(Address),
     /// Too many capabilities were found for a PCI device.
     TooManyCapabilities,
     /// The device has MSI support, but is not 64-bit capable.
@@ -81,6 +85,10 @@ pub enum Error {
     DeviceOwned,
     /// The PCI device is not owned, or is owned by another VM.
     DeviceNotOwned,
+    /// The PCI device could not be found.
+    DeviceNotFound,
+    /// The PCI device was expected to be on the root bus, but wasn't.
+    DeviceNotOnRootBus,
 }
 
 /// Holds results for PCI operations.

--- a/drivers/src/pci/mod.rs
+++ b/drivers/src/pci/mod.rs
@@ -17,4 +17,4 @@ pub use device::{DeviceId, PciDevice, PciDeviceInfo, VendorId};
 pub use error::Error as PciError;
 pub use error::Result as PciResult;
 pub use resource::PciResourceType;
-pub use root::{PciBarPage, PciBarPageIter, PciResourceIter, PcieRoot};
+pub use root::{PciArenaId, PciBarPage, PciBarPageIter, PciResourceIter, PcieRoot};

--- a/drivers/src/pci/mod.rs
+++ b/drivers/src/pci/mod.rs
@@ -13,7 +13,7 @@ mod registers;
 mod resource;
 mod root;
 
-pub use device::{PciDevice, PciDeviceInfo};
+pub use device::{DeviceId, PciDevice, PciDeviceInfo, VendorId};
 pub use error::Error as PciError;
 pub use error::Result as PciResult;
 pub use resource::PciResourceType;

--- a/drivers/src/pci/root.rs
+++ b/drivers/src/pci/root.rs
@@ -25,7 +25,7 @@ use super::resource::*;
 pub type PciDeviceArena = Arena<Mutex<PciDevice>, Global>;
 
 /// Identifiers in the PCI device arena.
-pub type PciDeviceId = ArenaId<Mutex<PciDevice>>;
+pub type PciArenaId = ArenaId<Mutex<PciDevice>>;
 
 // The number of "PCI address" cells, as specified in the standard PCI binding.
 const PCI_ADDR_CELLS: usize = 3;
@@ -386,7 +386,7 @@ impl PcieRoot {
     }
 
     // Calls `f` for each device on `bus`.
-    fn for_each_device_on<F: FnMut(PciDeviceId)>(&self, bus: &PciBus, f: &mut F) {
+    fn for_each_device_on<F: FnMut(PciArenaId)>(&self, bus: &PciBus, f: &mut F) {
         for bd in bus.devices() {
             f(bd.id);
             // If the ID appears on a bus, it must be in the arena.
@@ -401,7 +401,7 @@ impl PcieRoot {
     }
 
     // Returns the device ID for the device at the virtualized PCI address `address` on `bus`.
-    fn device_by_virtual_address_on(&self, bus: &PciBus, address: Address) -> Option<PciDeviceId> {
+    fn device_by_virtual_address_on(&self, bus: &PciBus, address: Address) -> Option<PciArenaId> {
         if address.bus() == bus.virtual_secondary_bus_num() {
             // The device is on this bus.
             return bus
@@ -432,7 +432,7 @@ impl PcieRoot {
 
     // Returns the ID of the device whose config space is mapped at `offset` in the virtualized
     // config space, along with the offset within the device's config space.
-    fn virtual_config_offset_to_device(&self, offset: usize) -> Result<(PciDeviceId, usize)> {
+    fn virtual_config_offset_to_device(&self, offset: usize) -> Result<(PciArenaId, usize)> {
         let (address, dev_offset) = self
             .config_space
             .offset_to_address(offset)

--- a/src/host_vm_loader.rs
+++ b/src/host_vm_loader.rs
@@ -295,7 +295,7 @@ impl<T: GuestStagePageTable> HostVmLoader<T> {
             // TODO: PCI resources should have their own region type.
             self.vm
                 .add_confidential_memory_region(gpa, range.length_bytes());
-            let pages = pci.take_resource(res_type).unwrap();
+            let pages = pci.take_host_resource(res_type).unwrap();
             self.vm.add_pages(gpa, pages);
         }
 

--- a/src/host_vm_loader.rs
+++ b/src/host_vm_loader.rs
@@ -286,8 +286,9 @@ impl<T: GuestStagePageTable> HostVmLoader<T> {
             }
         }
 
-        // Identity-map the PCIe BAR resources.
         let pci = PcieRoot::get();
+        pci.take_host_devices();
+        // Identity-map the PCIe BAR resources.
         for (res_type, range) in pci.resources() {
             let gpa =
                 PageAddr::new(RawAddr::guest(range.base().bits(), PageOwnerId::host())).unwrap();


### PR DESCRIPTION
This series adds support to the PCI driver for claiming a PCI device for internal hypervisor usage and then uses this support to probe for and claim a RISC-V IOMMU device on the root bus.

Patches 1-7 are cleanups and prep-work. Notably they add support for per-device ownership, which we'll use to hide hypervisor-claimed devices from VMs.

Patch 8 adds support for claiming a device for hypervisor-internal usage. This includes the very basic ability to assign BAR resources to a PCI device, which for now is limited to just devices directly behind the host bridge (which is fine for the IOMMU since it's always a RCiEP). Resources assigned to hypervisor devices are taken from the end of the host bridge windows and are hidden from the host VM.

Patch 9 adds a stub IOMMU driver which finds the IOMMU on the PCI bus and verifies it supports the necessary features.

Tested with the RFC RISC-V IOMMU support patches. A QEMU branch with these patches (+ Sstc support) can be found here: https://github.com/abrestic-rivos/qemu/tree/testing/sstc-iommu.

With these changes, Salus is able to discover the IOMMU and hide it from a Linux host VM.

Related to #43 