### PR TITLE
IMSIC cleanups in preparation for MSI page tables

### DIFF
--- a/drivers/src/imsic.rs
+++ b/drivers/src/imsic.rs
@@ -396,7 +396,7 @@ impl Imsic {
             .props()
             .find(|p| p.name() == "riscv,hart-index-bits")
             .and_then(|p| p.value_u32().next())
-            .unwrap_or_else(|| num_cpus.next_power_of_two().log2());
+            .unwrap_or_else(|| num_cpus.next_power_of_two().ilog2());
 
         // If there are multiple groups, their index must be in the upper 8 bits of the address.
         let group_index_bits = imsic_node
@@ -411,7 +411,7 @@ impl Imsic {
             .unwrap_or(MIN_GROUP_SHIFT);
         assert!(group_index_shift < u64::BITS);
         assert!(group_index_shift >= MIN_GROUP_SHIFT);
-        let pfn_shift = (PageSize::Size4k as u64).log2();
+        let pfn_shift = (PageSize::Size4k as u64).ilog2();
         assert!(group_index_shift >= pfn_shift + hart_index_bits + guest_index_bits);
 
         // Now match up interrupt files to CPUs. The "hart index" for a CPU is the order in which

--- a/drivers/src/imsic/core.rs
+++ b/drivers/src/imsic/core.rs
@@ -12,27 +12,12 @@ use riscv_regs::Readable;
 use riscv_regs::{sie, stopei, RiscvCsrInterface, Writeable, CSR};
 use spin::{Mutex, Once};
 
+use super::error::{Error, Result};
 use crate::{CpuId, CpuInfo, MAX_CPUS};
 
 const MAX_GUEST_FILES: usize = 7;
 const MAX_MMIO_REGIONS: usize = 8;
 const MIN_GROUP_SHIFT: u32 = 24; // As mandated by the AIA spec.
-
-/// Errors that can be returned when claiming or releasing guest interrupt files.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Error {
-    /// The requested CPU does not exist.
-    InvalidCpu(CpuId),
-    /// No guest file for the specified guest.
-    InvalidGuestFile,
-    /// Guest file for this guest already taken.
-    GuestFileTaken,
-    /// Attempt to free a guest file that's not taken.
-    GuestFileFree,
-}
-
-/// Holds the result of IMSIC operations.
-pub type Result<T> = core::result::Result<T, Error>;
 
 /// IMSIC indirect CSRs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/drivers/src/imsic/error.rs
+++ b/drivers/src/imsic/error.rs
@@ -27,6 +27,10 @@ pub enum Error {
     InvalidMmioRegion(u64),
     /// Invalid parent interrupt specification in the device tree.
     InvalidParentInterrupt(u32, u32),
+    /// The given CPU does not have a valid IMSIC location specified in the device tree.
+    InvalidCpuLocation(CpuId),
+    /// The given CPU was referenced multiple times in the device tree.
+    DuplicateCpuEntries(CpuId),
     /// There were more interrupt files than CPUs found in the device tree.
     TooManyInterruptFiles,
     /// There were fewer interrupt files than CPUs found in the device tree.
@@ -35,12 +39,8 @@ pub enum Error {
     AddingMmioRegion(page_tracking::MemMapError),
     /// The requested CPU does not exist.
     InvalidCpu(CpuId),
-    /// No guest file for the specified guest.
-    InvalidGuestFile,
-    /// Guest file for this guest already taken.
-    GuestFileTaken,
-    /// Attempt to free a guest file that's not taken.
-    GuestFileFree,
+    /// Guest files for this CPU have already been taken.
+    GuestFilesTaken(CpuId),
 }
 
 /// Holds the result of IMSIC operations.

--- a/drivers/src/imsic/error.rs
+++ b/drivers/src/imsic/error.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::CpuId;
+
+/// Errors that can be returned when claiming or releasing guest interrupt files.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Error {
+    /// The requested CPU does not exist.
+    InvalidCpu(CpuId),
+    /// No guest file for the specified guest.
+    InvalidGuestFile,
+    /// Guest file for this guest already taken.
+    GuestFileTaken,
+    /// Attempt to free a guest file that's not taken.
+    GuestFileFree,
+}
+
+/// Holds the result of IMSIC operations.
+pub type Result<T> = core::result::Result<T, Error>;

--- a/drivers/src/imsic/error.rs
+++ b/drivers/src/imsic/error.rs
@@ -4,9 +4,33 @@
 
 use crate::CpuId;
 
-/// Errors that can be returned when claiming or releasing guest interrupt files.
+/// Errors that can be returned by the IMSIC driver.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Error {
+    /// The IMSIC node was not present in the device tree.
+    MissingImsicNode,
+    /// The specified property was missing from the IMSIC device tree node.
+    MissingProperty(&'static str),
+    /// Unexpected number of parent interrupts specified in the device tree.
+    InvalidParentInterruptCount(usize),
+    /// Invalid number of guest files per hart specified in the device tree.
+    InvalidGuestsPerHart(usize),
+    /// Invalid group index shift specified in the device tree.
+    InvalidGroupIndexShift(u32),
+    /// Unexpected number of MMIO regions specified in the device tree.
+    InvalidMmioRegionCount(usize),
+    /// Misaligned MMIO region specified in the device tree.
+    MisalignedMmioRegion(u64),
+    /// Invalid parent interrupt specification in the device tree.
+    InvalidParentInterrupt(u32, u32),
+    /// There were more interrupt files than CPUs found in the device tree.
+    TooManyInterruptFiles,
+    /// There were fewer interrupt files than CPUs found in the device tree.
+    MissingInterruptFiles,
+    /// A group base address did not match the expected pattern.
+    InvalidGeometry,
+    /// Failed to add an MMIO region to the system memory map.
+    AddingMmioRegion(page_tracking::MemMapError),
     /// The requested CPU does not exist.
     InvalidCpu(CpuId),
     /// No guest file for the specified guest.

--- a/drivers/src/imsic/error.rs
+++ b/drivers/src/imsic/error.rs
@@ -13,22 +13,24 @@ pub enum Error {
     MissingProperty(&'static str),
     /// Unexpected number of parent interrupts specified in the device tree.
     InvalidParentInterruptCount(usize),
-    /// Invalid number of guest files per hart specified in the device tree.
+    /// Invalid number of guest files per hart specified in the IMSIC geometry.
     InvalidGuestsPerHart(usize),
-    /// Invalid group index shift specified in the device tree.
+    /// Invalid group index shift specified in the IMSIC geometry.
     InvalidGroupIndexShift(u32),
+    /// The base address in the IMSIC geometry has non-zero index bits.
+    InvalidAddressPattern(u64),
     /// Unexpected number of MMIO regions specified in the device tree.
     InvalidMmioRegionCount(usize),
     /// Misaligned MMIO region specified in the device tree.
     MisalignedMmioRegion(u64),
+    /// An MMIO region specified in the device tree did not match the expected pattern.
+    InvalidMmioRegion(u64),
     /// Invalid parent interrupt specification in the device tree.
     InvalidParentInterrupt(u32, u32),
     /// There were more interrupt files than CPUs found in the device tree.
     TooManyInterruptFiles,
     /// There were fewer interrupt files than CPUs found in the device tree.
     MissingInterruptFiles,
-    /// A group base address did not match the expected pattern.
-    InvalidGeometry,
     /// Failed to add an MMIO region to the system memory map.
     AddingMmioRegion(page_tracking::MemMapError),
     /// The requested CPU does not exist.

--- a/drivers/src/imsic/geometry.rs
+++ b/drivers/src/imsic/geometry.rs
@@ -1,0 +1,407 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use riscv_pages::*;
+
+use super::error::*;
+
+/// Identifies a group or node in the IMSIC topology.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ImsicGroupId(u64);
+
+impl ImsicGroupId {
+    /// Creates a new `ImsicGroupId` from `id`.
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    /// Returns the raw value of this `ImsicGroupId`.
+    pub fn bits(&self) -> u64 {
+        self.0
+    }
+}
+
+/// Identifies a hart within a group in the IMSIC topology.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ImsicHartId(u64);
+
+impl ImsicHartId {
+    /// Creates a new `ImsicGroupId` from `id`.
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    /// Returns the raw value of this `ImsicHartId`.
+    pub fn bits(&self) -> u64 {
+        self.0
+    }
+}
+
+/// Identifies the interrupt file page within a hart.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ImsicFileId {
+    /// The supervisor-level interrupt file. Always at index 0.
+    Supervisor,
+    /// Guest (virtual supervisor) interrupt files. Immediately follow the supervisor file.
+    Guest(u32),
+}
+
+impl ImsicFileId {
+    /// The `ImsicFileId` for the supervisor-level interrupt file.
+    pub fn supervisor() -> Self {
+        ImsicFileId::Supervisor
+    }
+
+    /// The `ImsicFileId` for the specified guest interrupt file.
+    pub fn guest(guest: u32) -> Self {
+        ImsicFileId::Guest(guest)
+    }
+
+    /// Returns the `ImsicFileId` corresponding to the raw `index`.
+    pub fn from_index(index: u32) -> Self {
+        if index == 0 {
+            ImsicFileId::Supervisor
+        } else {
+            ImsicFileId::Guest(index - 1)
+        }
+    }
+
+    /// Returns the raw value of this `ImsicFileId`.
+    pub fn bits(&self) -> u32 {
+        match self {
+            ImsicFileId::Supervisor => 0,
+            ImsicFileId::Guest(g) => g + 1,
+        }
+    }
+}
+
+/// Specifies the location of an IMSIC interrupt file within an IMSIC topology. Can be translated
+/// to and from the page address of interrupt file using `ImsicGeometry`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ImsicLocation {
+    group: ImsicGroupId,
+    hart: ImsicHartId,
+    file: ImsicFileId,
+}
+
+impl ImsicLocation {
+    /// Creates a new `ImsicLocation` from its individual components.
+    pub fn new(group: ImsicGroupId, hart: ImsicHartId, file: ImsicFileId) -> Self {
+        Self { group, hart, file }
+    }
+
+    /// Returns the group ID of this IMSIC.
+    pub fn group(&self) -> ImsicGroupId {
+        self.group
+    }
+
+    /// Returns the hart ID of this IMSIC.
+    pub fn hart(&self) -> ImsicHartId {
+        self.hart
+    }
+
+    /// Returns the file ID of this IMSIC.
+    pub fn file(&self) -> ImsicFileId {
+        self.file
+    }
+}
+
+/// Describes the layout of the IMSICs in a system.
+#[derive(Clone, Debug)]
+pub struct ImsicGeometry<AS: AddressSpace> {
+    base_addr: PageAddr<AS>,
+    group_index_bits: u32,
+    group_index_shift: u32,
+    hart_index_bits: u32,
+    guest_index_bits: u32,
+    guests_per_hart: usize,
+}
+
+/// An `ImsicGeometry` specifying the supervisor's IMSIC layout.
+pub type SupervisorImsicGeometry = ImsicGeometry<SupervisorPhys>;
+/// An `ImsicGeometry` specifying a guest's IMSIC layout (in guest physical address space).
+pub type GuestImsicGeometry = ImsicGeometry<GuestPhys>;
+
+/// The guest index bits are always the least-significant bits of the PFN.
+pub const GUEST_INDEX_SHIFT: u32 = 12;
+/// The minimum shift for the group index bits, as mandated by the AIA specification.
+pub const MIN_GROUP_INDEX_SHIFT: u32 = 24;
+
+fn gen_mask(num_bits: u32, shift: u32) -> u64 {
+    ((1 << num_bits) - 1) << shift
+}
+
+fn extract(val: u64, num_bits: u32, shift: u32) -> u64 {
+    (val >> shift) & ((1 << num_bits) - 1)
+}
+
+impl<AS: AddressSpace> ImsicGeometry<AS> {
+    /// Creates a new `ImsicGeometry` starting at `base_addr` (address of group 0, hart 0) with
+    /// the specified index widths.
+    pub fn new(
+        base_addr: PageAddr<AS>,
+        group_index_bits: u32,
+        group_index_shift: u32,
+        hart_index_bits: u32,
+        guest_index_bits: u32,
+        guests_per_hart: usize,
+    ) -> Result<Self> {
+        if guests_per_hart >= (1 << guest_index_bits) {
+            return Err(Error::InvalidGuestsPerHart(guests_per_hart));
+        }
+        if (group_index_shift + group_index_bits) >= u64::BITS
+            || group_index_shift < MIN_GROUP_INDEX_SHIFT
+            || group_index_shift < (GUEST_INDEX_SHIFT + hart_index_bits + guest_index_bits)
+        {
+            return Err(Error::InvalidGroupIndexShift(group_index_shift));
+        }
+        let geo = Self {
+            base_addr,
+            group_index_bits,
+            group_index_shift,
+            hart_index_bits,
+            guest_index_bits,
+            guests_per_hart,
+        };
+        if (base_addr.bits() & geo.index_mask()) != 0 {
+            return Err(Error::InvalidAddressPattern(base_addr.bits()));
+        }
+        Ok(geo)
+    }
+
+    /// Returns the base address of the IMSIC geometry.
+    pub fn base_addr(&self) -> PageAddr<AS> {
+        self.base_addr
+    }
+
+    /// Returns the number of guest index bits.
+    pub fn guest_index_bits(&self) -> u32 {
+        self.guest_index_bits
+    }
+
+    /// Returns the number of hart index bits.
+    pub fn hart_index_bits(&self) -> u32 {
+        self.hart_index_bits
+    }
+
+    /// Returns the shift of the group index bits in an IMSIC address.
+    pub fn group_index_shift(&self) -> u32 {
+        self.group_index_shift
+    }
+
+    /// Returns the number of group index bits.
+    pub fn group_index_bits(&self) -> u32 {
+        self.group_index_bits
+    }
+
+    /// Returns the number of guest files per hart.
+    pub fn guests_per_hart(&self) -> usize {
+        self.guests_per_hart
+    }
+
+    /// Returns the total number of index bits.
+    pub fn index_bits(&self) -> u32 {
+        self.group_index_bits + self.hart_index_bits + self.guest_index_bits
+    }
+
+    /// Returns a bit mask with all the index bits (guest, hart, group) set.
+    pub fn index_mask(&self) -> u64 {
+        let hart_mask = gen_mask(
+            self.hart_index_bits + self.guest_index_bits,
+            GUEST_INDEX_SHIFT,
+        );
+        let group_mask = gen_mask(self.group_index_bits, self.group_index_shift);
+        hart_mask | group_mask
+    }
+
+    /// Returns if the specified location is valid in this geometry.
+    pub fn location_is_valid(&self, loc: ImsicLocation) -> bool {
+        (loc.group().bits() < (1 << self.group_index_bits))
+            && (loc.hart().bits() < (1 << self.hart_index_bits))
+            && ((loc.file().bits() as usize) <= self.guests_per_hart)
+    }
+
+    /// Translates the given IMSIC location to the address of the interrupt file it refers to.
+    pub fn location_to_addr(&self, loc: ImsicLocation) -> Option<PageAddr<AS>> {
+        if !self.location_is_valid(loc) {
+            return None;
+        }
+        let num_pages = (loc.file().bits() as u64)
+            | (loc.hart().bits() << self.guest_index_bits)
+            | (loc.group().bits() << (self.group_index_shift - GUEST_INDEX_SHIFT));
+        self.base_addr.checked_add_pages(num_pages)
+    }
+
+    /// Translates the given address to the corresponding IMSIC location specifier.
+    pub fn addr_to_location(&self, addr: PageAddr<AS>) -> Option<ImsicLocation> {
+        if (addr.bits() & !self.index_mask()) != self.base_addr.bits() {
+            return None;
+        }
+        let group = extract(addr.bits(), self.group_index_bits, self.group_index_shift);
+        let hart = extract(
+            addr.bits(),
+            self.hart_index_bits,
+            self.guest_index_bits + GUEST_INDEX_SHIFT,
+        );
+        let file = extract(addr.bits(), self.guest_index_bits, GUEST_INDEX_SHIFT) as u32;
+        if file as usize > self.guests_per_hart {
+            return None;
+        }
+        let loc = ImsicLocation::new(
+            ImsicGroupId::new(group),
+            ImsicHartId::new(hart),
+            ImsicFileId::from_index(file),
+        );
+        Some(loc)
+    }
+
+    /// Returns an iterator over the address ranges for each IMSIC group.
+    pub fn group_ranges(&self) -> impl ExactSizeIterator<Item = PageAddrRange<AS>> {
+        GroupRangeIter::new(self)
+    }
+}
+
+// An iterator over the address ranges for each IMSIC group.
+struct GroupRangeIter<AS: AddressSpace> {
+    base_addr: PageAddr<AS>,
+    group_index_shift: u32,
+    index: usize,
+    total: usize,
+    group_pages: u64,
+}
+
+impl<AS: AddressSpace> GroupRangeIter<AS> {
+    fn new(geometry: &ImsicGeometry<AS>) -> Self {
+        let group_pages = 1 << (geometry.hart_index_bits() + geometry.guest_index_bits());
+        Self {
+            base_addr: geometry.base_addr(),
+            group_index_shift: geometry.group_index_shift(),
+            index: 0,
+            total: 1 << geometry.group_index_bits(),
+            group_pages,
+        }
+    }
+}
+
+impl<AS: AddressSpace> Iterator for GroupRangeIter<AS> {
+    type Item = PageAddrRange<AS>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.total {
+            return None;
+        }
+        let pages = (self.index as u64) << (self.group_index_shift - GUEST_INDEX_SHIFT);
+        let base = self.base_addr.checked_add_pages(pages)?;
+        self.index += 1;
+        Some(PageAddrRange::new(base, self.group_pages))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let count = self.total - self.index;
+        (count, Some(count))
+    }
+}
+
+impl<AS: AddressSpace> ExactSizeIterator for GroupRangeIter<AS> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        const NUM_GUESTS: usize = 10;
+        let geometry = ImsicGeometry::new(
+            PageAddr::new(RawAddr::supervisor(0x2800_0000)).unwrap(),
+            0,
+            MIN_GROUP_INDEX_SHIFT,
+            4,
+            4,
+            NUM_GUESTS,
+        )
+        .unwrap();
+        assert_eq!(geometry.index_bits(), 8);
+        assert_eq!(geometry.index_mask(), 0x000f_f000);
+        let h0s = ImsicLocation::new(
+            ImsicGroupId::new(0),
+            ImsicHartId::new(0),
+            ImsicFileId::supervisor(),
+        );
+        assert_eq!(geometry.location_to_addr(h0s).unwrap().bits(), 0x2800_0000);
+        let h3g6 = ImsicLocation::new(
+            ImsicGroupId::new(0),
+            ImsicHartId::new(3),
+            ImsicFileId::guest(6),
+        );
+        assert_eq!(geometry.location_to_addr(h3g6).unwrap().bits(), 0x2803_7000);
+        let h20s = ImsicLocation::new(
+            ImsicGroupId::new(0),
+            ImsicHartId::new(20),
+            ImsicFileId::supervisor(),
+        );
+        assert!(!geometry.location_is_valid(h20s));
+        let h2g2 = ImsicLocation::new(
+            ImsicGroupId::new(0),
+            ImsicHartId::new(2),
+            ImsicFileId::guest(2),
+        );
+        assert_eq!(
+            geometry
+                .addr_to_location(PageAddr::new(RawAddr::supervisor(0x2802_3000)).unwrap())
+                .unwrap(),
+            h2g2
+        );
+    }
+
+    #[test]
+    fn with_groups() {
+        const NUM_GUESTS: usize = 3;
+        let geometry = ImsicGeometry::new(
+            PageAddr::new(RawAddr::supervisor(0x2800_0000)).unwrap(),
+            2,
+            MIN_GROUP_INDEX_SHIFT,
+            4,
+            4,
+            NUM_GUESTS,
+        )
+        .unwrap();
+        assert_eq!(geometry.index_bits(), 10);
+        assert_eq!(geometry.index_mask(), 0x030f_f000);
+        let g0h0s = ImsicLocation::new(
+            ImsicGroupId::new(0),
+            ImsicHartId::new(0),
+            ImsicFileId::supervisor(),
+        );
+        assert_eq!(
+            geometry.location_to_addr(g0h0s).unwrap().bits(),
+            0x2800_0000
+        );
+        let g2h3g1 = ImsicLocation::new(
+            ImsicGroupId::new(2),
+            ImsicHartId::new(3),
+            ImsicFileId::guest(1),
+        );
+        assert_eq!(
+            geometry.location_to_addr(g2h3g1).unwrap().bits(),
+            0x2a03_2000
+        );
+        let g1h1s = ImsicLocation::new(
+            ImsicGroupId::new(1),
+            ImsicHartId::new(1),
+            ImsicFileId::supervisor(),
+        );
+        assert_eq!(
+            geometry
+                .addr_to_location(PageAddr::new(RawAddr::supervisor(0x2901_0000)).unwrap())
+                .unwrap(),
+            g1h1s
+        );
+
+        let mut range_iter = geometry.group_ranges();
+        assert_eq!(range_iter.len(), 4);
+        assert_eq!(range_iter.next().unwrap().base().bits(), 0x2800_0000);
+        assert_eq!(range_iter.next().unwrap().base().bits(), 0x2900_0000);
+        assert_eq!(range_iter.next().unwrap().length_bytes(), 0x10_0000);
+    }
+}

--- a/drivers/src/imsic/mod.rs
+++ b/drivers/src/imsic/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+mod core;
+mod error;
+
+pub use self::core::{Imsic, ImsicGuestId, ImsicGuestPage, ImsicInterruptId};
+pub use error::Error as ImsicError;
+pub use error::Result as ImsicResult;

--- a/drivers/src/imsic/mod.rs
+++ b/drivers/src/imsic/mod.rs
@@ -6,7 +6,7 @@ mod core;
 mod error;
 mod geometry;
 
-pub use self::core::{Imsic, ImsicGuestId, ImsicGuestPage, ImsicInterruptId};
+pub use self::core::{Imsic, ImsicGuestPage, ImsicGuestPageIter, ImsicInterruptId};
 pub use error::Error as ImsicError;
 pub use error::Result as ImsicResult;
 pub use geometry::*;

--- a/drivers/src/imsic/mod.rs
+++ b/drivers/src/imsic/mod.rs
@@ -4,7 +4,9 @@
 
 mod core;
 mod error;
+mod geometry;
 
 pub use self::core::{Imsic, ImsicGuestId, ImsicGuestPage, ImsicInterruptId};
 pub use error::Error as ImsicError;
 pub use error::Result as ImsicResult;
+pub use geometry::*;

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -24,13 +24,10 @@ pub mod iommu;
 pub mod pci;
 
 pub use cpu::{CpuId, CpuInfo, MAX_CPUS};
-pub use imsic::{
-    Error as ImsicError, Imsic, ImsicGuestId, ImsicGuestPage, ImsicInterruptId,
-    Result as ImsicResult,
-};
 
 #[cfg(test)]
 mod tests {
+    use super::imsic::Imsic;
     use super::*;
     use alloc::vec::Vec;
     use device_tree::DeviceTree;

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -238,7 +238,7 @@ mod tests {
         let tree = stub_tree();
         CpuInfo::parse_from(&tree);
         let mut mem_map = stub_mem_map();
-        Imsic::probe_from(&tree, &mut mem_map);
+        Imsic::probe_from(&tree, &mut mem_map).unwrap();
 
         let imsic = Imsic::get();
         assert_eq!(imsic.guests_per_hart(), (1 << GUEST_BITS as usize) - 1);

--- a/drivers/src/pci/root.rs
+++ b/drivers/src/pci/root.rs
@@ -11,7 +11,7 @@ use page_tracking::{HwMemMap, PageTracker};
 use riscv_pages::*;
 use spin::{Mutex, Once};
 
-use crate::Imsic;
+use crate::imsic::Imsic;
 
 use super::address::*;
 use super::bus::PciBus;

--- a/src/host_vm_loader.rs
+++ b/src/host_vm_loader.rs
@@ -5,7 +5,7 @@
 use arrayvec::ArrayString;
 use core::{fmt, slice};
 use device_tree::{DeviceTree, DeviceTreeResult, DeviceTreeSerializer};
-use drivers::{pci::PcieRoot, CpuId, CpuInfo, Imsic, ImsicGuestId};
+use drivers::{imsic::Imsic, imsic::ImsicGuestId, pci::PcieRoot, CpuId, CpuInfo};
 use page_tracking::{HwMemRegion, HypPageAlloc, PageList};
 use riscv_page_tables::GuestStagePageTable;
 use riscv_pages::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,11 +315,11 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
 
     // Probe for the IMSIC.
     Imsic::probe_from(&hyp_dt, &mut mem_map).expect("Failed to probe IMSIC");
-    let imsic = Imsic::get();
+    let imsic_geometry = Imsic::get().phys_geometry();
     println!(
         "IMSIC at 0x{:08x}; {} guest interrupt files supported",
-        imsic.base_addr().bits(),
-        imsic.guests_per_hart()
+        imsic_geometry.base_addr().bits(),
+        imsic_geometry.guests_per_hart()
     );
     Imsic::setup_this_cpu();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ mod vm_id;
 mod vm_pages;
 
 use device_tree::{DeviceTree, Fdt};
-use drivers::{iommu::Iommu, pci::PcieRoot, CpuInfo, Imsic};
+use drivers::{imsic::Imsic, iommu::Iommu, pci::PcieRoot, CpuInfo};
 use host_vm_loader::HostVmLoader;
 use hyp_alloc::HypAlloc;
 use page_tracking::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,7 +314,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     );
 
     // Probe for the IMSIC.
-    Imsic::probe_from(&hyp_dt, &mut mem_map);
+    Imsic::probe_from(&hyp_dt, &mut mem_map).expect("Failed to probe IMSIC");
     let imsic = Imsic::get();
     println!(
         "IMSIC at 0x{:08x}; {} guest interrupt files supported",

--- a/src/smp.rs
+++ b/src/smp.rs
@@ -4,7 +4,7 @@
 
 use core::arch::asm;
 use core::cell::{RefCell, RefMut};
-use drivers::{CpuId, CpuInfo, Imsic};
+use drivers::{imsic::Imsic, CpuId, CpuInfo};
 use page_tracking::{HwMemMap, HwMemRegionType, HwReservedMemType};
 use riscv_pages::{PageSize, RawAddr, SupervisorPageAddr};
 use riscv_regs::{sstatus, ReadWriteable, CSR};

--- a/src/trap.rs
+++ b/src/trap.rs
@@ -4,7 +4,7 @@
 
 use core::arch::global_asm;
 use core::mem::size_of;
-use drivers::{Imsic, ImsicInterruptId};
+use drivers::imsic::{Imsic, ImsicInterruptId};
 use memoffset::offset_of;
 use riscv_regs::{
     sie, GeneralPurposeRegisters, GprIndex, Interrupt, Readable, RiscvCsrInterface, Trap,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -8,7 +8,7 @@ use attestation::{
 };
 use core::{mem, slice};
 use der::Decode;
-use drivers::{pci::PcieRoot, CpuId, CpuInfo, ImsicGuestId, MAX_CPUS};
+use drivers::{imsic::ImsicGuestId, pci::PcieRoot, CpuId, CpuInfo, MAX_CPUS};
 use page_tracking::{HypPageAlloc, PageList, PageTracker};
 use riscv_page_tables::{GuestStagePageTable, PlatformPageTable};
 use riscv_pages::*;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -8,7 +8,7 @@ use attestation::{
 };
 use core::{mem, slice};
 use der::Decode;
-use drivers::{imsic::ImsicGuestId, pci::PcieRoot, CpuId, CpuInfo, MAX_CPUS};
+use drivers::{imsic::ImsicFileId, pci::PcieRoot, CpuId, CpuInfo, MAX_CPUS};
 use page_tracking::{HypPageAlloc, PageList, PageTracker};
 use riscv_page_tables::{GuestStagePageTable, PlatformPageTable};
 use riscv_pages::*;
@@ -323,7 +323,7 @@ impl<T: GuestStagePageTable> Vm<T, VmStateInitializing> {
 
 impl<T: GuestStagePageTable> Vm<T, VmStateFinalized> {
     /// Binds the specified vCPU to an IMSIC interrupt file.
-    fn bind_vcpu(&self, vcpu_id: u64, interrupt_file: ImsicGuestId) -> EcallResult<()> {
+    fn bind_vcpu(&self, vcpu_id: u64, interrupt_file: ImsicFileId) -> EcallResult<()> {
         let vcpu = self
             .vcpus
             .get_vcpu(vcpu_id)
@@ -1412,7 +1412,9 @@ enum MmioEmulationError {
 impl<T: GuestStagePageTable> HostVm<T, VmStateFinalized> {
     /// Run the host VM's vCPU with ID `vcpu_id`. Does not return.
     pub fn run(&self, vcpu_id: u64) {
-        self.inner.bind_vcpu(vcpu_id, ImsicGuestId::HostVm).unwrap();
+        self.inner
+            .bind_vcpu(vcpu_id, ImsicFileId::guest(0))
+            .unwrap();
 
         // Always make vCPU0 the boot CPU.
         if vcpu_id == 0 {

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -4,7 +4,7 @@
 
 use core::arch::global_asm;
 use core::{mem::size_of, ops::Deref, ops::DerefMut};
-use drivers::{CpuId, CpuInfo, ImsicGuestId};
+use drivers::{imsic::ImsicGuestId, CpuId, CpuInfo};
 use memoffset::offset_of;
 use page_tracking::collections::PageVec;
 use page_tracking::{PageTracker, TlbVersion};


### PR DESCRIPTION
Prepare for MSI page table support by introducing `ImsicGeometry` and `ImsicLocation` which support translation between an IMSIC location specifier (effectively a group + hart + guest index tuple) and the address of the interrupt file.

- Patch 1 fixes a compile error recently introduced by a nightly update.
- Patch 2 separates `imsic.rs` into multiple modules to avoid making the main IMSIC module too crowded.
- Patch 3 makes `Imsic::probe_from()` propagate errors rather than asserting/panicing. Not strictly related to the rest of the series, but is good practice nonetheless.
- Patch 4 adds the new `ImsicGeometry` and related types.
- Patch 5 is a minor cleanup to remove the unnecessary `ImsicMmioRegion` type.
- Patch 6 simplifies the IMSIC per-CPU state management and initial mapping of the IMSIC into the host VM.

Tested by booting SMP Linux; no regressions.