### PR TITLE
Enable DMA from host-assigned PCI devices

### DIFF
--- a/drivers/src/imsic/core.rs
+++ b/drivers/src/imsic/core.rs
@@ -70,7 +70,16 @@ impl ImsicInterruptId {
 /// A `PhysPage` implementation representing an IMSIC guest interrupt file page.
 pub struct ImsicGuestPage<S: State> {
     addr: SupervisorPageAddr,
+    location: ImsicLocation,
     state: PhantomData<S>,
+}
+
+impl<S: State> ImsicGuestPage<S> {
+    /// Returns the location of the IMSIC file that this page corresponds to in the physical IMSIC
+    /// geometry.
+    pub fn location(&self) -> ImsicLocation {
+        self.location
+    }
 }
 
 impl<S: State> PhysPage for ImsicGuestPage<S> {
@@ -81,8 +90,12 @@ impl<S: State> PhysPage for ImsicGuestPage<S> {
     /// The caller must ensure `addr` refers to a uniquely owned IMSIC guest interrupt file.
     unsafe fn new_with_size(addr: SupervisorPageAddr, size: PageSize) -> Self {
         assert_eq!(size, PageSize::Size4k);
+        // This page must refer to an IMSIC page, so it must have a valid location in the physical
+        // IMSIC geometry.
+        let location = Imsic::get().phys_geometry().addr_to_location(addr).unwrap();
         Self {
             addr,
+            location,
             state: PhantomData,
         }
     }

--- a/drivers/src/imsic/geometry.rs
+++ b/drivers/src/imsic/geometry.rs
@@ -108,7 +108,7 @@ impl ImsicLocation {
 }
 
 /// Describes the layout of the IMSICs in a system.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ImsicGeometry<AS: AddressSpace> {
     base_addr: PageAddr<AS>,
     group_index_bits: u32,

--- a/drivers/src/iommu/core.rs
+++ b/drivers/src/iommu/core.rs
@@ -197,6 +197,7 @@ impl Iommu {
             return Err(Error::OwnerMismatch);
         }
         self.ddt.enable_device(dev_id, pt, msi_pt, gscid)?;
+        dev.set_iommu_attached();
         state.ref_count += 1;
         Ok(())
     }
@@ -214,6 +215,7 @@ impl Iommu {
             if dev.owner() != Some(state.owner) {
                 return Err(Error::OwnerMismatch);
             }
+            dev.clear_iommu_attached();
             self.ddt.disable_device(dev_id)?;
             // Drop our reference to the GSCID used for the device.
             state.ref_count -= 1;

--- a/drivers/src/iommu/core.rs
+++ b/drivers/src/iommu/core.rs
@@ -94,10 +94,9 @@ impl Iommu {
         Ok(())
     }
 
-    /// Gets a reference to the `Iommu` singleton. Panics if `Iommu::probe_from()` has not yet
-    /// been called to initialize it.
-    pub fn get() -> &'static Self {
-        IOMMU.get().unwrap()
+    /// Gets a reference to the `Iommu` singleton.
+    pub fn get() -> Option<&'static Self> {
+        IOMMU.get()
     }
 
     /// Returns the version of this IOMMU device.

--- a/drivers/src/iommu/device_directory.rs
+++ b/drivers/src/iommu/device_directory.rs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO: Remove once hooked up to the public IOMMU interface.
-#![allow(dead_code)]
-
 use assertions::const_assert;
 use core::marker::PhantomData;
 use riscv_page_tables::{GuestStagePageTable, GuestStagePagingMode};
@@ -392,7 +389,7 @@ impl<D: DirectoryMode> DeviceDirectory<D> {
         gscid: GscId,
     ) -> Result<()> {
         if pt.page_owner_id() != msi_pt.owner() {
-            return Err(Error::PageTableOwnerMismatch);
+            return Err(Error::OwnerMismatch);
         }
         let mut inner = self.inner.lock();
         let entry = inner

--- a/drivers/src/iommu/error.rs
+++ b/drivers/src/iommu/error.rs
@@ -4,7 +4,7 @@
 
 use riscv_pages::SupervisorPageAddr;
 
-use super::device_directory::DeviceId;
+use super::device_directory::{DeviceId, GscId};
 use crate::imsic::ImsicLocation;
 use crate::pci::{Address, PciError};
 
@@ -57,6 +57,14 @@ pub enum Error {
     QueueFull,
     /// No elements are available to be popped from the queue.
     QueueEmpty,
+    /// Ran out of available GSCIDs.
+    OutOfGscIds,
+    /// The supplied GSCID was invalid.
+    InvalidGscId(GscId),
+    /// Attempted to free a GSCID that's not currently allocated.
+    GscIdAlreadyFree(GscId),
+    /// Attempted to free a GSCID that's currently being used for translation.
+    GscIdInUse(GscId),
 }
 
 /// Holds results for IOMMU operations.

--- a/drivers/src/iommu/error.rs
+++ b/drivers/src/iommu/error.rs
@@ -43,8 +43,8 @@ pub enum Error {
     NotIntermediateTable,
     /// Unable to map a PCI BDF address to an IOMMU device ID.
     PciAddressTooLarge(Address),
-    /// Mismatch between MSI and CPU page table owners.
-    PageTableOwnerMismatch,
+    /// Mismatch between page table and device ownership.
+    OwnerMismatch,
     /// No device context found.
     DeviceNotFound(DeviceId),
     /// The device already has an active device context.

--- a/drivers/src/iommu/error.rs
+++ b/drivers/src/iommu/error.rs
@@ -51,6 +51,12 @@ pub enum Error {
     DeviceAlreadyEnabled(DeviceId),
     /// The device does not have an active device context.
     DeviceNotEnabled(DeviceId),
+    /// The head/tail pointer is out of bounds for the queue.
+    InvalidQueuePointer(usize),
+    /// No more elements can be pushed to the queue.
+    QueueFull,
+    /// No elements are available to be popped from the queue.
+    QueueEmpty,
 }
 
 /// Holds results for IOMMU operations.

--- a/drivers/src/iommu/queue.rs
+++ b/drivers/src/iommu/queue.rs
@@ -2,9 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO: Remove once hooked up to the public IOMMU interface.
-#![allow(dead_code)]
-
 use core::marker::PhantomData;
 use core::mem::size_of;
 use data_model::{DataInit, VolatileMemory, VolatileSlice};
@@ -76,6 +73,7 @@ impl<T: DataInit, Q> Queue<T, Q> {
     }
 
     /// Returns the head index of the queue.
+    #[allow(dead_code)]
     pub fn head(&self) -> usize {
         self.head
     }
@@ -116,6 +114,8 @@ impl<T: DataInit> Queue<T, Producer> {
     }
 }
 
+// TODO: Remove once we have support for the fault queue in place.
+#[allow(dead_code)]
 impl<T: DataInit> Queue<T, Consumer> {
     /// Updates the tail pointer of the queue to `tail`. Expected to be used to update the queue's
     /// software tail pointer with a tail pointer read from an IOMMU register.

--- a/drivers/src/iommu/queue.rs
+++ b/drivers/src/iommu/queue.rs
@@ -1,0 +1,229 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO: Remove once hooked up to the public IOMMU interface.
+#![allow(dead_code)]
+
+use core::marker::PhantomData;
+use core::mem::size_of;
+use data_model::{DataInit, VolatileMemory, VolatileSlice};
+use riscv_pages::*;
+
+use super::device_directory::{DeviceId, GscId};
+use super::error::*;
+
+/// Type marker for a queue where software is the producer.
+pub enum Producer {}
+/// Type marker for a queue where software is the consumer.
+pub enum Consumer {}
+
+/// An IOMMU queue, used to communicate between software and the IOMMU hardware. The queue is
+/// a page-aligned ring buffer of uniformly-sized structs (though different types of queues can
+/// have different struct sizes/layouts). For simplicity, we use a single 4kB page for queue
+/// storage.
+pub struct Queue<T: DataInit, Q> {
+    mem: VolatileSlice<'static>,
+    head: usize,
+    tail: usize,
+    capacity: usize,
+    _elem_type: PhantomData<T>,
+    _queue_type: PhantomData<Q>,
+}
+
+impl<T: DataInit, Q> Queue<T, Q> {
+    /// Creates a new `Queue` with elements of type `T`, using `page` as the backing store.
+    pub fn new(page: Page<InternalClean>) -> Self {
+        // Queue structs are always powers of 2.
+        //
+        // TODO: Use `const_assert!` once `generic_const_exprs` stabilizes.
+        assert!(size_of::<T>().is_power_of_two());
+        assert!(size_of::<T>() < PageSize::Size4k as usize);
+        let capacity = (page.size() as usize) / size_of::<T>();
+        // Safety: We uniquely own the memory in `page` and are able to read and write it as bytes.
+        let mem = unsafe {
+            core::slice::from_raw_parts_mut(page.addr().bits() as *mut u8, page.size() as usize)
+        };
+        Self {
+            mem: VolatileSlice::new(mem),
+            head: 0,
+            tail: 0,
+            capacity,
+            _elem_type: PhantomData,
+            _queue_type: PhantomData,
+        }
+    }
+
+    /// Returns the base physical address of this queue.
+    pub fn base_address(&self) -> SupervisorPageAddr {
+        // Unwrap ok since the queue must've been created from a page-aligned slice of memory.
+        PageAddr::new(RawAddr::supervisor(self.mem.as_ptr() as u64)).unwrap()
+    }
+
+    /// Returns the total number of elements that can be held in the queue.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Returns if the queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.head == self.tail
+    }
+
+    /// Returns if the queue is full.
+    pub fn is_full(&self) -> bool {
+        (self.tail + 1) & (self.capacity - 1) == self.head
+    }
+
+    /// Returns the head index of the queue.
+    pub fn head(&self) -> usize {
+        self.head
+    }
+
+    /// Returns the tail index of the queue.
+    pub fn tail(&self) -> usize {
+        self.tail
+    }
+}
+
+impl<T: DataInit> Queue<T, Producer> {
+    /// Updates the head pointer of the queue to `haed`. Expected to be used to update the queue's
+    /// software head pointer with a head pointer read from an IOMMU register.
+    pub fn update_head(&mut self, head: usize) -> Result<()> {
+        // Make sure `head` isn't being advanced past `self.tail`. Silence clippy as its suggestion
+        // is less readable and is just as many comparisons.
+        #[allow(clippy::nonminimal_bool)]
+        if head >= self.capacity
+            || (self.head <= self.tail && (head > self.tail || self.head > head))
+            || (self.head > self.tail && self.tail < head && head < self.head)
+        {
+            return Err(Error::InvalidQueuePointer(head));
+        }
+        self.head = head;
+        Ok(())
+    }
+
+    /// Pushes an element to the tail of the queue.
+    pub fn push(&mut self, elem: T) -> Result<()> {
+        if self.is_full() {
+            return Err(Error::QueueFull);
+        }
+        // Unwrap ok since `self.tail` must be in bounds.
+        let tail_ref = self.mem.get_ref(self.tail * size_of::<T>()).unwrap();
+        tail_ref.store(elem);
+        self.tail = (self.tail + 1) & (self.capacity - 1);
+        Ok(())
+    }
+}
+
+impl<T: DataInit> Queue<T, Consumer> {
+    /// Updates the tail pointer of the queue to `tail`. Expected to be used to update the queue's
+    /// software tail pointer with a tail pointer read from an IOMMU register.
+    pub fn update_tail(&mut self, tail: usize) -> Result<()> {
+        // Make sure `tail` isn't being advanced to or past `self.head`.
+        if tail >= self.capacity
+            || (self.head < self.tail && self.head <= tail && tail < self.tail)
+            || (self.head > self.tail && (tail >= self.head || self.tail > tail))
+        {
+            return Err(Error::InvalidQueuePointer(tail));
+        }
+        self.tail = tail;
+        Ok(())
+    }
+
+    /// Pops an element from the head of the queue.
+    pub fn pop(&mut self) -> Result<T> {
+        if self.is_empty() {
+            return Err(Error::QueueEmpty);
+        }
+        // Unwrap ok since `self.head` must be in bounds.
+        let head_ref = self.mem.get_ref(self.head * size_of::<T>()).unwrap();
+        self.head += 1;
+        Ok(head_ref.load())
+    }
+}
+
+/// An entry in the IOMMU command queuee. Used to perform translation cache invalidations.
+///
+/// Note that completion of a particular invalidation command does not guarantee that the
+/// invalidation itself has completed; an `IOFENCE.C` command is needed to flush all in-flight
+/// commands.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct Command {
+    op: u64,
+    addr: u64,
+}
+
+const FUNC3_SHIFT: u64 = 7;
+
+impl Command {
+    /// Creates a new `IOTINVAL.GVMA` comamnd for flushing 2nd-stage translation caches.
+    ///
+    /// If `gscid` is not `None`, only translations matching the specified GSCID are flushed.
+    ///
+    /// If `gpa` is not `None`, only translations matching the specified guest physical address
+    /// are flushed.
+    pub fn iotinval_gvma(gscid: Option<GscId>, gpa: Option<GuestPageAddr>) -> Self {
+        const IOTINVAL_OP: u64 = 0x1;
+        const GVMA_FUNC: u64 = 0x1;
+        let mut op = IOTINVAL_OP | (GVMA_FUNC << FUNC3_SHIFT);
+
+        const GV: u64 = 1 << 12;
+        const GSCID_SHIFT: u64 = 40;
+        if let Some(g) = gscid {
+            op |= GV | ((g.bits() as u64) << GSCID_SHIFT);
+        }
+
+        const AV: u64 = 1 << 11;
+        let addr = if let Some(g) = gpa {
+            op |= AV;
+            g.bits()
+        } else {
+            0
+        };
+
+        Self { op, addr }
+    }
+
+    /// Creates a new `IODIR.INVAL_DDT` command for flushing device directory table caches.
+    ///
+    /// If `dev` is not `None`, only translations for the specified device ID are flushed.
+    pub fn iodir_inval_ddt(dev: Option<DeviceId>) -> Self {
+        const IODIR_OP: u64 = 0x3;
+        const INVAL_DDT_FUNC: u64 = 0x0;
+        let mut op = IODIR_OP | (INVAL_DDT_FUNC << FUNC3_SHIFT);
+
+        const DV: u64 = 1 << 10;
+        const DID_SHIFT: u64 = 40;
+        if let Some(d) = dev {
+            op |= DV | ((d.bits() as u64) << DID_SHIFT);
+        }
+
+        Self { op, addr: 0 }
+    }
+
+    /// Creates a new `IOFENCE.C` command for synchronizing the command queue. Upon completion of
+    /// this command, all prior commands submitted to the command queue are guaranteed to have
+    /// completed.
+    pub fn iofence() -> Self {
+        const IOFENCE_OP: u64 = 0x2;
+        const PR: u64 = 1 << 10;
+        const PW: u64 = 1 << 11;
+
+        // TODO: Make PR/PW optional. Probably not needed on every fence.
+        Self {
+            op: IOFENCE_OP | PR | PW,
+            addr: 0,
+        }
+    }
+}
+
+// Safety: `Command` is a POD struct without implicit padding and therefore can be initialized
+// from a byte array.
+unsafe impl DataInit for Command {}
+
+/// The IOMMU command queue.
+pub type CommandQueue = Queue<Command, Producer>;
+
+// TODO: Fault queue.

--- a/drivers/src/iommu/registers.rs
+++ b/drivers/src/iommu/registers.rs
@@ -28,6 +28,23 @@ register_bitfields![u64,
         Busy OFFSET(59) NUMBITS(1),
         Mode OFFSET(60) NUMBITS(4),
     ],
+
+    pub QueueBase [
+        Log2SzMinus1 OFFSET(0) NUMBITS(5),
+        Ppn OFFSET(5) NUMBITS(44),
+    ],
+];
+
+register_bitfields![u32,
+    pub CqControl [
+        Enable OFFSET(0) NUMBITS(1),
+        InterruptEnable OFFSET(1) NUMBITS(1),
+        MemoryFault OFFSET(8) NUMBITS(1),
+        CommandTimeout OFFSET(9) NUMBITS(1),
+        CommandIllegal OFFSET(10) NUMBITS(1),
+        On OFFSET(16) NUMBITS(1),
+        Busy OFFSET(17) NUMBITS(1),
+    ],
 ];
 
 /// The IOMMU register set.
@@ -37,16 +54,16 @@ pub struct IommuRegisters {
     pub fctrl: ReadWrite<u32>,
     _reserved0: u32,
     pub ddtp: ReadWrite<u64, DirectoryPointer::Register>,
-    pub cqb: ReadWrite<u64>,
-    pub cqh: ReadWrite<u32>,
-    pub cqt: ReadOnly<u32>,
-    pub fqb: ReadWrite<u64>,
+    pub cqb: ReadWrite<u64, QueueBase::Register>,
+    pub cqh: ReadOnly<u32>,
+    pub cqt: ReadWrite<u32>,
+    pub fqb: ReadWrite<u64, QueueBase::Register>,
     pub fqh: ReadWrite<u32>,
     pub fqt: ReadOnly<u32>,
-    pub pqb: ReadWrite<u64>,
+    pub pqb: ReadWrite<u64, QueueBase::Register>,
     pub pqh: ReadWrite<u32>,
     pub pqt: ReadOnly<u32>,
-    pub cqcsr: ReadWrite<u32>,
+    pub cqcsr: ReadWrite<u32, CqControl::Register>,
     pub fqcsr: ReadWrite<u32>,
     pub pqcsr: ReadWrite<u32>,
     pub ipsr: ReadWrite<u32>,

--- a/hyp-alloc/src/arena.rs
+++ b/hyp-alloc/src/arena.rs
@@ -112,6 +112,21 @@ impl<T, A: Allocator> Arena<T, A> {
     pub fn get_mut(&mut self, id: ArenaId<T>) -> Option<&mut T> {
         self.vals.get_mut(id.index)?.as_mut()
     }
+
+    /// Returns an iterator over the valid IDs in the arena.
+    pub fn ids(&self) -> impl Iterator<Item = ArenaId<T>> + '_ {
+        self.vals.iter().enumerate().filter_map(|(i, v)| {
+            v.as_ref().map(|_| ArenaId {
+                index: i,
+                phantom: PhantomData,
+            })
+        })
+    }
+
+    /// Returns an iterator over the items in the arena.
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.vals.iter().filter_map(|v| v.as_ref())
+    }
 }
 
 impl<T: Default, A: Allocator> Arena<T, A> {

--- a/riscv-regs/src/fence.rs
+++ b/riscv-regs/src/fence.rs
@@ -37,6 +37,13 @@ pub fn mmio_rmb() {
     unsafe { asm!("fence i,r") };
 }
 
+/// Hint that the CPU's rate of instruction retirement should be temporarily paused or reduced.
+#[cfg(all(target_arch = "riscv64", target_os = "none"))]
+pub fn pause() {
+    // TODO: Replace with `pause` once the toolchain supports it.
+    unsafe { asm!(".word 0x0100000f") };
+}
+
 // Make fence instructions a no-op for testing.
 #[cfg(not(any(target_arch = "riscv64", target_os = "none")))]
 pub fn dma_wmb() {}
@@ -46,3 +53,5 @@ pub fn dma_rmb() {}
 pub fn mmio_wmb() {}
 #[cfg(not(any(target_arch = "riscv64", target_os = "none")))]
 pub fn mmio_rmb() {}
+#[cfg(not(any(target_arch = "riscv64", target_os = "none")))]
+pub fn pause() {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -465,7 +465,9 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
 
     // Probe for a PCI bus.
     PcieRoot::probe_from(&hyp_dt, &mut mem_map).expect("Failed to set up PCIe");
-    PcieRoot::get().for_each_device(|dev| {
+    let pci = PcieRoot::get();
+    for dev in pci.devices() {
+        let dev = dev.lock();
         println!(
             "Found func {}; type: {}, MSI: {}, MSI-X: {}, PCIe: {}",
             dev.info(),
@@ -474,7 +476,6 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
             dev.has_msix(),
             dev.is_pcie(),
         );
-
         for bar in dev.bar_info().bars() {
             println!(
                 "BAR{:}: type {:?}, size 0x{:x}",
@@ -483,7 +484,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
                 bar.size()
             );
         }
-    });
+    }
 
     setup_hyp_paging(&mut mem_map);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -509,7 +509,10 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
         hyp_mem.take_pages_for_host_state(1).into_iter().next()
     }) {
         Ok(_) => {
-            println!("Found RISC-V IOMMU version 0x{:x}", Iommu::get().version());
+            println!(
+                "Found RISC-V IOMMU version 0x{:x}",
+                Iommu::get().unwrap().version()
+            );
         }
         Err(e) => {
             println!("Failed to probe IOMMU: {:?}", e);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -8,7 +8,7 @@ use attestation::{
 };
 use core::{mem, slice};
 use der::Decode;
-use drivers::{imsic::*, iommu::*, pci::PcieRoot, CpuId, CpuInfo, MAX_CPUS};
+use drivers::{imsic::*, iommu::*, pci::PciDevice, pci::PcieRoot, CpuId, CpuInfo, MAX_CPUS};
 use page_tracking::{HypPageAlloc, PageList, PageTracker};
 use riscv_page_tables::{GuestStagePageTable, GuestStagePagingMode};
 use riscv_pages::*;
@@ -1482,6 +1482,11 @@ impl<T: GuestStagePagingMode> HostVm<T, VmStateInitializing> {
                 .unwrap();
             mapper.map_imsic_page(vm_addr, mappable).unwrap();
         }
+    }
+
+    /// Attaches the given PCI device to the host VM.
+    pub fn attach_pci_device(&self, dev: &mut PciDevice) {
+        self.inner.vm_pages.attach_pci_device(dev).unwrap();
     }
 
     /// Completes intialization of the host, returning it in a finalized state.

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -4,7 +4,7 @@
 
 use core::arch::global_asm;
 use core::{mem::size_of, ops::Deref, ops::DerefMut};
-use drivers::{imsic::ImsicFileId, CpuId, CpuInfo};
+use drivers::{imsic::ImsicFileId, imsic::ImsicLocation, CpuId, CpuInfo};
 use memoffset::offset_of;
 use page_tracking::collections::PageVec;
 use page_tracking::{PageTracker, TlbVersion};
@@ -654,6 +654,7 @@ struct VirtualRegisters {
 pub struct VmCpu {
     state: VmCpuState,
     virt_regs: VirtualRegisters,
+    imsic_location: Option<ImsicLocation>,
     current_cpu: Option<CurrentCpu>,
     // TODO: interrupt_file should really be part of CurrentCpu, but we have no way to migrate it
     // at present.
@@ -691,6 +692,7 @@ impl VmCpu {
         Self {
             state,
             virt_regs: VirtualRegisters::default(),
+            imsic_location: None,
             current_cpu: None,
             pending_mmio_op: None,
             interrupt_file: None,
@@ -746,6 +748,16 @@ impl VmCpu {
             MmioLoad => self.virt_regs.mmio_load,
             MmioStore => self.virt_regs.mmio_store,
         }
+    }
+
+    /// Sets the location of this vCPU's virtualized IMSIC.
+    pub fn set_imsic_location(&mut self, imsic_location: ImsicLocation) {
+        self.imsic_location = Some(imsic_location);
+    }
+
+    /// Returns the location of this vCPU's virtualized IMSIC.
+    pub fn get_imsic_location(&self) -> Option<ImsicLocation> {
+        self.imsic_location
     }
 
     /// Sets the interrupt file for this vCPU.


### PR DESCRIPTION
This series adds support for attaching PCI devices to the IOMMU so that DMA may safely be enabled, including for MSI writes.

- Patches 1-4 are minor cleanups / prep-work for supporting device attachment in the IOMMU API.
- Patch 5 adds support for building and manipulating the IOMMU's in-memory queue structures. Only instantiates the command queue for now.
- Patches 6 and 7 introduce the public API for the IOMMU, with the former supporting GSCID allocation and the latter supporting device attachment.
- Patch 8 allows DMA to be enabled for a PCI device if it's attached to the IOMMU.
- Patch 9 and 10 are minor IMSIC driver convenience changes.
- Patch 11 introduces tracking of per-VM IMSIC geometry (and per-vCPU IMSIC location).
- Patch 12 adds support for updating MSI page tables whenever IMSIC pages are mapped.
- Patch 13 adds support for fencing the IOMMU on page table updates.
- Patch 14 attaches PCI devices assigned to the host VM to the IOMMU.

With this series a Linux host VM is able to use DMA and MSI(-X) with passed-through host devices. Tested by booting a [Debian image](https://people.debian.org/~gio/dqib/) with the following QEMU command-line:

```
sudo qemu-system-riscv64 \
   -M virt,aia=aplic-imsic,aia-guests=4 \
   -cpu rv64,x-aia=true -m 2048 -smp "${NCPU}" \
   -nographic \
   -bios "${OPENSBI}" \
   -kernel "${SALUS}" -device guest-loader,addr=0xc0200000,kernel="${KERNEL}" \
   -append "console=hvc0 earlycon=sbi keep_bootcon root=LABEL=rootfs" \
   -device guest-loader,addr=0xc2200000,initrd="${INITRD}" \
   -device x-riscv-iommu-pci \
   -drive file="${ROOTFS}",if=none,id=hd \
   -device nvme,serial=deadbeef,bus=pcie.0,drive=hd \
   -device pcie-root-port,id=rp1,bus=pcie.0,chassis=1,addr=6.0,multifunction=on \
   -netdev user,id=usernet,hostfwd=tcp:127.0.0.1:7722-0.0.0.0:22 \
   -device pcie-root-port,id=rp2,bus=pcie.0,chassis=2,addr=6.1 \
   -device e1000e,netdev=usernet,bus=rp2 \
   -device pcie-root-port,id=rp3,bus=pcie.0,chassis=3,addr=8.0 \
```

Note that virtio devices are also usable, but require extra flags; see #55.

QEMU branch: https://github.com/abrestic-rivos/qemu/tree/testing/sstc-iommu
Linux branch: https://github.com/abrestic-rivos/linux/tree/testing/aia-sstc-iommu

Closes #43 
