### PR TITLE
Enable Sv48 paging while Salus is running in S mode.

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -77,15 +77,15 @@ classDiagram
         active_guests: Vec of PageOwnerId
         pages: PageMap
     }
-    PlatformPageTable "N" o-- "1" PageTracker
-    class PlatformPageTable {
+    GuestStagePageTable "N" o-- "1" PageTracker
+    class GuestStagePageTable {
         root: Top-level page table
         owner: PageOwnerId
         pages: PageTracker
     }
-    VmPages "N" *-- "1" PlatformPageTable
+    VmPages "N" *-- "1" GuestStagePageTable
     class VmPages {
-        root: PlatformPageTable
+        root: GuestStagePageTable
         regions: Vec of VmRegion
         measurement: ...
     }
@@ -126,14 +126,14 @@ page in the system. It allows indexing the pages by a page address.
 `PageTracker` is a system-side singleton that contains `PageMap` and a
 list of active page owners (VM guests).
 
-A `PlatformPageTable` is created for each running VM and is used to
+A `GuestStagePageTable` is created for each running VM and is used to
 manage the 2nd-stage translation tables for the VM, with `root` pointing to
 the 16kB root page table of the paging hierarchy. This is the entity that is
 assigned a unique `PageOwnerId` for the VM and it maintains a reference to
 `PageTracker` for checking which pages are allowed to be mapped or unmapped
 from the VM.
 
-`VmPages` is a per-VM structure that has a `PlatformPageTable` and
+`VmPages` is a per-VM structure that has a `GuestStagePageTable` and
 a `VmRegionList`, which tracks the parts of the physical address space are
 eligible to be used for confidential or shared memory. `VmPages` is used to
 coordinate the assignment, reclaim, or sharing of pages with a child VM.

--- a/drivers/src/iommu/device_directory.rs
+++ b/drivers/src/iommu/device_directory.rs
@@ -7,7 +7,7 @@
 
 use assertions::const_assert;
 use core::marker::PhantomData;
-use riscv_page_tables::{GuestStagePageTable, PlatformPageTable};
+use riscv_page_tables::{GuestStagePageTable, GuestStagePagingMode};
 use riscv_pages::*;
 use riscv_regs::dma_wmb;
 use spin::Mutex;
@@ -122,9 +122,9 @@ impl DeviceContext {
     }
 
     // Marks the device context as valid, using `pt` and `msi_pt` for translation.
-    fn set<T: GuestStagePageTable>(
+    fn set<T: GuestStagePagingMode>(
         &mut self,
-        pt: &PlatformPageTable<T>,
+        pt: &GuestStagePageTable<T>,
         msi_pt: &MsiPageTable,
         gscid: GscId,
     ) {
@@ -384,10 +384,10 @@ impl<D: DirectoryMode> DeviceDirectory<D> {
     /// Enables IOMMU translation for the specified device, using `pt` for 2nd-stage translation
     /// and `msi_pt` for MSI translation. The device must have been previously added with
     /// `add_device()`.
-    pub fn enable_device<T: GuestStagePageTable>(
+    pub fn enable_device<T: GuestStagePagingMode>(
         &self,
         id: DeviceId,
-        pt: &PlatformPageTable<T>,
+        pt: &GuestStagePageTable<T>,
         msi_pt: &MsiPageTable,
         gscid: GscId,
     ) -> Result<()> {

--- a/drivers/src/iommu/mod.rs
+++ b/drivers/src/iommu/mod.rs
@@ -20,7 +20,7 @@ mod tests {
     use super::*;
     use crate::imsic::*;
     use page_tracking::{HwMemMapBuilder, HypPageAlloc, PageList, PageTracker};
-    use riscv_page_tables::{PagingMode, PlatformPageTable, Sv48x4};
+    use riscv_page_tables::{GuestStagePageTable, PagingMode, Sv48x4};
     use riscv_pages::*;
 
     const IMSIC_START: u64 = 0x2800_0000;
@@ -90,7 +90,7 @@ mod tests {
         page_tracker: PageTracker,
         pages: &mut PageList<Page<ConvertedClean>>,
         owner: PageOwnerId,
-    ) -> PlatformPageTable<Sv48x4> {
+    ) -> GuestStagePageTable<Sv48x4> {
         // Find 4 properly aligned pages from `pages`.
         let root_pages = SequentialPages::from_pages(
             pages
@@ -103,7 +103,7 @@ mod tests {
                 }),
         )
         .unwrap();
-        PlatformPageTable::new(root_pages, owner, page_tracker).unwrap()
+        GuestStagePageTable::new(root_pages, owner, page_tracker).unwrap()
     }
 
     #[test]

--- a/page-tracking/src/page_tracker.rs
+++ b/page-tracking/src/page_tracker.rs
@@ -309,6 +309,16 @@ impl PageTracker {
         info.unlock()
     }
 
+    /// Returns true if and only if `addr` is a page owned by `owner`.
+    pub fn is_owned(&self, addr: SupervisorPageAddr, owner: PageOwnerId) -> bool {
+        let mut page_tracker = self.inner.lock();
+        if let Ok(info) = page_tracker.get(addr) {
+            info.owner() == Some(owner)
+        } else {
+            false
+        }
+    }
+
     /// Returns true if and only if `addr` is a "Mapped" page owned by `owner` with type `mem_type`.
     pub fn is_mapped_page(
         &self,

--- a/riscv-page-tables/src/lib.rs
+++ b/riscv-page-tables/src/lib.rs
@@ -106,12 +106,25 @@ mod tests {
     }
 
     #[test]
+    fn ownership_root_pages() {
+        let state = stub_sys_memory();
+
+        let page_tracker = state.page_tracker;
+        let id = page_tracker.add_active_guest().unwrap();
+
+        // Should fail as root_pages owner is not set.
+        assert!(
+            PlatformPageTable::<Sv48x4>::new(state.root_pages, id, page_tracker.clone()).is_err()
+        );
+    }
+
+    #[test]
     fn map_and_unmap_sv48x4() {
         let state = stub_sys_memory();
 
         let page_tracker = state.page_tracker;
         let mut host_pages = state.host_pages;
-        let id = page_tracker.add_active_guest().unwrap();
+        let id = PageOwnerId::host();
         let guest_page_table: PlatformPageTable<Sv48x4> =
             PlatformPageTable::new(state.root_pages, id, page_tracker.clone())
                 .expect("creating sv48x4");
@@ -161,7 +174,7 @@ mod tests {
 
         let page_tracker = state.page_tracker;
         let mut host_pages = state.host_pages;
-        let id = page_tracker.add_active_guest().unwrap();
+        let id = PageOwnerId::host();
         let guest_page_table: PlatformPageTable<Sv48> =
             PlatformPageTable::new(state.root_pages, id, page_tracker.clone())
                 .expect("creating sv48");

--- a/riscv-page-tables/src/lib.rs
+++ b/riscv-page-tables/src/lib.rs
@@ -45,6 +45,7 @@ pub use page_table::Result as PageTableResult;
 pub use page_table::{
     FirstStagePageTable, GuestStagePageTable, PageTableMapper, PagingMode, PlatformPageTable,
 };
+pub use pte::{PteFieldBits, PteLeafPerms};
 pub use sv48::Sv48;
 pub use sv48x4::Sv48x4;
 

--- a/riscv-page-tables/src/lib.rs
+++ b/riscv-page-tables/src/lib.rs
@@ -10,7 +10,7 @@
 //! the `riscv-pages` crate.
 //! - `PageTracker` tracks per-page ownership and typing information, and is used to verify the
 //! safety of page table operations. Provided by the `page-tracking` crate.
-//! - `PlatformPageTable` is a top-level page table structures used to manipulate address translation
+//! - `GuestStagePageTable` is a top-level page table structures used to manipulate address translation
 //! and protection.
 //! - `PageTable` provides a generic implementation of a single level of multi-level translation.
 //! - `Sv48x4`, `Sv48`, etc. define standard RISC-V translation modes for 1st or 2nd-stage translation
@@ -18,7 +18,7 @@
 //!
 //! ## Safety
 //!
-//! Safe interfaces are exposed by giving each `PlatformPageTable` ownership of the pages used to
+//! Safe interfaces are exposed by giving each `GuestStagePageTable` ownership of the pages used to
 //! construct the page tables. In this way the pages can be manipulated as needed, but only by the
 //! owning page table. The details of managing the pages are contained in the page table.
 //!
@@ -43,7 +43,7 @@ pub mod tlb;
 pub use page_table::Error as PageTableError;
 pub use page_table::Result as PageTableResult;
 pub use page_table::{
-    FirstStagePageTable, GuestStagePageTable, PageTableMapper, PagingMode, PlatformPageTable,
+    FirstStagePagingMode, GuestStageMapper, GuestStagePageTable, GuestStagePagingMode, PagingMode,
 };
 pub use pte::{PteFieldBits, PteLeafPerms};
 pub use sv48::Sv48;
@@ -115,7 +115,7 @@ mod tests {
 
         // Should fail as root_pages owner is not set.
         assert!(
-            PlatformPageTable::<Sv48x4>::new(state.root_pages, id, page_tracker.clone()).is_err()
+            GuestStagePageTable::<Sv48x4>::new(state.root_pages, id, page_tracker.clone()).is_err()
         );
     }
 
@@ -126,8 +126,8 @@ mod tests {
         let page_tracker = state.page_tracker;
         let mut host_pages = state.host_pages;
         let id = PageOwnerId::host();
-        let guest_page_table: PlatformPageTable<Sv48x4> =
-            PlatformPageTable::new(state.root_pages, id, page_tracker.clone())
+        let guest_page_table: GuestStagePageTable<Sv48x4> =
+            GuestStagePageTable::new(state.root_pages, id, page_tracker.clone())
                 .expect("creating sv48x4");
 
         let pages_to_map = [host_pages.next().unwrap(), host_pages.next().unwrap()];
@@ -176,8 +176,8 @@ mod tests {
         let page_tracker = state.page_tracker;
         let mut host_pages = state.host_pages;
         let id = PageOwnerId::host();
-        let guest_page_table: PlatformPageTable<Sv48> =
-            PlatformPageTable::new(state.root_pages, id, page_tracker.clone())
+        let guest_page_table: GuestStagePageTable<Sv48> =
+            GuestStagePageTable::new(state.root_pages, id, page_tracker.clone())
                 .expect("creating sv48");
 
         let pages_to_map = [host_pages.next().unwrap(), host_pages.next().unwrap()];

--- a/riscv-page-tables/src/pte.rs
+++ b/riscv-page-tables/src/pte.rs
@@ -166,6 +166,14 @@ impl PteFieldBits {
         ret
     }
 
+    /// Creates a new status for a leaf entry with the given `perms`.
+    pub fn user_leaf_with_perms(perms: PteLeafPerms) -> Self {
+        let mut ret = Self::default();
+        ret.bits |= perms as u64;
+        ret.set_bit(PteFieldBit::User);
+        ret
+    }
+
     /// Creates a new status for a non-leaf entry.
     /// Used for intermeidate levels of page tables.
     pub fn non_leaf() -> Self {

--- a/riscv-page-tables/src/sv48.rs
+++ b/riscv-page-tables/src/sv48.rs
@@ -58,7 +58,7 @@ impl PageTableLevel for Sv48Level {
 /// The `Sv48` addressing mode for 1st-stage translation tables.
 pub enum Sv48 {}
 
-impl FirstStagePageTable for Sv48 {
+impl FirstStagePagingMode for Sv48 {
     const SATP_VALUE: u64 = 9;
 }
 

--- a/riscv-page-tables/src/sv48x4.rs
+++ b/riscv-page-tables/src/sv48x4.rs
@@ -73,7 +73,7 @@ impl PageTableLevel for Sv48x4Level {
 /// The `Sv48x4` addressing mode for 2nd-stage translation tables.
 pub enum Sv48x4 {}
 
-impl GuestStagePageTable for Sv48x4 {
+impl GuestStagePagingMode for Sv48x4 {
     const HGATP_VALUE: u64 = 9;
 }
 

--- a/riscv-pages/src/page.rs
+++ b/riscv-pages/src/page.rs
@@ -45,11 +45,25 @@ impl PageSize {
     }
 
     /// Rounds up the quantity to the nearest multiple of this page size.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use riscv_pages::PageSize;
+    /// assert_eq!(PageSize::Size4k.round_up(8000), 8192)
+    /// ```
     pub fn round_up(&self, val: u64) -> u64 {
         (val + *self as u64 - 1) & !(*self as u64 - 1)
     }
 
     /// Rounds down the quantity to the nearest multiple of this page size.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use riscv_pages::PageSize;
+    /// assert_eq!(PageSize::Size4k.round_down(8000), 4096)
+    /// ```
     pub fn round_down(&self, val: u64) -> u64 {
         val & !(*self as u64 - 1)
     }

--- a/riscv-pages/src/sequential_pages.rs
+++ b/riscv-pages/src/sequential_pages.rs
@@ -159,6 +159,11 @@ impl<S: State> SequentialPages<S> {
             state: PhantomData,
         })
     }
+
+    /// Returns an iterator across the addresses of all pages in `self`.
+    pub fn page_addrs(&self) -> impl Iterator<Item = SupervisorPageAddr> {
+        self.addr.iter_from().take(self.count as usize)
+    }
 }
 
 impl<S: Cleanable> SequentialPages<S> {

--- a/riscv-pages/src/sequential_pages.rs
+++ b/riscv-pages/src/sequential_pages.rs
@@ -8,17 +8,6 @@ use core::marker::PhantomData;
 use crate::page::{CleanablePhysPage, Page, PageSize, PhysPage, SupervisorPageAddr};
 use crate::state::*;
 
-/// `SequentialPages` holds a range of consecutive pages of the same size and state. Each page's
-/// address is one page after the previous. This forms a contiguous area of memory suitable for
-/// holding an array or other linear data.
-#[derive(Debug)]
-pub struct SequentialPages<S: State> {
-    addr: SupervisorPageAddr,
-    page_size: PageSize,
-    count: u64,
-    state: PhantomData<S>,
-}
-
 /// An error resulting from trying to convert an iterator of pages to `SequentialPages`.
 pub enum Error<S: State, I: Iterator<Item = Page<S>>> {
     /// There were zero pages in the list of pages given to create `Self`.
@@ -35,6 +24,17 @@ pub enum Error<S: State, I: Iterator<Item = Page<S>>> {
 /// aligned to the requested size.
 #[derive(Clone, Copy, Debug)]
 pub struct UnalignedPages;
+
+/// `SequentialPages` holds a range of consecutive pages of the same size and state. Each page's
+/// address is one page after the previous. This forms a contiguous area of memory suitable for
+/// holding an array or other linear data.
+#[derive(Debug)]
+pub struct SequentialPages<S: State> {
+    addr: SupervisorPageAddr,
+    page_size: PageSize,
+    count: u64,
+    state: PhantomData<S>,
+}
 
 impl<S: State> SequentialPages<S> {
     /// Creates a `SequentialPages` form the passed iterator.

--- a/riscv-regs/src/csrs/defs.rs
+++ b/riscv-regs/src/csrs/defs.rs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use riscv_page_tables::{FirstStagePagingMode, GuestStagePageTable, GuestStagePagingMode};
+use riscv_page_tables::{
+    FirstStagePageTable, FirstStagePagingMode, GuestStagePageTable, GuestStagePagingMode,
+};
 use riscv_pages::Pfn;
 use tock_registers::register_bitfields;
 use tock_registers::LocalRegisterCopy;
@@ -198,11 +200,11 @@ register_bitfields![u64,
 ];
 
 pub trait SatpHelpers {
-    fn set_from<T: FirstStagePagingMode>(&mut self, pt_root: &GuestStagePageTable<T>, asid: u64);
+    fn set_from<T: FirstStagePagingMode>(&mut self, pt_root: &FirstStagePageTable<T>, asid: u64);
 }
 
 impl SatpHelpers for LocalRegisterCopy<u64, satp::Register> {
-    fn set_from<T: FirstStagePagingMode>(&mut self, pt: &GuestStagePageTable<T>, asid: u64) {
+    fn set_from<T: FirstStagePagingMode>(&mut self, pt: &FirstStagePageTable<T>, asid: u64) {
         self.modify(satp::asid.val(asid));
         self.modify(satp::ppn.val(Pfn::from(pt.get_root_address()).bits()));
         self.modify(satp::mode.val(T::SATP_VALUE));

--- a/riscv-regs/src/csrs/defs.rs
+++ b/riscv-regs/src/csrs/defs.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use riscv_page_tables::{FirstStagePageTable, GuestStagePageTable, PlatformPageTable};
+use riscv_page_tables::{FirstStagePagingMode, GuestStagePageTable, GuestStagePagingMode};
 use riscv_pages::Pfn;
 use tock_registers::register_bitfields;
 use tock_registers::LocalRegisterCopy;
@@ -198,11 +198,11 @@ register_bitfields![u64,
 ];
 
 pub trait SatpHelpers {
-    fn set_from<T: FirstStagePageTable>(&mut self, pt_root: &PlatformPageTable<T>, asid: u64);
+    fn set_from<T: FirstStagePagingMode>(&mut self, pt_root: &GuestStagePageTable<T>, asid: u64);
 }
 
 impl SatpHelpers for LocalRegisterCopy<u64, satp::Register> {
-    fn set_from<T: FirstStagePageTable>(&mut self, pt: &PlatformPageTable<T>, asid: u64) {
+    fn set_from<T: FirstStagePagingMode>(&mut self, pt: &GuestStagePageTable<T>, asid: u64) {
         self.modify(satp::asid.val(asid));
         self.modify(satp::ppn.val(Pfn::from(pt.get_root_address()).bits()));
         self.modify(satp::mode.val(T::SATP_VALUE));
@@ -385,11 +385,11 @@ register_bitfields![u64,
 ];
 
 pub trait HgatpHelpers {
-    fn set_from<T: GuestStagePageTable>(&mut self, pt_root: &PlatformPageTable<T>, vmid: u64);
+    fn set_from<T: GuestStagePagingMode>(&mut self, pt_root: &GuestStagePageTable<T>, vmid: u64);
 }
 
 impl HgatpHelpers for LocalRegisterCopy<u64, hgatp::Register> {
-    fn set_from<T: GuestStagePageTable>(&mut self, pt: &PlatformPageTable<T>, vmid: u64) {
+    fn set_from<T: GuestStagePagingMode>(&mut self, pt: &GuestStagePageTable<T>, vmid: u64) {
         self.modify(hgatp::vmid.val(vmid));
         self.modify(hgatp::ppn.val(Pfn::from(pt.get_root_address()).bits()));
         self.modify(hgatp::mode.val(T::HGATP_VALUE));

--- a/src/host_vm_loader.rs
+++ b/src/host_vm_loader.rs
@@ -7,7 +7,7 @@ use core::{fmt, slice};
 use device_tree::{DeviceTree, DeviceTreeResult, DeviceTreeSerializer};
 use drivers::{imsic::Imsic, pci::PcieRoot, CpuId, CpuInfo};
 use page_tracking::{HwMemRegion, HypPageAlloc, PageList};
-use riscv_page_tables::GuestStagePageTable;
+use riscv_page_tables::GuestStagePagingMode;
 use riscv_pages::*;
 
 use crate::print_util::*;
@@ -143,7 +143,7 @@ enum FdtPages {
 /// creation (specifically, the root of the G-stage page-table), we guarantee that each
 /// contiguous T::TOP_LEVEL_ALIGN block of the guest physical address space of the host VM maps to
 /// a contiguous T::TOP_LEVEL_ALIGN block of the host physical address space.
-pub struct HostVmLoader<T: GuestStagePageTable> {
+pub struct HostVmLoader<T: GuestStagePagingMode> {
     hypervisor_dt: DeviceTree,
     kernel: HwMemRegion,
     initramfs: Option<HwMemRegion>,
@@ -154,7 +154,7 @@ pub struct HostVmLoader<T: GuestStagePageTable> {
     ram_size: u64,
 }
 
-impl<T: GuestStagePageTable> HostVmLoader<T> {
+impl<T: GuestStagePagingMode> HostVmLoader<T> {
     /// Creates a new loader with the given device-tree and kernel & initramfs images. Uses
     /// `page_alloc` to allocate any additional pages that are necessary to load the VM.
     pub fn new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ static HOST_VM: Once<HostVm<Sv48x4>> = Once::new();
 /// Builds the hardware memory map from the device-tree. The kernel & initramfs image regions are
 /// aligned to `T::TOP_LEVEL_ALIGN` so that they can be mapped directly into the host VM's guest
 /// physical address space.
-fn build_memory_map<T: GuestStagePageTable>(fdt: &Fdt) -> MemMapResult<HwMemMap> {
+fn build_memory_map<T: GuestStagePagingMode>(fdt: &Fdt) -> MemMapResult<HwMemMap> {
     let mut builder = HwMemMapBuilder::new(T::TOP_LEVEL_ALIGN);
 
     // First add the memory regions.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1451,8 +1451,8 @@ impl<T: GuestStagePageTable> HostVm<T, VmStateFinalized> {
                             poweroff();
                         }
                     }
-                    _ => {
-                        println!("Unhandled host VM exit; shutting down");
+                    reason => {
+                        println!("Unhandled host VM exit {:?}; shutting down", reason);
                         poweroff();
                     }
                 };


### PR DESCRIPTION
This will be useful for setting page permissions and for u-mode tasks. Both of which will be added following this series.

- Patch 1 Adds information to host exits for debugging
- Patches 2-6 are small additions and clean ups that make the later patches simpler.
- Patches 7 and 8 move the VM-specific fields from `PageTableInner` to `PlatformPageTable` allowing Sv48 to re-use `PageTableInner` funcionality.
- Patches 9-13 rework Page tables to allow non-owning pages to share code with VM page tables taht own pages
- Patches 14-15 allocate pages, build a Sv48 page table and install it on all running CPUs