### PR TITLE
Update README with instructions for launching a Linux VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,46 @@
-OBJCOPY ?= riscv64-unknown-elf-objcopy
-MACH_ARGS ?= -M virt,aia=aplic-imsic,aia-guests=4 -cpu rv64,x-aia=true
+# Path variables:
+#
+#  RV64_PREFIX: Path prefix for riscv64 toolchain. Default: use toolchain in $PATH.
+#  QEMU: Path to compiled QEMU tree. Default: use QEMU in $PATH.
+#  LINUX: Path to compiled Linux kernel tree.
+#  DEBIAN: Path to a pre-baked Debian image.
+
+RV64_PREFIX ?= riscv64-unknown-elf-
+OBJCOPY := $(RV64_PREFIX)objcopy
+
+QEMU ?=
+ifneq ($(QEMU),)
+QEMU_PATH := $(QEMU)/build/riscv64-softmmu/
+else
+QEMU_PATH :=
+endif
+QEMU_BIN := $(QEMU_PATH)qemu-system-riscv64
+
+LINUX ?=
+LINUX_BIN := $(LINUX)/arch/riscv/boot/Image
+
+DEBIAN ?=
+ROOTFS_IMAGE := $(DEBIAN)/image.qcow2
+INITRD_IMAGE := $(DEBIAN)/initrd
+
+RELEASE_BINS := target/riscv64gc-unknown-none-elf/release/
+DEBUG_BINS := target/riscv64gc-unknown-none-elf/debug/
+
+KERNEL_ADDR := 0xc0200000
+INITRD_ADDR := 0xc2200000
+BOOTARGS := console=hvc0 earlycon=sbi
+
+# QEMU options:
+#
+#  NCPU: Number of CPUs to boot with. Default: 1
+#  MEM_SIZE: RAM size for the emulated system. Default: 4GB
+#  EXTRA_QEMU_ARGS: Any extra flags to pass to QEMU (e.g. other devices).
+
 NCPU ?= 1
 MEM_SIZE ?= 4096
-
-# Sanitize LOCAL_PATH
-ifdef LOCAL_PATH
-LOCAL_PATH:=${LOCAL_PATH}/
-endif
+EXTRA_QEMU_ARGS ?=
+MACH_ARGS := -M virt,aia=aplic-imsic,aia-guests=4 -cpu rv64,x-aia=true
+MACH_ARGS += -smp $(NCPU) -m $(MEM_SIZE) -nographic
 
 HOST_TRIPLET := $(shell cargo -Vv | grep '^host:' | awk ' { print $$2; } ')
 
@@ -29,8 +63,8 @@ salus_debug:
 	cargo build --bin salus
 
 tellus_bin: tellus
-	${OBJCOPY} -O binary target/riscv64gc-unknown-none-elf/release/tellus tellus_raw
-	${OBJCOPY} -O binary target/riscv64gc-unknown-none-elf/release/guestvm guestvm_raw
+	${OBJCOPY} -O binary $(RELEASE_BINS)tellus tellus_raw
+	${OBJCOPY} -O binary $(RELEASE_BINS)guestvm guestvm_raw
 	./create_guest_image.sh tellus_raw guestvm_raw tellus_guestvm
 
 guestvm:
@@ -40,30 +74,48 @@ guestvm:
 tellus: guestvm
 	cargo build --package test_workloads --bin tellus --release
 
+# Runnable targets:
+#
+#  run_tellus_gdb: Run Tellus as the host VM with GDB debugging enabled.
+#  run_tellus: Run Tellus as the host VM.
+#  run_linux: Run a bare Linux kernel as the host VM.
+#  run_debian: Run a Linux kernel as the host VM with a Debian rootfs.
+
 run_tellus_gdb: tellus_bin salus_debug
-	     ${LOCAL_PATH}qemu-system-riscv64 \
-		     -s -S \
-		     ${MACH_ARGS} -smp ${NCPU} -m ${MEM_SIZE} \
-		     -nographic \
-		     -kernel target/riscv64gc-unknown-none-elf/debug/salus \
-		     -device guest-loader,kernel=tellus_guestvm,addr=0xc0200000
+	$(QEMU_BIN) \
+		-s -S $(MACH_ARGS) \
+		-kernel $(DEBUG_BINS)salus \
+		-device guest-loader,kernel=tellus_guestvm,addr=$(KERNEL_ADDR) \
+		$(EXTRA_QEMU_ARGS)
 
 run_tellus: tellus_bin salus
-	     ${LOCAL_PATH}qemu-system-riscv64 \
-		     ${GDB_ARGS} \
-		     ${MACH_ARGS} -smp ${NCPU} -m ${MEM_SIZE} \
-		     -nographic \
-		     -kernel target/riscv64gc-unknown-none-elf/release/salus \
-		     -device guest-loader,kernel=tellus_guestvm,addr=0xc0200000
+	$(QEMU_BIN) \
+		$(MACH_ARGS) \
+		-kernel $(RELEASE_BINS)salus \
+		-device guest-loader,kernel=tellus_guestvm,addr=$(KERNEL_ADDR) \
+		$(EXTRA_QEMU_ARGS)
 
 run_linux: salus
-	     ${LOCAL_PATH}qemu-system-riscv64 \
-		     ${GDB_ARGS} \
-		     ${MACH_ARGS} -smp ${NCPU} -m ${MEM_SIZE} \
-		     -nographic \
-		     -kernel target/riscv64gc-unknown-none-elf/release/salus \
-		     -device guest-loader,kernel=../linux/arch/riscv/boot/Image,addr=0xc0200000 \
-		     -append "console=ttyS0 earlycon=sbi keep_bootcon bootmem_debug"
+	$(QEMU_BIN) \
+		$(MACH_ARGS) \
+		-kernel $(RELEASE_BINS)salus \
+		-device guest-loader,kernel=$(LINUX_BIN),addr=$(KERNEL_ADDR) \
+		-append "$(BOOTARGS)" \
+		$(EXTRA_QEMU_ARGS)
+
+run_debian: salus
+	$(QEMU_BIN) \
+		$(MACH_ARGS) \
+		-kernel $(RELEASE_BINS)salus \
+		-device guest-loader,kernel=$(LINUX_BIN),addr=$(KERNEL_ADDR) \
+		-append "$(BOOTARGS) root=LABEL=rootfs" \
+		-device guest-loader,initrd=$(INITRD_IMAGE),addr=$(INITRD_ADDR) \
+		-device x-riscv-iommu-pci \
+		-drive file=$(ROOTFS_IMAGE),if=none,id=hd \
+		-device nvme,serial=deadbeef,drive=hd \
+		-netdev user,id=usernet,hostfwd=tcp:127.0.0.1:7722-0.0.0.0:22 \
+		-device e1000e,netdev=usernet \
+		$(EXTRA_QEMU_ARGS)
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
Now that we can boot usable Linux host VMs, add more detailed instructions to the README including pointers to known-working QEMU and Linux branches that include the necessary out-of-tree patches.