### PR TITLE
Support setting AIA virtualization params for TVMs

### DIFF
--- a/sbi/src/api/mod.rs
+++ b/sbi/src/api/mod.rs
@@ -14,5 +14,9 @@ pub mod state;
 #[cfg(all(target_arch = "riscv64", target_os = "none"))]
 pub mod tsm;
 
+/// Host interfaces for confidential computing interrupt virtualization.
+#[cfg(all(target_arch = "riscv64", target_os = "none"))]
+pub mod tsm_aia;
+
 /// Host interfaces for PMU.
 pub mod pmu;

--- a/sbi/src/api/tsm_aia.rs
+++ b/sbi/src/api/tsm_aia.rs
@@ -1,0 +1,32 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::TeeAiaFunction::*;
+use crate::TvmAiaParams;
+use crate::{ecall_send, Result, SbiMessage};
+
+/// Configures AIA virtualization for `tvm_id` with the settings in `tvm_aia_params`.
+pub fn tvm_aia_init(tvm_id: u64, tvm_aia_params: TvmAiaParams) -> Result<()> {
+    let msg = SbiMessage::TeeAia(TvmAiaInit {
+        tvm_id,
+        params_addr: (&tvm_aia_params as *const TvmAiaParams) as u64,
+        len: core::mem::size_of::<TvmAiaParams>() as u64,
+    });
+    // Safety: `TvmConfigureAia` will only read up to `len` bytes of the `TvmAiaParams` structure
+    // we passed in.
+    unsafe { ecall_send(&msg) }?;
+    Ok(())
+}
+
+/// Sets the guest physical address of the specified vCPU's virtualized IMSIC to `imsic_addr`.
+pub fn set_vcpu_imsic_addr(tvm_id: u64, vcpu_id: u64, imsic_addr: u64) -> Result<()> {
+    let msg = SbiMessage::TeeAia(TvmCpuSetImsicAddr {
+        tvm_id,
+        vcpu_id,
+        imsic_addr,
+    });
+    // Safety: `TvmCpuSetImsicAddr` doesn't touch host memory in any way.
+    unsafe { ecall_send(&msg) }?;
+    Ok(())
+}

--- a/sbi/src/consts.rs
+++ b/sbi/src/consts.rs
@@ -12,5 +12,6 @@ pub const EXT_PMU: u64 = 0x504D55;
 pub const EXT_RESET: u64 = 0x53525354;
 pub const EXT_TEE: u64 = 0x41544545;
 pub const EXT_ATTESTATION: u64 = 0x41545354; // ATST
+pub const EXT_TEE_AIA: u64 = 0x54414941; // TAIA
 
 pub const SBI_SUCCESS: i64 = 0;

--- a/sbi/src/consts.rs
+++ b/sbi/src/consts.rs
@@ -11,8 +11,6 @@ pub const EXT_HART_STATE: u64 = 0x48534D;
 pub const EXT_PMU: u64 = 0x504D55;
 pub const EXT_RESET: u64 = 0x53525354;
 pub const EXT_TEE: u64 = 0x41544545;
-pub const EXT_MEASUREMENT: u64 = 0x5464545;
-// TODO Replace the measurement extension once the `GetEvidence` implementation is complete
 pub const EXT_ATTESTATION: u64 = 0x41545354; // ATST
 
 pub const SBI_SUCCESS: i64 = 0;

--- a/sbi/src/sbi.rs
+++ b/sbi/src/sbi.rs
@@ -28,7 +28,9 @@ pub use state::*;
 // The TSM SBI extension
 mod tsm;
 pub use tsm::*;
-
+// The TSM-AIA SBI extension.
+mod tsm_aia;
+pub use tsm_aia::*;
 // The PMU SBI extension
 mod pmu;
 pub use pmu::*;
@@ -110,6 +112,8 @@ pub enum SbiMessage {
     Tee(TeeFunction),
     /// The extension for getting attestation evidences and extending measurements.
     Attestation(AttestationFunction),
+    /// Provides interrupt virtualization for confidential virtual machines.
+    TeeAia(TeeAiaFunction),
     /// The extension for getting performance counter state.
     Pmu(PmuFunction),
 }
@@ -126,6 +130,7 @@ impl SbiMessage {
             EXT_RESET => ResetFunction::from_regs(args).map(SbiMessage::Reset),
             EXT_TEE => TeeFunction::from_regs(args).map(SbiMessage::Tee),
             EXT_ATTESTATION => AttestationFunction::from_regs(args).map(SbiMessage::Attestation),
+            EXT_TEE_AIA => TeeAiaFunction::from_regs(args).map(SbiMessage::TeeAia),
             EXT_PMU => PmuFunction::from_regs(args).map(SbiMessage::Pmu),
             _ => Err(Error::NotSupported),
         }
@@ -140,6 +145,7 @@ impl SbiMessage {
             SbiMessage::Reset(_) => EXT_RESET,
             SbiMessage::Tee(_) => EXT_TEE,
             SbiMessage::Attestation(_) => EXT_ATTESTATION,
+            SbiMessage::TeeAia(_) => EXT_TEE_AIA,
             SbiMessage::Pmu(_) => EXT_PMU,
         }
     }
@@ -153,6 +159,7 @@ impl SbiMessage {
             SbiMessage::Reset(_) => 0,
             SbiMessage::Tee(f) => f.a6(),
             SbiMessage::Attestation(f) => f.a6(),
+            SbiMessage::TeeAia(f) => f.a6(),
             SbiMessage::Pmu(f) => f.a6(),
         }
     }
@@ -161,6 +168,7 @@ impl SbiMessage {
     pub fn a5(&self) -> u64 {
         match self {
             SbiMessage::Tee(f) => f.a5(),
+            SbiMessage::TeeAia(f) => f.a5(),
             SbiMessage::Pmu(f) => f.a5(),
             _ => 0,
         }
@@ -170,6 +178,7 @@ impl SbiMessage {
     pub fn a4(&self) -> u64 {
         match self {
             SbiMessage::Tee(f) => f.a4(),
+            SbiMessage::TeeAia(f) => f.a4(),
             SbiMessage::Pmu(f) => f.a4(),
             _ => 0,
         }
@@ -181,6 +190,7 @@ impl SbiMessage {
             SbiMessage::Tee(f) => f.a3(),
             SbiMessage::Attestation(f) => f.a3(),
             SbiMessage::Pmu(f) => f.a3(),
+            SbiMessage::TeeAia(f) => f.a3(),
             _ => 0,
         }
     }
@@ -192,6 +202,7 @@ impl SbiMessage {
             SbiMessage::Tee(f) => f.a2(),
             SbiMessage::Attestation(f) => f.a2(),
             SbiMessage::Pmu(f) => f.a2(),
+            SbiMessage::TeeAia(f) => f.a2(),
             _ => 0,
         }
     }
@@ -203,6 +214,7 @@ impl SbiMessage {
             SbiMessage::HartState(f) => f.a1(),
             SbiMessage::Tee(f) => f.a1(),
             SbiMessage::Attestation(f) => f.a1(),
+            SbiMessage::TeeAia(f) => f.a1(),
             SbiMessage::Pmu(f) => f.a1(),
             _ => 0,
         }
@@ -216,6 +228,7 @@ impl SbiMessage {
             SbiMessage::HartState(f) => f.a0(),
             SbiMessage::Tee(f) => f.a0(),
             SbiMessage::Attestation(f) => f.a0(),
+            SbiMessage::TeeAia(f) => f.a0(),
             SbiMessage::Pmu(f) => f.a0(),
             _ => 0,
         }

--- a/sbi/src/tsm_aia.rs
+++ b/sbi/src/tsm_aia.rs
@@ -1,0 +1,170 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The TEE-AIA extension supplements the TEE extension with hardware-assisted interrupt
+//! virtualization using the RISC-V Advanced Interrupt Architecture (AIA) on platforms which
+//! support it.
+
+use crate::error::*;
+use crate::function::*;
+
+/// Describes a TVM's AIA configuration.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TvmAiaParams {
+    /// The base address of the virtualized IMSIC in guest physical address space.
+    ///
+    /// IMSIC addresses follow the below pattern:
+    ///
+    /// XLEN-1           >=24                                 12    0
+    /// |                  |                                  |     |
+    /// -------------------------------------------------------------
+    /// |xxxxxx|Group Index|xxxxxxxxxxx|Hart Index|Guest Index|  0  |
+    /// -------------------------------------------------------------
+    ///
+    /// The base address is the address of the IMSIC with group ID, hart ID, and guest ID of 0.
+    pub imsic_base_addr: u64,
+    /// The number of group index bits in an IMSIC address.
+    pub group_index_bits: u32,
+    /// The location of the group index in an IMSIC address. Must be >= 24.
+    pub group_index_shift: u32,
+    /// The number of hart index bits in an IMSIC address.
+    pub hart_index_bits: u32,
+    /// The number of guest index bits in an IMSIC address. Must be >= log2(guests_per_hart + 1).
+    pub guest_index_bits: u32,
+    /// The number of guest interrupt files to be implemented per vCPU. Implementations may
+    /// reject configurations with guests_per_hart > 0 if nested IMSIC virtualization is not
+    /// supported.
+    pub guests_per_hart: u32,
+}
+
+/// Functions provided by the TEE-AIA extension.
+#[derive(Copy, Clone)]
+pub enum TeeAiaFunction {
+    /// Configures AIA virtualization for the TVM identified by `tvm_id` from the parameters in
+    /// the `TvmAiaParams` structure at the non-confidential physical address `params_addr`.
+    ///
+    /// May only be called prior to TVM finalization.
+    ///
+    /// Returns 0 on success.
+    ///
+    /// a6 = 0
+    TvmAiaInit {
+        /// a0 = TVM ID
+        tvm_id: u64,
+        /// a1 = physical address of the `TvmAiaParams` structure
+        params_addr: u64,
+        /// a2 = length of the `TvmAiaParams` structure in bytes
+        len: u64,
+    },
+    /// Sets the guest physical address of the specified vCPU's virtualized IMSIC to `imsic_addr`.
+    /// `imsic_addr` must be valid for the AIA configuration that was set in `TvmAiaInit` and no
+    /// two vCPUs may share the same `imsic_addr`.
+    ///
+    /// May only be called prior to TVM finalization and after `TvmAiaInit`. All vCPUs in
+    /// an AIA-enabled TVM must their IMSIC configuration set with `TvmCpuSetImsicAddr` prior
+    /// to TVM finalization.
+    ///
+    /// Returns 0 on success.
+    ///
+    /// a6 - 1
+    TvmCpuSetImsicAddr {
+        /// a0 = TVM ID
+        tvm_id: u64,
+        /// a1 = vCPU ID
+        vcpu_id: u64,
+        /// a2 = guest physical address of vCPU's IMSIC
+        imsic_addr: u64,
+    },
+}
+
+impl TeeAiaFunction {
+    /// Attempts to parse `Self` from the register values passed in `a0-a7`.
+    pub(crate) fn from_regs(args: &[u64]) -> Result<Self> {
+        use TeeAiaFunction::*;
+        match args[6] {
+            0 => Ok(TvmAiaInit {
+                tvm_id: args[0],
+                params_addr: args[1],
+                len: args[2],
+            }),
+            1 => Ok(TvmCpuSetImsicAddr {
+                tvm_id: args[0],
+                vcpu_id: args[1],
+                imsic_addr: args[2],
+            }),
+            _ => Err(Error::NotSupported),
+        }
+    }
+}
+
+impl SbiFunction for TeeAiaFunction {
+    fn a6(&self) -> u64 {
+        use TeeAiaFunction::*;
+        match self {
+            TvmAiaInit { .. } => 0,
+            TvmCpuSetImsicAddr { .. } => 1,
+        }
+    }
+
+    fn a0(&self) -> u64 {
+        use TeeAiaFunction::*;
+        match self {
+            TvmAiaInit {
+                tvm_id,
+                params_addr: _,
+                len: _,
+            } => *tvm_id,
+            TvmCpuSetImsicAddr {
+                tvm_id,
+                vcpu_id: _,
+                imsic_addr: _,
+            } => *tvm_id,
+        }
+    }
+
+    fn a1(&self) -> u64 {
+        use TeeAiaFunction::*;
+        match self {
+            TvmAiaInit {
+                tvm_id: _,
+                params_addr,
+                len: _,
+            } => *params_addr,
+            TvmCpuSetImsicAddr {
+                tvm_id: _,
+                vcpu_id,
+                imsic_addr: _,
+            } => *vcpu_id,
+        }
+    }
+
+    fn a2(&self) -> u64 {
+        use TeeAiaFunction::*;
+        match self {
+            TvmAiaInit {
+                tvm_id: _,
+                params_addr: _,
+                len,
+            } => *len,
+            TvmCpuSetImsicAddr {
+                tvm_id: _,
+                vcpu_id: _,
+                imsic_addr,
+            } => *imsic_addr,
+        }
+    }
+
+    fn a3(&self) -> u64 {
+        0
+    }
+
+    fn a4(&self) -> u64 {
+        0
+    }
+
+    fn a5(&self) -> u64 {
+        0
+    }
+}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -663,6 +663,7 @@ impl<T: GuestStagePagingMode> Vm<T, VmStateFinalized> {
             SbiMessage::Attestation(attestation_func) => {
                 self.handle_attestation_msg(attestation_func, active_vcpu.active_pages())
             }
+            SbiMessage::TeeAia(_) => EcallAction::Continue(SbiReturn::from(SbiError::NotSupported)),
             SbiMessage::Pmu(pmu_func) => self.handle_pmu_msg(pmu_func, active_vcpu).into(),
         }
     }
@@ -807,7 +808,8 @@ impl<T: GuestStagePagingMode> Vm<T, VmStateFinalized> {
                 | sbi::EXT_HART_STATE
                 | sbi::EXT_RESET
                 | sbi::EXT_TEE
-                | sbi::EXT_ATTESTATION => 1,
+                | sbi::EXT_ATTESTATION
+                | sbi::EXT_TEE_AIA => 1,
                 sbi::EXT_PMU if PmuInfo::get().is_ok() => 1,
                 _ => 0,
             },

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1368,7 +1368,7 @@ impl<T: GuestStagePagingMode> Vm<T, VmStateFinalized> {
 
         active_pages
             .copy_to_guest(cert_gpa, cert_bytes)
-            .map_err(|_| EcallError::Sbi(SbiError::InvalidAddress))?;
+            .map_err(EcallError::from)?;
 
         Ok(cert_bytes_len as u64)
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -807,7 +807,7 @@ impl<T: GuestStagePagingMode> Vm<T, VmStateFinalized> {
                 | sbi::EXT_HART_STATE
                 | sbi::EXT_RESET
                 | sbi::EXT_TEE
-                | sbi::EXT_MEASUREMENT => 1,
+                | sbi::EXT_ATTESTATION => 1,
                 sbi::EXT_PMU if PmuInfo::get().is_ok() => 1,
                 _ => 0,
             },

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -1000,9 +1000,9 @@ pub enum VirtualRegister {
     Cause0,
     /// 2nd detailed exit cause register. Usage depends on the exit code.
     Cause1,
-    /// xxx
+    /// Result of an emulated MMIO load.
     MmioLoad,
-    /// xxx
+    /// Source value of an emulated MMIO store.
     MmioStore,
 }
 

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -1260,6 +1260,11 @@ impl VmCpus {
         Ok(Self { inner })
     }
 
+    /// Returns the number of vCPUs in this `VmCpus`.
+    pub fn num_vcpus(&self) -> usize {
+        self.inner.len()
+    }
+
     /// Adds the vCPU at `vcpu_id` as an available vCPU, returning a reference to it.
     pub fn add_vcpu(&self, vcpu_id: u64) -> Result<IdleVmCpu> {
         let entry = self.inner.get(vcpu_id as usize).ok_or(Error::BadCpuId)?;


### PR DESCRIPTION
This PR introduces two new TEECALLs (in a new extension) for configuring AIA virtualization in a TVM: setting the TVM's IMSIC geometry (`TvmInitAia`) and setting a vCPU's IMSIC location (`TvmCpuSetImsicAddr`). We'll build on this in following PRs to enable assignment of guest interrupt files from the host VM to its child TVMs.

I've initially chosen to put this in a separate extension, though I'm definitely open to other options here. Rationale for making it an optional extension:
- We may want to support nested TVMs, and nested AIA virtualization gets extremely complicated.
- It's possible to do interrupt virtualization without hardware AIA virtualization using emulated MMIO and (to-be-implemented) support for injecting interrupts.

Patches 1-3 are minor cleanups, patch 4 introduces the SBI definitions, patches 5&6 wire up the new TEECALLs, and patch 7 tests them out in `tellus`.