### PR TITLE
Support conversion of IMSIC pages

### DIFF
--- a/sbi/src/api/mod.rs
+++ b/sbi/src/api/mod.rs
@@ -3,19 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Host interfaces for reset extension.
-#[cfg(all(target_arch = "riscv64", target_os = "none"))]
 pub mod reset;
 
 /// Host interfaces for hart state management.
-#[cfg(all(target_arch = "riscv64", target_os = "none"))]
 pub mod state;
 
 /// Host interfaces for confidential computing.
-#[cfg(all(target_arch = "riscv64", target_os = "none"))]
 pub mod tsm;
 
 /// Host interfaces for confidential computing interrupt virtualization.
-#[cfg(all(target_arch = "riscv64", target_os = "none"))]
 pub mod tsm_aia;
 
 /// Host interfaces for PMU.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1037,6 +1037,7 @@ impl<T: GuestStagePagingMode> Vm<T, VmStateFinalized> {
             } => self
                 .guest_set_vcpu_imsic_addr(tvm_id, vcpu_id, imsic_addr)
                 .into(),
+            _ => EcallAction::Continue(SbiReturn::from(SbiError::NotSupported)),
         }
     }
 


### PR DESCRIPTION
This looks much like conversion of ordinary memory pages except that we're only dealing with one 4kB page at a time and we may need to update MSI page tables. Patch 1 is a trivial cleanup, patch 2 adds the new TEECALL definitions, patch 3 implements them, and patch 4 tests them out in `tellus`. Note that we can't do much with these until we're able to assign the interrupt files to guest TVMs.