### PR TITLE
Changes to allow saving vector state on context switches.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -10,3 +10,10 @@ rustflags = [
     # new in 1.60 and generates false positives
     "-Aclippy::only_used_in_recursion",
 ]
+
+[target.riscv64gcv-unknown-none-elf]
+rustflags = [
+    '-Clink-arg=-Tlds/qemu.lds',
+    # new in 1.60 and generates false positives
+    "-Aclippy::only_used_in_recursion",
+]

--- a/PATCH.rust-vectors
+++ b/PATCH.rust-vectors
@@ -1,0 +1,84 @@
+diff --git a/library/std/src/sys/unsupported/locks/condvar.rs b/library/std/src/sys/unsupported/locks/condvar.rs
+index e703fd0d269..527a26a12bc 100644
+--- a/library/std/src/sys/unsupported/locks/condvar.rs
++++ b/library/std/src/sys/unsupported/locks/condvar.rs
+@@ -7,6 +7,7 @@ pub struct Condvar {}
+ 
+ impl Condvar {
+     #[inline]
++    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
+     pub const fn new() -> Condvar {
+         Condvar {}
+     }
+diff --git a/library/std/src/sys/unsupported/locks/mutex.rs b/library/std/src/sys/unsupported/locks/mutex.rs
+index d7cb12e0cf9..81b49c64cae 100644
+--- a/library/std/src/sys/unsupported/locks/mutex.rs
++++ b/library/std/src/sys/unsupported/locks/mutex.rs
+@@ -12,6 +12,7 @@ unsafe impl Sync for Mutex {} // no threads on this platform
+ 
+ impl Mutex {
+     #[inline]
++    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
+     pub const fn new() -> Mutex {
+         Mutex { locked: Cell::new(false) }
+     }
+diff --git a/library/std/src/sys/unsupported/locks/rwlock.rs b/library/std/src/sys/unsupported/locks/rwlock.rs
+index aca5fb7152c..5292691b955 100644
+--- a/library/std/src/sys/unsupported/locks/rwlock.rs
++++ b/library/std/src/sys/unsupported/locks/rwlock.rs
+@@ -12,6 +12,7 @@ unsafe impl Sync for RwLock {} // no threads on this platform
+ 
+ impl RwLock {
+     #[inline]
++    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
+     pub const fn new() -> RwLock {
+         RwLock { mode: Cell::new(0) }
+     }
+diff --git a/library/std/src/sys_common/condvar.rs b/library/std/src/sys_common/condvar.rs
+index f3ac1061b89..8bc5b24115d 100644
+--- a/library/std/src/sys_common/condvar.rs
++++ b/library/std/src/sys_common/condvar.rs
+@@ -15,6 +15,7 @@ pub struct Condvar {
+ impl Condvar {
+     /// Creates a new condition variable for use.
+     #[inline]
++    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
+     pub const fn new() -> Self {
+         Self { inner: imp::MovableCondvar::new(), check: CondvarCheck::new() }
+     }
+diff --git a/library/std/src/sys_common/condvar/check.rs b/library/std/src/sys_common/condvar/check.rs
+index ce8f3670487..4ac9e62bf86 100644
+--- a/library/std/src/sys_common/condvar/check.rs
++++ b/library/std/src/sys_common/condvar/check.rs
+@@ -50,6 +50,7 @@ impl CondvarCheck for imp::Mutex {
+ 
+ #[allow(dead_code)]
+ impl NoCheck {
++    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
+     pub const fn new() -> Self {
+         Self
+     }
+diff --git a/library/std/src/sys_common/mutex.rs b/library/std/src/sys_common/mutex.rs
+index 48479f5bdb3..7b9f7ef5487 100644
+--- a/library/std/src/sys_common/mutex.rs
++++ b/library/std/src/sys_common/mutex.rs
+@@ -61,6 +61,7 @@ unsafe impl Sync for MovableMutex {}
+ impl MovableMutex {
+     /// Creates a new mutex.
+     #[inline]
++    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
+     pub const fn new() -> Self {
+         Self(imp::MovableMutex::new())
+     }
+diff --git a/library/std/src/sys_common/rwlock.rs b/library/std/src/sys_common/rwlock.rs
+index ba56f3a8f1b..34e9a91e874 100644
+--- a/library/std/src/sys_common/rwlock.rs
++++ b/library/std/src/sys_common/rwlock.rs
+@@ -75,6 +75,7 @@ fn drop(&mut self) {
+ impl MovableRwLock {
+     /// Creates a new reader-writer lock for use.
+     #[inline]
++    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
+     pub const fn new() -> Self {
+         Self(imp::MovableRwLock::new())
+     }

--- a/README.md
+++ b/README.md
@@ -171,3 +171,13 @@ loaded it and passes the device tree to Salus.
 The above instructions use OpenSBI inbuilt in Qemu. If OpenSBI needs to be
 built from scratch, fw_dynamic should be used for `-bios` argument in the qemu
 commandline.
+
+### Vectors
+
+To run with the vector extension enabled requires a custom rust toolchain, due to a bug
+in nightly that prevents a no-std build with a custom target to not compile. Included in this
+directory is a patch file called PATCH.rust-vectors which should be applied to a rust compiler
+source code before building. Once you have you the custom toolchain configured, adding VECTORS=yes
+as an environment variable will cause the build to have the vector extension enabled.
+This problem seems to be the same as [Rust issue 98293](https://github.com/rust-lang/rust/issues/98293)
+or [Rust issue 98378](https://github.com/rust-lang/rust/issues/98378).

--- a/drivers/src/cpu.rs
+++ b/drivers/src/cpu.rs
@@ -36,9 +36,11 @@ pub struct CpuInfo {
     has_sstc: bool,
     // True if the Sscofpmf extension is supported.
     has_sscofpmf: bool,
+    // True if the vector extension is supported
+    has_vector: bool,
     // CPU timer frequency.
     timer_frequency: u32,
-    // ISA string as reprted in the device-tree. All CPUs are expected to have the same ISA.
+    // ISA string as reported in the device-tree. All CPUs are expected to have the same ISA.
     isa_string: ArrayString<MAX_ISA_STRING_LEN>,
     // Mapping of logical CPU index to hart IDs.
     hart_ids: ArrayVec<u32, MAX_CPUS>,
@@ -77,6 +79,14 @@ fn intc_phandle_from_cpu_node(dt: &DeviceTree, node: &DeviceTreeNode) -> u32 {
 
 fn isa_string_has_extension(isa_string: &str, extension: &str) -> bool {
     isa_string.split('_').any(|f| f == extension)
+}
+
+fn isa_string_has_base_extension(isa_string: &str, extension: char) -> bool {
+    isa_string
+        .split('_')
+        .next()
+        .and_then(|s| s.chars().skip(4).find(|c| *c == extension))
+        .is_some()
 }
 
 impl CpuInfo {
@@ -151,6 +161,7 @@ impl CpuInfo {
         let cpu_info = CpuInfo {
             has_sstc: isa_string_has_extension(isa_string, "sstc"),
             has_sscofpmf: isa_string_has_extension(isa_string, "sscofpmf"),
+            has_vector: isa_string_has_base_extension(isa_string, 'v'),
             isa_string: ArrayString::from(isa_string).unwrap(),
             timer_frequency,
             hart_ids,
@@ -173,6 +184,11 @@ impl CpuInfo {
     /// Returns true if the Sscofpmf extension is supported.
     pub fn has_sscofpmf(&self) -> bool {
         self.has_sscofpmf
+    }
+
+    /// Returns true if the vector extension is supported
+    pub fn has_vector(&self) -> bool {
+        self.has_vector
     }
 
     /// Returns the total number of CPUs.

--- a/riscv-regs/src/csrs/defs.rs
+++ b/riscv-regs/src/csrs/defs.rs
@@ -386,6 +386,41 @@ register_bitfields![u64,
     ]
 ];
 
+// Vector start position
+register_bitfields![u64,
+    pub vstart [
+        value OFFSET(0) NUMBITS(64) [],
+    ]
+];
+
+// Vector control and status register
+register_bitfields![u64,
+    pub vcsr [
+        value OFFSET(0) NUMBITS(64) [],
+    ]
+];
+
+// Vector length
+register_bitfields![u64,
+    pub vl [
+        value OFFSET(0) NUMBITS(64) [],
+    ]
+];
+
+// Vector data type register
+register_bitfields![u64,
+    pub vtype [
+        value OFFSET(0) NUMBITS(64) [],
+    ]
+];
+
+// VLEN/8 (vector register width in bytes)
+register_bitfields![u64,
+    pub vlenb [
+        value OFFSET(0) NUMBITS(64) [],
+    ]
+];
+
 pub trait HgatpHelpers {
     fn set_from<T: GuestStagePagingMode>(&mut self, pt_root: &GuestStagePageTable<T>, vmid: u64);
 }

--- a/riscv-regs/src/csrs/mod.rs
+++ b/riscv-regs/src/csrs/mod.rs
@@ -67,6 +67,12 @@ pub struct CSR {
     pub vsatp: ReadWriteRiscvCsr<satp::Register, CSR_VSATP>,
     pub vstopi: ReadWriteRiscvCsr<stopi::Register, 0xeb0>,
 
+    pub vstart: ReadWriteRiscvCsr<vstart::Register, 0x008>,
+    pub vcsr: ReadWriteRiscvCsr<vcsr::Register, 0x00F>,
+    pub vl: ReadWriteRiscvCsr<vl::Register, 0xC20>,
+    pub vtype: ReadWriteRiscvCsr<vtype::Register, 0xC21>,
+    pub vlenb: ReadWriteRiscvCsr<vlenb::Register, 0xC22>,
+
     pub hpmcounter: [&'static dyn RiscvCsrInterface<R = hpmcounter::Register>; 32],
 }
 
@@ -117,6 +123,12 @@ pub const CSR: &CSR = &CSR {
     vstopei: ReadWriteRiscvCsr::new(),
     vsatp: ReadWriteRiscvCsr::new(),
     vstopi: ReadWriteRiscvCsr::new(),
+
+    vstart: ReadWriteRiscvCsr::new(),
+    vcsr: ReadWriteRiscvCsr::new(),
+    vl: ReadWriteRiscvCsr::new(),
+    vtype: ReadWriteRiscvCsr::new(),
+    vlenb: ReadWriteRiscvCsr::new(),
 
     // TODO: Use a procedural macro to generate these.
     hpmcounter: [

--- a/riscv-regs/src/regs.rs
+++ b/riscv-regs/src/regs.rs
@@ -117,3 +117,20 @@ impl GeneralPurposeRegisters {
 #[derive(Default)]
 #[repr(C)]
 pub struct FloatingPointRegisters([u64; 32]);
+
+/// The vector register file. We don't expect to directly interact with a guest's vector state
+/// other than for saving/restoring the registers, so simply treat the register file as an array
+/// of 256b values. This actually depends on the vlenb csr, so if the register is greater than 256
+/// bits (i.e. the vlenb csr is greater than 32) we will need to increase this.
+
+// The width of a vector register in bytes
+pub const MAX_VECTOR_REGISTER_LEN: usize = 32;
+const U64S_IN_REGISTER: usize = MAX_VECTOR_REGISTER_LEN >> 3;
+
+#[derive(Default)]
+#[repr(C)]
+pub struct VectorRegister([u64; U64S_IN_REGISTER]);
+
+#[derive(Default)]
+#[repr(C)]
+pub struct VectorRegisters([VectorRegister; 32]);

--- a/riscv64gcv-unknown-none-elf.json
+++ b/riscv64gcv-unknown-none-elf.json
@@ -1,0 +1,18 @@
+{
+  "arch": "riscv64",
+  "code-model": "medium",
+  "cpu": "generic-rv64",
+  "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n64-S128",
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "features": "+m,+a,+f,+d,+c,+v",
+  "is-builtin": false,
+  "linker": "rust-lld",
+  "linker-flavor": "ld.lld",
+  "llvm-abiname": "lp64d",
+  "llvm-target": "riscv64",
+  "max-atomic-width": 64,
+  "panic-strategy": "abort",
+  "relocation-model": "static",
+  "target-pointer-width": "64"
+}

--- a/src/vectors.S
+++ b/src/vectors.S
@@ -1,0 +1,80 @@
+.section .text.init
+.global _run_guest_vector,_guest_exit_vector
+
+// t5 -> cached sstatus
+// a0 -> pointer to VmCpuState
+// _restore_vectors restores vector state for the
+// guest before leaving salus and running the guest.
+.align 2
+_restore_vector:
+    
+    // Save sstatus
+    csrr t5, sstatus
+
+    // Enable vector commands
+    li t4, {sstatus_vs_enable}
+    csrrs zero, sstatus, t4
+
+    // Restore type and length
+    ld t1, ({guest_vl})(a0)
+    ld t2, ({guest_vtype})(a0)
+    vsetvl t0,t1,t2
+
+    // Restore vstart
+    ld t0, ({guest_vstart})(a0)
+    csrw vstart, t0
+
+    // Restore vcsr
+    ld t0, ({guest_vcsr})(a0)
+    csrw vcsr, t0
+
+    // Restore register file
+    addi t3, a0, {guest_v0}
+    vl8r.v  v0, (t3)
+    addi t3, a0, {guest_v8}
+    vl8r.v  v8, (t3)
+    addi t3, a0, {guest_v16}
+    vl8r.v  v16, (t3)
+    addi t3, a0, {guest_v24}
+    vl8r.v  v24, (t3)
+
+    csrw sstatus, t5
+    ret
+
+// t5 -> cached sstatus
+// a0 -> pointer to VmCpuState
+// _save_vector saves vector state from a guest to
+// salus memory before returning to salus
+.align 2
+_save_vector:
+    // Save sstatus so we can enable vectors
+    csrr  t5, sstatus
+
+    // Enable vectors
+    li    t0, {sstatus_vs_enable}
+    csrrs zero, sstatus, t0
+
+    // Store csr's
+    csrr  t4, vcsr
+    sd t4, {guest_vcsr}(a0)
+    csrr t4, vstart
+    sd t4, {guest_vstart}(a0)
+    csrr t4, vtype
+    sd t4, {guest_vtype}(a0)
+    csrr t4, vl
+    sd t4, {guest_vl}(a0)
+
+    // Store register file
+    addi t3, a0, {guest_v0}
+    vs8r.v  v0, (t3)
+    addi t3, a0, {guest_v8}
+    vs8r.v  v8, (t3)
+    addi t3, a0, {guest_v16}
+    vs8r.v  v16, (t3)
+    addi t3, a0, {guest_v24}
+    vs8r.v  v24, (t3)
+
+    // Restore sstatus
+    csrw  sstatus, t5
+
+    ret


### PR DESCRIPTION
adds the VECTORS  environment variable to the Makefile
adds the vectors feature to the main crate and test-workload

uses rv64,v=on,vlen=256,elen=64 as the cpu

Currently, to work with vectors this requires a custom rust tool chain to fix a still open bug.