### PR TITLE
Attestation: Track and measure the TVM configuration

### DIFF
--- a/attestation/src/measurement.rs
+++ b/attestation/src/measurement.rs
@@ -380,6 +380,13 @@ impl<'a, D: Digest, H: HmacImpl<D>> AttestationManager<D, H> {
         self.measurements.write()[idx].extend(bytes, address)
     }
 
+    /// Extend the TVM pages measurement.
+    /// This is a extend_msmt_register wrapper, where the address is not
+    /// optional, and the measurement register is fixed to TvmPage.
+    pub fn extend_tvm_page(&self, bytes: &[u8], address: u64) -> Result<()> {
+        self.extend_msmt_register(MeasurementIndex::TvmPage, bytes, Some(address))
+    }
+
     fn attestation_tci(&self) -> GenericArray<u8, <D as OutputSizeUser>::OutputSize> {
         // The attestation TCI only includes the static measurements.
         let mut hasher = D::new();

--- a/attestation/src/measurement.rs
+++ b/attestation/src/measurement.rs
@@ -319,6 +319,16 @@ pub struct TvmConfiguration {
     entry_arg: u64,
 }
 
+impl TvmConfiguration {
+    fn set_epc(&mut self, epc: u64) {
+        self.entry_pc = epc;
+    }
+
+    fn set_arg(&mut self, a1: u64) {
+        self.entry_arg = a1;
+    }
+}
+
 /// The attestation manager.
 #[derive(Debug)]
 pub struct AttestationManager<D: Digest, H: HmacImpl<D> = hmac::Hmac<D>> {
@@ -508,5 +518,15 @@ impl<'a, D: Digest, H: HmacImpl<D>> AttestationManager<D, H> {
             public: (&secret).into(),
             secret,
         })
+    }
+
+    /// Set the TVM initial PC.
+    pub fn set_epc(&self, epc: u64) {
+        self.tvm_config.write().set_epc(epc);
+    }
+
+    /// Set the TVM initial argument (A1).
+    pub fn set_arg(&self, a1: u64) {
+        self.tvm_config.write().set_arg(a1);
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -287,8 +287,14 @@ impl<T: GuestStagePagingMode> Vm<T, VmStateInitializing> {
         let mut vcpu = vcpu.lock();
         use TvmCpuRegister::*;
         match register {
-            EntryPc => vcpu.set_sepc(value),
-            EntryArg => vcpu.set_gpr(GprIndex::A1, value),
+            EntryPc => {
+                self.attestation_mgr.set_epc(value);
+                vcpu.set_sepc(value);
+            }
+            EntryArg => {
+                self.attestation_mgr.set_arg(value);
+                vcpu.set_gpr(GprIndex::A1, value);
+            }
             _ => {
                 return Err(EcallError::Sbi(SbiError::Denied));
             }

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use attestation::measurement::{AttestationManager, MeasurementIndex};
+use attestation::measurement::AttestationManager;
 use core::arch::global_asm;
 use core::{marker::PhantomData, ops::Deref};
 use drivers::{imsic::*, iommu::*, pci::PciDevice, pci::PcieRoot};
@@ -370,11 +370,7 @@ impl<'a, T: GuestStagePagingMode> VmPagesMapper<'a, T, VmStateInitializing> {
         H: hkdf::HmacImpl<D>,
     {
         measurement
-            .extend_msmt_register(
-                MeasurementIndex::TvmPage,
-                page.as_bytes(),
-                Some(to_addr.bits()),
-            )
+            .extend_tvm_page(page.as_bytes(), to_addr.bits())
             .map_err(Error::Measurement)?;
         self.mapper.map_page(to_addr, page).map_err(Error::Paging)
     }


### PR DESCRIPTION
This PR tracks the TVM configuration bits (EPC and initial argument) and extends PCR3 with a measurement of that data when the TVM finalizes.

In order to include this measurement into the right PCR, this PR also includes a PCR mapping update and fix.