### PR TITLE
Initial SBI attestation update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,6 +549,7 @@ name = "sbi"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
+ "flagset",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
+ "sbi",
  "spin",
  "spki",
 ]
@@ -546,6 +547,9 @@ dependencies = [
 [[package]]
 name = "sbi"
 version = "0.1.0"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "scopeguard"

--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -16,5 +16,6 @@ generic-array = "0.14.5"
 hex = { version = "0.4.3", default-features = false }
 hkdf = "0.12.3"
 hmac = "0.12.1"
+sbi = { path = "../sbi" }
 spin = { version = "*", default-features = false, features = ["rwlock"] }
 spki = "0.6.0"

--- a/attestation/src/certificate.rs
+++ b/attestation/src/certificate.rs
@@ -22,7 +22,7 @@ use crate::{
     name::{Name, RdnSequence, RelativeDistinguishedName},
     request::CertReq,
     time::{Time, Validity},
-    Error, Result, MAX_CERT_ATV, MAX_CERT_EXTENSIONS, MAX_CERT_LEN, MAX_CERT_RDN,
+    Error, Result, MAX_CERT_ATV, MAX_CERT_EXTENSIONS, MAX_CERT_RDN,
 };
 
 /// Certificate `Version` as defined in [RFC 5280 Section 4.1].
@@ -255,7 +255,7 @@ impl<'a> Certificate<'a> {
         };
 
         // We can now sign the TBS and generate the actual certificate
-        let mut tbs_bytes_buffer = [0u8; MAX_CERT_LEN];
+        let mut tbs_bytes_buffer = [0u8; sbi::api::attestation::MAX_CERT_SIZE];
         let tbs_bytes = tbs_certificate
             .encode_to_slice(&mut tbs_bytes_buffer)
             .map_err(Error::InvalidDer)?;

--- a/attestation/src/lib.rs
+++ b/attestation/src/lib.rs
@@ -63,6 +63,9 @@ pub enum Error {
     /// Invalid measurement register index
     InvalidMeasurementRegisterIndex(usize),
 
+    /// Invalid measurement register descriptor index
+    InvalidMeasurementRegisterDescIndex(usize),
+
     /// Invalid data digest
     InvalidDigest(der::Error),
 

--- a/attestation/src/lib.rs
+++ b/attestation/src/lib.rs
@@ -6,9 +6,6 @@
 //! Pure Rust, heapless attestation crate.
 #![no_std]
 
-/// Maximum supported length for a certificate
-pub const MAX_CERT_LEN: usize = 4096;
-
 /// Maximum supported length for a CSR
 pub const MAX_CSR_LEN: usize = 4096;
 

--- a/attestation/src/verify.rs
+++ b/attestation/src/verify.rs
@@ -7,7 +7,7 @@ use ed25519::pkcs8::{DecodePublicKey, PublicKeyBytes};
 use ed25519_dalek::{PublicKey, Signature, Verifier};
 use spki::AlgorithmIdentifier;
 
-use crate::{request::CertReq, Error, Result, MAX_CERT_LEN};
+use crate::{request::CertReq, Error, Result, MAX_CSR_LEN};
 
 pub trait CertVerifier {
     /// Verifies a CSR signature
@@ -35,7 +35,7 @@ impl CertVerifier for Ed25519Verifier {
         let pub_key = PublicKey::from_bytes(&pub_key_bytes.to_bytes())
             .map_err(|_| Error::InvalidPublicKey)?;
 
-        let mut csr_info_bytes = [0u8; MAX_CERT_LEN];
+        let mut csr_info_bytes = [0u8; MAX_CSR_LEN];
         let csr_info = csr
             .info
             .encode_to_slice(&mut csr_info_bytes)

--- a/sbi/Cargo.toml
+++ b/sbi/Cargo.toml
@@ -5,8 +5,9 @@ license = "Apache-2.0"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-path = "./src/sbi.rs"
-
 [dependencies]
 arrayvec = { version = "0.7.2", default-features = false }
+flagset = "0.4.3"
+
+[lib]
+path = "./src/sbi.rs"

--- a/sbi/Cargo.toml
+++ b/sbi/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 
 [lib]
 path = "./src/sbi.rs"
+
+[dependencies]
+arrayvec = { version = "0.7.2", default-features = false }

--- a/sbi/src/api/attestation.rs
+++ b/sbi/src/api/attestation.rs
@@ -1,0 +1,62 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use arrayvec::ArrayVec;
+
+use crate::{
+    ecall_send, AttestationFunction, Error, EvidenceFormat, Result, SbiMessage,
+    EVIDENCE_DATA_BLOB_SIZE,
+};
+
+/// Maximum supported size for the attestation evidence certificate.
+pub const MAX_CERT_SIZE: usize = 4096;
+
+/// Get an attestation evidence.
+/// This function returns a serialized, DER formatted X.509 certificate.
+/// The attestation evidence is included as a certificate extension.
+///
+/// # Arguments
+///
+/// * `cert_request` - The [Certificate Signing Request]((https://datatracker.ietf.org/doc/html/rfc2986) buffer.
+/// * `request_data` - A data blob that will be included in the generated
+///                    certificate, as [UserNotice]((https://datatracker.ietf.org/doc/html/rfc2986)
+///                    X.509 certificate extension. This is typically used to
+///                    pass a cryptographic nonce.
+/// * `evidence_format` - The format of the attestation evidence as defined by [`EvidenceFormat`](crate::api::attestation::EvidenceFormat).
+pub fn get_evidence(
+    cert_request: &[u8],
+    request_data: &[u8],
+    evidence_format: EvidenceFormat,
+) -> Result<ArrayVec<u8, MAX_CERT_SIZE>> {
+    if request_data.len() != EVIDENCE_DATA_BLOB_SIZE {
+        return Err(Error::InvalidParam);
+    }
+
+    let mut cert_bytes = ArrayVec::<u8, MAX_CERT_SIZE>::new();
+    let msg = SbiMessage::Attestation(AttestationFunction::GetEvidence {
+        cert_request_addr: cert_request.as_ptr() as u64,
+        cert_request_size: cert_request.len() as u64,
+        request_data_addr: request_data.as_ptr() as u64,
+        evidence_format: evidence_format as u64,
+        cert_addr_out: (cert_bytes.as_ptr()) as u64,
+        cert_size: MAX_CERT_SIZE as u64,
+    });
+
+    // Safety: GetEvidence only reads the pages pointed to by `cert_request` and
+    // `request_data`. This is safe because they're owned by the borrowed slices
+    // passed as arguments.
+    // GetEvidence writes to a single reference to `cert_bytes``, which is
+    // defined in this scope.
+    let len = unsafe { ecall_send(&msg) }?;
+
+    // Safety: cert_bytes is backed by a MAX_CERT_SIZE array.
+    unsafe {
+        if len as usize > MAX_CERT_SIZE {
+            return Err(Error::Failed);
+        }
+        cert_bytes.set_len(len as usize);
+    };
+
+    Ok(cert_bytes)
+}

--- a/sbi/src/api/attestation.rs
+++ b/sbi/src/api/attestation.rs
@@ -5,12 +5,26 @@
 use arrayvec::ArrayVec;
 
 use crate::{
-    ecall_send, AttestationFunction, Error, EvidenceFormat, Result, SbiMessage,
-    EVIDENCE_DATA_BLOB_SIZE,
+    ecall_send, AttestationCapabilities, AttestationFunction, Error, EvidenceFormat, Result,
+    SbiMessage, EVIDENCE_DATA_BLOB_SIZE,
 };
 
 /// Maximum supported size for the attestation evidence certificate.
 pub const MAX_CERT_SIZE: usize = 4096;
+
+/// Get the attestation capabilities.
+pub fn get_capabilities() -> Result<AttestationCapabilities> {
+    let caps = AttestationCapabilities::default();
+    let msg = SbiMessage::Attestation(AttestationFunction::GetCapabilities {
+        caps_addr_out: (&caps as *const AttestationCapabilities) as u64,
+        caps_size: core::mem::size_of::<AttestationCapabilities>() as u64,
+    });
+
+    // Safety: &caps is the single reference to a variable defined in this scope.
+    unsafe { ecall_send(&msg) }?;
+
+    Ok(caps)
+}
 
 /// Get an attestation evidence.
 /// This function returns a serialized, DER formatted X.509 certificate.

--- a/sbi/src/api/mod.rs
+++ b/sbi/src/api/mod.rs
@@ -19,3 +19,6 @@ pub mod pmu;
 
 /// Base SBI inferfaces.
 pub mod base;
+
+/// Host interfaces for attestation.
+pub mod attestation;

--- a/sbi/src/attestation.rs
+++ b/sbi/src/attestation.rs
@@ -5,29 +5,149 @@
 use crate::error::*;
 use crate::function::*;
 
+use flagset::{flags, FlagSet};
+
 /// The data blob passed to the GetEvidence call must be 64 bytes long.
 pub const EVIDENCE_DATA_BLOB_SIZE: usize = 64;
 
-/// Attestation evidence formats.
-#[derive(Copy, Clone, Debug)]
-#[repr(u64)]
-pub enum EvidenceFormat {
-    /// Single layer DICE TCB
-    /// https://trustedcomputinggroup.org/resource/dice-attestation-architecture/
-    DiceTcbInfo = 0,
+/// The maximum number of measurement registers in the attestation capabilities.
+pub const MAX_MEASUREMENT_REGISTERS: usize = 32;
 
-    /// X.509 extension for multiple layers DICE TCB.
-    /// https://trustedcomputinggroup.org/resource/dice-attestation-architecture/
-    DiceMultiTcbInfo = 1,
+flags! {
+    /// Attestation evidence formats.
+    #[derive(Default)]
+    #[repr(u8)]
+    pub enum EvidenceFormat: u8 {
+        /// Single layer DICE TCB
+        /// https://trustedcomputinggroup.org/resource/dice-attestation-architecture/
+        #[default]
+        DiceTcbInfo = 1,
+        /// X.509 extension for multiple layers DICE TCB.
+        /// https://trustedcomputinggroup.org/resource/dice-attestation-architecture/
+        DiceMultiTcbInfo = 2,
+        /// Open DICE profile
+        /// https://pigweed.googlesource.com/open-dice/+/HEAD/docs/specification.md
+        OpenDice = 4,
+    }
+}
 
-    /// Open DICE profile
-    /// https://pigweed.googlesource.com/open-dice/+/HEAD/docs/specification.md
-    OpenDice = 2,
+/// A list of supported hash algorithms.
+#[derive(Copy, Clone, Default, Debug)]
+#[repr(u8)]
+pub enum HashAlgorithm {
+    /// SHA-384
+    #[default]
+    Sha384 = 1,
+    /// SHA-512
+    Sha512 = 2,
+}
+
+/// Attestation Capabilities
+///
+/// This structure exposes the supported attestation capabilities to the SBI
+/// GetCapabilities caller. It lets the caller know which hash algorithms,
+/// evidence formats, and measurements mappings the SBI implementation supports.
+#[repr(C)]
+#[derive(Default)]
+pub struct AttestationCapabilities {
+    /// The TCB Secure Version Number.
+    pub tcb_svn: u64,
+    /// The supported hash algorithm.
+    pub hash_algorithm: HashAlgorithm,
+    /// The supported evidence formats. This is a bitmap.
+    pub evidence_formats: FlagSet<EvidenceFormat>,
+    /// Number of static measurement registers.
+    pub static_measurements: u8,
+    /// Number of runtime measurement registers.
+    pub runtime_measurements: u8,
+    /// Array of all measurement register descriptors.
+    pub measurement_registers: [MeasurementRegisterDescriptor; MAX_MEASUREMENT_REGISTERS],
+}
+
+impl AttestationCapabilities {
+    /// Create new attestation capabilities structure.
+    pub fn new(
+        tcb_svn: u64,
+        hash_algorithm: HashAlgorithm,
+        evidence_formats: impl Into<FlagSet<EvidenceFormat>>,
+        static_measurements: u8,
+        runtime_measurements: u8,
+    ) -> Self {
+        AttestationCapabilities {
+            tcb_svn,
+            hash_algorithm,
+            evidence_formats: evidence_formats.into(),
+            static_measurements,
+            runtime_measurements,
+            ..Default::default()
+        }
+    }
+
+    /// Add a measurement register to the attestation capabilities.
+    pub fn add_measurement_register(
+        &mut self,
+        register: MeasurementRegisterDescriptor,
+        index: usize,
+    ) -> Result<&mut AttestationCapabilities> {
+        // We do not allow for a sparse measurement register array.
+        if index + 1 > (self.static_measurements + self.runtime_measurements) as usize {
+            return Err(Error::Failed);
+        }
+
+        *self
+            .measurement_registers
+            .get_mut(index)
+            .ok_or(Error::Failed)? = register;
+
+        Ok(self)
+    }
+}
+
+/// Measurement register descriptor.
+///
+/// This structure describes an attestation measurement register.
+/// The AttestationCapabilities structure includes an array of those descriptors
+/// for all the supported measurement registers.
+#[repr(C)]
+#[derive(Default)]
+pub struct MeasurementRegisterDescriptor {
+    tcb_layer_index: u8,
+    fwid_index: u8,
+    tcg_pcr_index: u8,
+    runtime: bool,
+}
+
+impl MeasurementRegisterDescriptor {
+    /// Create a new measurement register descriptor.
+    pub fn new(tcb_layer_index: u8, fwid_index: u8, tcg_pcr_index: u8, runtime: bool) -> Self {
+        MeasurementRegisterDescriptor {
+            tcb_layer_index,
+            fwid_index,
+            tcg_pcr_index,
+            runtime,
+        }
+    }
 }
 
 /// Functions provided by the attestation extension.
 #[derive(Copy, Clone)]
 pub enum AttestationFunction {
+    /// Get the SBI implementation attestation capabilities.
+    /// The attestation capabilities let the SBI implementations expose which
+    /// hash algorithm is being used for measurements, which evidence formats
+    /// are supported. The attestation capabilities structure also contains a
+    /// map of all  measurement registers.
+    ///
+    /// a6 = 0
+    /// a0 = Attestation capabilities buffer
+    /// a1 = Attestation capabilities buffer size
+    GetCapabilities {
+        /// a0 = Capabilities structure address
+        caps_addr_out: u64,
+        /// a1 = Capabilities structure length
+        caps_size: u64,
+    },
+
     /// Get an attestion evidence from a Certificate Signing Request (CSR)
     /// (https://datatracker.ietf.org/doc/html/rfc2986).
     /// The caller passes the CSR and its length through the first 2 arguments.
@@ -39,7 +159,7 @@ pub enum AttestationFunction {
     /// The fifthh argument is the address where the generated certificate will be placed.
     /// The evidence is formatted an x.509 DiceTcbInfo certificate extension
     ///
-    /// a6 = 0
+    /// a6 = 1
     /// a0 = CSR address
     /// a1 = CSR length
     /// a2 = Data blob address
@@ -65,7 +185,7 @@ pub enum AttestationFunction {
     /// TBD: Do we allow for a specific PCR index to be passed, or do we extend
     /// one dedicated PCR with all runtime extended measurements?
     ///
-    /// a6 = 0
+    /// a6 = 2
     /// a0 = Measurement entry address
     /// a1 = Measurement entry length
     ExtendMeasurement {
@@ -81,7 +201,12 @@ impl AttestationFunction {
     pub(crate) fn from_regs(args: &[u64]) -> Result<Self> {
         use AttestationFunction::*;
         match args[6] {
-            0 => Ok(GetEvidence {
+            0 => Ok(GetCapabilities {
+                caps_addr_out: args[0],
+                caps_size: args[1],
+            }),
+
+            1 => Ok(GetEvidence {
                 cert_request_addr: args[0],
                 cert_request_size: args[1],
                 request_data_addr: args[2],
@@ -90,7 +215,7 @@ impl AttestationFunction {
                 cert_size: args[5],
             }),
 
-            1 => Ok(ExtendMeasurement {
+            2 => Ok(ExtendMeasurement {
                 measurement_addr: args[0],
                 len: args[1],
             }),
@@ -104,6 +229,11 @@ impl SbiFunction for AttestationFunction {
     fn a6(&self) -> u64 {
         use AttestationFunction::*;
         match self {
+            GetCapabilities {
+                caps_addr_out: _,
+                caps_size: _,
+            } => 0,
+
             GetEvidence {
                 cert_request_addr: _,
                 cert_request_size: _,
@@ -111,12 +241,12 @@ impl SbiFunction for AttestationFunction {
                 evidence_format: _,
                 cert_addr_out: _,
                 cert_size: _,
-            } => 0,
+            } => 1,
 
             ExtendMeasurement {
                 measurement_addr: _,
                 len: _,
-            } => 1,
+            } => 2,
         }
     }
 
@@ -181,12 +311,18 @@ impl SbiFunction for AttestationFunction {
                 measurement_addr: _,
                 len,
             } => *len,
+            _ => 0,
         }
     }
 
     fn a1(&self) -> u64 {
         use AttestationFunction::*;
         match self {
+            GetCapabilities {
+                caps_addr_out: _,
+                caps_size,
+            } => *caps_size,
+
             GetEvidence {
                 cert_request_addr: _,
                 cert_request_size,
@@ -206,6 +342,11 @@ impl SbiFunction for AttestationFunction {
     fn a0(&self) -> u64 {
         use AttestationFunction::*;
         match self {
+            GetCapabilities {
+                caps_addr_out,
+                caps_size: _,
+            } => *caps_addr_out,
+
             GetEvidence {
                 cert_request_addr,
                 cert_request_size: _,

--- a/sbi/src/sbi.rs
+++ b/sbi/src/sbi.rs
@@ -170,6 +170,7 @@ impl SbiMessage {
             SbiMessage::Tee(f) => f.a5(),
             SbiMessage::TeeAia(f) => f.a5(),
             SbiMessage::Pmu(f) => f.a5(),
+            SbiMessage::Attestation(f) => f.a5(),
             _ => 0,
         }
     }
@@ -180,6 +181,7 @@ impl SbiMessage {
             SbiMessage::Tee(f) => f.a4(),
             SbiMessage::TeeAia(f) => f.a4(),
             SbiMessage::Pmu(f) => f.a4(),
+            SbiMessage::Attestation(f) => f.a4(),
             _ => 0,
         }
     }

--- a/test-workloads/src/bin/guestvm.rs
+++ b/test-workloads/src/bin/guestvm.rs
@@ -181,6 +181,18 @@ fn test_attestation() {
         return;
     }
 
+    let caps = attestation::get_capabilities().expect("Failed to get attestation capabilities");
+    println!(
+        "caps: SVN {:#x} Evidence formats {:?}",
+        caps.tcb_svn, caps.evidence_formats
+    );
+    if !caps
+        .evidence_formats
+        .contains(sbi::EvidenceFormat::DiceTcbInfo)
+    {
+        panic!("DICE TcbInfo format is not supported")
+    }
+
     if TEST_CSR.len() > MAX_CSR_LEN as usize {
         panic!("Test CSR is too large")
     }

--- a/test-workloads/src/bin/guestvm.rs
+++ b/test-workloads/src/bin/guestvm.rs
@@ -237,7 +237,7 @@ fn test_attestation() {
         .map(|fwids| fwids.get(TvmPage as usize).expect("Missing TVM page fwid"))
         .expect("Missing TVM fwids");
 
-    print!(
+    println!(
         "Certificate version:{:?} Issuer:{} Signature algorithm:{}",
         cert.tbs_certificate.version, cert.tbs_certificate.issuer, cert.signature_algorithm.oid
     );


### PR DESCRIPTION
This PR updates the `GetEvidence` function handler and adds a high level API for it.
It also adds a new function: `GetCapabilities`, that lets the attestation SBI callers know which attestation capabilities and features are available before calling into the rest of the API.

This partially fixes #77 