### PR TITLE
Fix an out-of-bounds store

### DIFF
--- a/s-mode-utils/src/lib.rs
+++ b/s-mode-utils/src/lib.rs
@@ -10,8 +10,7 @@
     allocator_api,
     alloc_error_handler,
     lang_items,
-    asm_const,
-    const_ptr_offset_from
+    asm_const
 )]
 
 pub use core::alloc::{GlobalAlloc, Layout};

--- a/src/guest_mem.S
+++ b/src/guest_mem.S
@@ -73,7 +73,7 @@ _fetch_guest_instruction:
 1:
     hlvx.hu t2, (a0)
     add_extable 1b
-    sw    t2, (a1)
+    sh    t2, (a1)
     addi  a0, a0, 2
     addi  a1, a1, 2
     // If it's a compressed instrution (bits [1:0] != 'b11) then we're done.
@@ -84,7 +84,7 @@ _fetch_guest_instruction:
 2:
     hlvx.hu t2, (a0)
     add_extable 2b
-    sw    t2, (a1)
+    sh    t2, (a1)
 3:
     mv    a0, zero
     ret

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@
     lang_items,
     if_let_guard,
     asm_const,
-    const_ptr_offset_from,
     ptr_sub_ptr,
     slice_ptr_get
 )]


### PR DESCRIPTION
`_fetch_guest_instruction` actually ends up writing 6 bytes when fetching a 32-bit instruction due to use of `sw` rather than `sh` for making a 16-bit store. Oops. This resulted in corruption of the neighboring 16-bit value on the stack, which was breaking `run_debian`.

Patch 2 is a trivial clippy fix, courtesy of sameo@.