### PR TITLE
salus: added save/restore for vector context on context switch

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -10,3 +10,10 @@ rustflags = [
     # new in 1.60 and generates false positives
     "-Aclippy::only_used_in_recursion",
 ]
+
+[target.riscv64gcv-unknown-none-elf]
+rustflags = [
+    '-Clink-arg=-Tlds/qemu.lds',
+    # new in 1.60 and generates false positives
+    "-Aclippy::only_used_in_recursion",
+]

--- a/PATCH.rust-vectors
+++ b/PATCH.rust-vectors
@@ -1,0 +1,84 @@
+diff --git a/library/std/src/sys/unsupported/locks/condvar.rs b/library/std/src/sys/unsupported/locks/condvar.rs
+index e703fd0d269..527a26a12bc 100644
+--- a/library/std/src/sys/unsupported/locks/condvar.rs
++++ b/library/std/src/sys/unsupported/locks/condvar.rs
+@@ -7,6 +7,7 @@ pub struct Condvar {}
+ 
+ impl Condvar {
+     #[inline]
++    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
+     pub const fn new() -> Condvar {
+         Condvar {}
+     }
+diff --git a/library/std/src/sys/unsupported/locks/mutex.rs b/library/std/src/sys/unsupported/locks/mutex.rs
+index d7cb12e0cf9..81b49c64cae 100644
+--- a/library/std/src/sys/unsupported/locks/mutex.rs
++++ b/library/std/src/sys/unsupported/locks/mutex.rs
+@@ -12,6 +12,7 @@ unsafe impl Sync for Mutex {} // no threads on this platform
+ 
+ impl Mutex {
+     #[inline]
++    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
+     pub const fn new() -> Mutex {
+         Mutex { locked: Cell::new(false) }
+     }
+diff --git a/library/std/src/sys/unsupported/locks/rwlock.rs b/library/std/src/sys/unsupported/locks/rwlock.rs
+index aca5fb7152c..5292691b955 100644
+--- a/library/std/src/sys/unsupported/locks/rwlock.rs
++++ b/library/std/src/sys/unsupported/locks/rwlock.rs
+@@ -12,6 +12,7 @@ unsafe impl Sync for RwLock {} // no threads on this platform
+ 
+ impl RwLock {
+     #[inline]
++    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
+     pub const fn new() -> RwLock {
+         RwLock { mode: Cell::new(0) }
+     }
+diff --git a/library/std/src/sys_common/condvar.rs b/library/std/src/sys_common/condvar.rs
+index f3ac1061b89..8bc5b24115d 100644
+--- a/library/std/src/sys_common/condvar.rs
++++ b/library/std/src/sys_common/condvar.rs
+@@ -15,6 +15,7 @@ pub struct Condvar {
+ impl Condvar {
+     /// Creates a new condition variable for use.
+     #[inline]
++    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
+     pub const fn new() -> Self {
+         Self { inner: imp::MovableCondvar::new(), check: CondvarCheck::new() }
+     }
+diff --git a/library/std/src/sys_common/condvar/check.rs b/library/std/src/sys_common/condvar/check.rs
+index ce8f3670487..4ac9e62bf86 100644
+--- a/library/std/src/sys_common/condvar/check.rs
++++ b/library/std/src/sys_common/condvar/check.rs
+@@ -50,6 +50,7 @@ impl CondvarCheck for imp::Mutex {
+ 
+ #[allow(dead_code)]
+ impl NoCheck {
++    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
+     pub const fn new() -> Self {
+         Self
+     }
+diff --git a/library/std/src/sys_common/mutex.rs b/library/std/src/sys_common/mutex.rs
+index 48479f5bdb3..7b9f7ef5487 100644
+--- a/library/std/src/sys_common/mutex.rs
++++ b/library/std/src/sys_common/mutex.rs
+@@ -61,6 +61,7 @@ unsafe impl Sync for MovableMutex {}
+ impl MovableMutex {
+     /// Creates a new mutex.
+     #[inline]
++    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
+     pub const fn new() -> Self {
+         Self(imp::MovableMutex::new())
+     }
+diff --git a/library/std/src/sys_common/rwlock.rs b/library/std/src/sys_common/rwlock.rs
+index ba56f3a8f1b..34e9a91e874 100644
+--- a/library/std/src/sys_common/rwlock.rs
++++ b/library/std/src/sys_common/rwlock.rs
+@@ -75,6 +75,7 @@ fn drop(&mut self) {
+ impl MovableRwLock {
+     /// Creates a new reader-writer lock for use.
+     #[inline]
++    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
+     pub const fn new() -> Self {
+         Self(imp::MovableRwLock::new())
+     }

--- a/README.md
+++ b/README.md
@@ -171,3 +171,11 @@ loaded it and passes the device tree to Salus.
 The above instructions use OpenSBI inbuilt in Qemu. If OpenSBI needs to be
 built from scratch, fw_dynamic should be used for `-bios` argument in the qemu
 commandline.
+
+### Vectors
+
+To run with the vector extension enabled requires a custom rust toolchain, due to a bug
+in nightly that prevents a no-std build with a custom target to not compile. Included in this
+directory is a patch file called PATCH.rust-vectors which should be applied to a rust compiler
+source code before building. Once you have you the custom toolchain configured, adding VECTORS=yes
+as an environment variable will cause the build to have the vector extension enabled.

--- a/drivers/src/cpu.rs
+++ b/drivers/src/cpu.rs
@@ -36,9 +36,11 @@ pub struct CpuInfo {
     has_sstc: bool,
     // True if the Sscofpmf extension is supported.
     has_sscofpmf: bool,
+    // True if the vector extension is supported
+    has_vector: bool,
     // CPU timer frequency.
     timer_frequency: u32,
-    // ISA string as reprted in the device-tree. All CPUs are expected to have the same ISA.
+    // ISA string as reported in the device-tree. All CPUs are expected to have the same ISA.
     isa_string: ArrayString<MAX_ISA_STRING_LEN>,
     // Mapping of logical CPU index to hart IDs.
     hart_ids: ArrayVec<u32, MAX_CPUS>,
@@ -77,6 +79,16 @@ fn intc_phandle_from_cpu_node(dt: &DeviceTree, node: &DeviceTreeNode) -> u32 {
 
 fn isa_string_has_extension(isa_string: &str, extension: &str) -> bool {
     isa_string.split('_').any(|f| f == extension)
+}
+
+fn isa_string_has_base_extension(isa_string: &str, extension: char) -> bool {
+    isa_string
+        .split('_')
+        .next()
+        .unwrap_or("rv32")
+        .chars()
+        .skip(4)
+        .any(|c| c == extension)
 }
 
 impl CpuInfo {
@@ -151,6 +163,7 @@ impl CpuInfo {
         let cpu_info = CpuInfo {
             has_sstc: isa_string_has_extension(isa_string, "sstc"),
             has_sscofpmf: isa_string_has_extension(isa_string, "sscofpmf"),
+            has_vector: isa_string_has_base_extension(isa_string, 'v'),
             isa_string: ArrayString::from(isa_string).unwrap(),
             timer_frequency,
             hart_ids,
@@ -173,6 +186,11 @@ impl CpuInfo {
     /// Returns true if the Sscofpmf extension is supported.
     pub fn has_sscofpmf(&self) -> bool {
         self.has_sscofpmf
+    }
+
+    /// Returns true if the vector extension is supported
+    pub fn has_vector(&self) -> bool {
+        self.has_vector
     }
 
     /// Returns the total number of CPUs.

--- a/riscv-regs/src/csrs/defs.rs
+++ b/riscv-regs/src/csrs/defs.rs
@@ -386,6 +386,41 @@ register_bitfields![u64,
     ]
 ];
 
+// Vector start position
+register_bitfields![u64,
+    pub vstart [
+        value OFFSET(0) NUMBITS(64) [],
+    ]
+];
+
+// Vector control and status register
+register_bitfields![u64,
+    pub vcsr [
+        value OFFSET(0) NUMBITS(64) [],
+    ]
+];
+
+// Vector length
+register_bitfields![u64,
+    pub vl [
+        value OFFSET(0) NUMBITS(64) [],
+    ]
+];
+
+// Vector data type register
+register_bitfields![u64,
+    pub vtype [
+        value OFFSET(0) NUMBITS(64) [],
+    ]
+];
+
+// VLEN/8 (vector register width in bytes)
+register_bitfields![u64,
+    pub vlenb [
+        value OFFSET(0) NUMBITS(64) [],
+    ]
+];
+
 pub trait HgatpHelpers {
     fn set_from<T: GuestStagePagingMode>(&mut self, pt_root: &GuestStagePageTable<T>, vmid: u64);
 }

--- a/riscv-regs/src/csrs/mod.rs
+++ b/riscv-regs/src/csrs/mod.rs
@@ -67,6 +67,12 @@ pub struct CSR {
     pub vsatp: ReadWriteRiscvCsr<satp::Register, CSR_VSATP>,
     pub vstopi: ReadWriteRiscvCsr<stopi::Register, 0xeb0>,
 
+    pub vstart: ReadWriteRiscvCsr<vstart::Register, 0x008>,
+    pub vcsr: ReadWriteRiscvCsr<vcsr::Register, 0x00F>,
+    pub vl: ReadWriteRiscvCsr<vl::Register, 0xC20>,
+    pub vtype: ReadWriteRiscvCsr<vtype::Register, 0xC21>,
+    pub vlenb: ReadWriteRiscvCsr<vlenb::Register, 0xC22>,
+
     pub hpmcounter: [&'static dyn RiscvCsrInterface<R = hpmcounter::Register>; 32],
 }
 
@@ -117,6 +123,12 @@ pub const CSR: &CSR = &CSR {
     vstopei: ReadWriteRiscvCsr::new(),
     vsatp: ReadWriteRiscvCsr::new(),
     vstopi: ReadWriteRiscvCsr::new(),
+
+    vstart: ReadWriteRiscvCsr::new(),
+    vcsr: ReadWriteRiscvCsr::new(),
+    vl: ReadWriteRiscvCsr::new(),
+    vtype: ReadWriteRiscvCsr::new(),
+    vlenb: ReadWriteRiscvCsr::new(),
 
     // TODO: Use a procedural macro to generate these.
     hpmcounter: [

--- a/riscv-regs/src/regs.rs
+++ b/riscv-regs/src/regs.rs
@@ -117,3 +117,22 @@ impl GeneralPurposeRegisters {
 #[derive(Default)]
 #[repr(C)]
 pub struct FloatingPointRegisters([u64; 32]);
+
+/// The vector register file. We don't expect to directly interact with a guest's vector state
+/// other than for saving/restoring the registers, so simply treat the register file as an array
+/// of 256b values. This actually depends on the vlenb csr, so if the register is greater than 256
+/// bits (i.e. the vlenb csr is greater than 32) we will need to increase this.
+
+// The width of a vector register in bytes
+pub const MAX_VECTOR_REGISTER: usize = 32;
+pub const fn u64s_in_register() -> usize {
+    MAX_VECTOR_REGISTER >> 3
+}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct VectorRegister([u64; u64s_in_register()]);
+
+#[derive(Default)]
+#[repr(C)]
+pub struct VectorRegisters([VectorRegister; 32]);

--- a/riscv64gcv-unknown-none-elf.json
+++ b/riscv64gcv-unknown-none-elf.json
@@ -1,0 +1,18 @@
+{
+  "arch": "riscv64",
+  "code-model": "medium",
+  "cpu": "generic-rv64",
+  "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n64-S128",
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "features": "+m,+a,+f,+d,+c,+v",
+  "is-builtin": false,
+  "linker": "rust-lld",
+  "linker-flavor": "ld.lld",
+  "llvm-abiname": "lp64d",
+  "llvm-target": "riscv64",
+  "max-atomic-width": 64,
+  "panic-strategy": "abort",
+  "relocation-model": "static",
+  "target-pointer-width": "64"
+}

--- a/src/vectors.S
+++ b/src/vectors.S
@@ -1,0 +1,112 @@
+.section .text.init
+.global _run_guest_vector,_guest_exit_vector
+
+// t5 -> cached sstatus
+// Restore vectors for guest
+// i.e. memory to main state
+.align 2
+_run_guest_vector:
+    
+    // Save sstatus
+    csrr t5, sstatus
+
+    // Enable vector commands
+    addi t4, zero, {sstatus_vs_enable}
+    csrrs zero, sstatus, t4
+
+    // Restore type and length
+    ld t1, ({guest_vl})(a0)
+    ld t2, ({guest_vtype})(a0)
+    vsetvl t0,t1,t2
+
+    // Restore vstart
+    ld t0, ({guest_vstart})(a0)
+    csrw vstart, t0
+
+    // Restore vcsr
+    ld t0, ({guest_vcsr})(a0)
+    csrw vcsr, t0
+
+    // Restore register file
+    addi t3, a0, {guest_v0}
+    vl8r.v  v0, (t3)
+    addi t3, a0, {guest_v8}
+    vl8r.v  v8, (t3)
+    addi t3, a0, {guest_v16}
+    vl8r.v  v16, (t3)
+    addi t3, a0, {guest_v24}
+    vl8r.v  v24, (t3)
+
+    csrw sstatus, t5
+    ret
+
+// t1 -> cached sstatus
+// Save vectors for guest
+// i.e. from guest to mem
+.align 2
+_guest_exit_vector:
+    // Save sstatus
+    csrr  t5, sstatus
+
+    // Get guest_sstatus (sstatus at exit)
+    ld    t1, {guest_sstatus}(a0)
+
+    
+    // if !(sstatus & sstatus) return
+    li    t0, {sstatus_vs_dirty}
+    and   t2, t1, t0
+    bne   t2, t0, _guest_exit_vector_return
+    
+    // Set sstatus value to clean
+    not   t0, t0
+    and   t1, t1, t0
+    li    t0, {sstatus_vs_clean}
+    or    t1, t1, t0
+
+    // Enable vectors
+    li    t0, {sstatus_vs_enable}
+    csrrs zero, sstatus, t0
+
+    // Store csr's
+    csrr  t4, vcsr
+    sd t4, {guest_vcsr}(a0)
+
+    csrr t4, vstart
+    sd t4, {guest_vstart}(a0)
+
+    csrr t4, vtype
+    sd t4, {guest_vtype}(a0)
+
+    csrr t4, vl
+    sd t4, {guest_vl}(a0)
+
+    // Store register file
+    addi t3, a0, {guest_v0}
+    vs8r.v  v0, (t3)
+    addi t3, a0, {guest_v8}
+    vs8r.v  v8, (t3)
+    addi t3, a0, {guest_v16}
+    vs8r.v  v16, (t3)
+    addi t3, a0, {guest_v24}
+    vs8r.v  v24, (t3)
+
+    // For debugging only: clear out vector registers 
+    // to be sure they are restored correctly.
+    // TODO: Remove this before going into production.
+    vmv.v.i v0, 0
+    vmv.v.i v4, 0
+    vmv.v.i v8, 0
+    vmv.v.i v12, 0
+    vmv.v.i v16, 0
+    vmv.v.i v20, 0
+    vmv.v.i v24, 0
+    vmv.v.i v28, 0
+
+    // Save corrected guest_sstatus
+    sd t1, {guest_sstatus}(a0)
+
+    // Restore sstatus
+    csrw  sstatus, t5
+
+_guest_exit_vector_return:
+    ret

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -12,6 +12,9 @@ use riscv_page_tables::GuestStagePagingMode;
 use riscv_pages::{
     GuestPhysAddr, GuestVirtAddr, InternalClean, PageOwnerId, RawAddr, SequentialPages,
 };
+#[cfg(target_feature = "v")]
+use riscv_regs::VectorRegister;
+use riscv_regs::VectorRegisters;
 use riscv_regs::{hstatus, scounteren, sstatus};
 use riscv_regs::{
     Exception, FloatingPointRegisters, GeneralPurposeRegisters, GprIndex, LocalRegisterCopy,
@@ -62,11 +65,17 @@ struct HostCpuState {
 struct GuestCpuState {
     gprs: GeneralPurposeRegisters,
     fprs: FloatingPointRegisters,
+    vprs: VectorRegisters,
     fcsr: u64,
     sstatus: u64,
     hstatus: u64,
     scounteren: u64,
     sepc: u64,
+
+    vstart: u64,
+    vcsr: u64,
+    vtype: u64,
+    vl: u64,
 }
 
 /// The CSRs that are only in effect when virtualization is enabled (V=1) and must be saved and
@@ -122,6 +131,12 @@ extern "C" {
     fn _restore_fp(state: *mut VmCpuState);
 }
 
+#[cfg(target_feature = "v")]
+extern "C" {
+    fn _run_guest_vector(g: *mut VmCpuState);
+    fn _guest_exit_vector(g: *mut VmCpuState);
+}
+
 #[allow(dead_code)]
 const fn host_gpr_offset(index: GprIndex) -> usize {
     offset_of!(VmCpuState, host_regs)
@@ -138,6 +153,13 @@ const fn guest_gpr_offset(index: GprIndex) -> usize {
 
 const fn guest_fpr_offset(index: usize) -> usize {
     offset_of!(VmCpuState, guest_regs) + offset_of!(GuestCpuState, fprs) + index * size_of::<u64>()
+}
+
+#[cfg(target_feature = "v")]
+const fn guest_vpr_offset(index: usize) -> usize {
+    offset_of!(VmCpuState, guest_regs)
+        + offset_of!(GuestCpuState, vprs)
+        + index * size_of::<VectorRegister>()
 }
 
 macro_rules! host_csr_offset {
@@ -253,6 +275,23 @@ global_asm!(
     guest_sepc = const guest_csr_offset!(sepc),
 );
 
+#[cfg(target_feature = "v")]
+global_asm!(
+    include_str!("vectors.S"),
+    guest_v0 =     const guest_vpr_offset(0),
+    guest_v8 =     const guest_vpr_offset(8),
+    guest_v16 =    const guest_vpr_offset(16),
+    guest_v24 =    const guest_vpr_offset(24),
+    guest_vstart = const guest_csr_offset!(vstart),
+    guest_vcsr =   const guest_csr_offset!(vcsr),
+    guest_vtype =  const guest_csr_offset!(vtype),
+    guest_vl =     const guest_csr_offset!(vl),
+    guest_sstatus = const guest_csr_offset!(sstatus),
+    sstatus_vs_dirty = const sstatus::vs::Dirty.value,
+    sstatus_vs_clean = const sstatus::vs::Clean.value,
+    sstatus_vs_enable = const 0x200,
+);
+
 /// Identifies the exit cause for a vCPU.
 pub enum VmCpuExit {
     /// ECALLs from VS mode.
@@ -295,6 +334,26 @@ pub struct ActiveVmCpu<'vcpu, 'pages, 'prev, T: GuestStagePagingMode> {
     // The parent vCPU which activated us.
     parent_vcpu: Option<&'prev mut dyn VmCpuSaveState>,
 }
+
+#[cfg(target_feature = "v")]
+fn run_guest_vector(_state: *mut VmCpuState) {
+    unsafe {
+        // safe because the only memory it touches is known offsets of _state
+        _run_guest_vector(_state);
+    }
+}
+#[cfg(target_feature = "v")]
+fn guest_exit_vector(_state: *mut VmCpuState) {
+    unsafe {
+        // safe because the only memory it touches is known offsets of _state
+        _guest_exit_vector(_state);
+    }
+}
+
+#[cfg(not(target_feature = "v"))]
+fn run_guest_vector(_state: *mut VmCpuState) {}
+#[cfg(not(target_feature = "v"))]
+fn guest_exit_vector(_state: *mut VmCpuState) {}
 
 impl<'vcpu, 'pages, 'prev, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, 'prev, T> {
     // Restores and activates the vCPU state from `vcpu`, with the VM address space represented by
@@ -340,6 +399,12 @@ impl<'vcpu, 'pages, 'prev, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, '
 
         // TODO: Enforce that the vCPU has an assigned interrupt file before running.
 
+        let has_vector = CpuInfo::get().has_vector();
+
+        if has_vector {
+            run_guest_vector(&mut self.state as *mut VmCpuState);
+        }
+
         unsafe {
             // Safe since _restore_fp() only reads within the bounds of the floating point
             // register state in VmCpuState.
@@ -348,6 +413,10 @@ impl<'vcpu, 'pages, 'prev, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, '
             // Safe to run the guest as it only touches memory assigned to it by being owned
             // by its page table.
             _run_guest(&mut self.state);
+        }
+
+        if has_vector {
+            guest_exit_vector(&mut self.state as *mut VmCpuState);
         }
 
         // Save off the trap information.
@@ -701,6 +770,8 @@ impl VmCpu {
         let mut sstatus = LocalRegisterCopy::<u64, sstatus::Register>::new(0);
         sstatus.modify(sstatus::spp::Supervisor);
         sstatus.modify(sstatus::fs::Initial);
+        #[cfg(target_feature = "v")]
+        sstatus.modify(sstatus::vs::Initial);
         state.guest_regs.sstatus = sstatus.get();
 
         let mut scounteren = LocalRegisterCopy::<u64, scounteren::Register>::new(0);

--- a/test-workloads/src/bin/guestvm.rs
+++ b/test-workloads/src/bin/guestvm.rs
@@ -46,6 +46,126 @@ pub fn alloc_error(_layout: Layout) -> ! {
     abort()
 }
 
+#[cfg(target_feature = "v")]
+pub fn print_vector_csrs() {
+    let mut vl: u64;
+    let mut vcsr: u64;
+    let mut vtype: u64;
+    let mut vlenb: u64;
+
+    unsafe {
+        // safe because we are only reading csr's
+        asm!(
+        "csrrs {vl}, vl, zero",
+        "csrrs {vcsr}, vcsr, zero",
+        "csrrs {vtype}, vtype, zero",
+        "csrrs {vlenb}, vlenb, zero",
+        vlenb = out(reg) vlenb,
+        vl= out(reg) vl,
+        vcsr = out(reg) vcsr,
+        vtype = out(reg) vtype,
+        options(nostack)
+        );
+    }
+    println!("vl    {}", vl);
+    println!("vlenb {}", vlenb);
+    println!("vcsr  {:#x}", vcsr);
+    println!("vtype {:#x}", vtype);
+}
+
+#[cfg(target_feature = "v")]
+pub fn test_vector() {
+    let vec_len: u64 = 8;
+    let vtype: u64 = 0xda;
+    let enable: u64 = 0x200;
+
+    unsafe {
+        // safe because we are only setting a bit in a csr
+        asm!(
+        "csrrs zero, sstatus, {enable}",
+        enable = in(reg) enable,
+        );
+    }
+    println!("Vectors Enabled");
+    print_vector_csrs();
+
+    unsafe {
+        // safe because we are only setting the vector csr's
+        asm!(
+        "vsetvl x0, {vec_len}, {vtype}",
+        vec_len = in(reg) vec_len,
+        vtype = in(reg) vtype,
+        options(nostack),
+        )
+    }
+
+    print_vector_csrs();
+
+    const REG_WIDTH_IN_U64S: usize = 4;
+
+    let mut inbuf = [0_u64; (32 * REG_WIDTH_IN_U64S)];
+    let mut refbuf = [0_u64; (32 * REG_WIDTH_IN_U64S)];
+    for i in 0..inbuf.len() {
+        inbuf[i] = 1 << (i % 53) as u64;
+        refbuf[i] = inbuf[i];
+    }
+
+    let bufp1 = inbuf.as_ptr();
+    let bufp2: *const u64;
+    let bufp3: *const u64;
+    let bufp4: *const u64;
+    unsafe {
+        // safe because we don't go past the length of inbuf
+        bufp2 = bufp1.add(8 * REG_WIDTH_IN_U64S);
+        bufp3 = bufp1.add(16 * REG_WIDTH_IN_U64S);
+        bufp4 = bufp1.add(24 * REG_WIDTH_IN_U64S);
+    }
+    println!("Loading vector registers");
+    unsafe {
+        // safe because the assembly reads into the vector register file
+        asm!(
+        "vl8r.v  v0, ({bufp1})",
+        "vl8r.v  v8, ({bufp2})",
+        "vl8r.v  v16, ({bufp3})",
+        "vl8r.v  v24, ({bufp4})",
+        bufp1 = in(reg) bufp1,
+        bufp2 = in(reg) bufp2,
+        bufp3 = in(reg) bufp3,
+        bufp4 = in(reg) bufp4,
+        options(nostack));
+    }
+
+    print_vector_csrs();
+
+    // Overwrite memory to verify that it changes
+    for i in 0..inbuf.len() {
+        inbuf[i] = 99_u64;
+    }
+
+    println!("reading vector registers");
+    unsafe {
+        // safe because enough memory provided to store entire register file
+        asm! {
+        "vs8r.v  v0, ({bufp1})",
+        "vs8r.v  v8, ({bufp2})",
+        "vs8r.v  v16, ({bufp3})",
+        "vs8r.v  v24, ({bufp4})",
+        bufp1 = in(reg) bufp1,
+        bufp2 = in(reg) bufp2,
+        bufp3 = in(reg) bufp3,
+        bufp4 = in(reg) bufp4,
+        options(nostack)}
+    }
+    print_vector_csrs();
+
+    println!("Verify registers");
+    for i in 0..inbuf.len() {
+        if inbuf[i] != refbuf[i] {
+            println!("error:  {} {} {}", i, refbuf[i], inbuf[i]);
+        }
+    }
+}
+
 /// Test `CertReq` encoded as ASN.1 DER
 const TEST_CSR: &[u8] = include_bytes!("test-ed25519.der");
 
@@ -167,6 +287,9 @@ extern "C" fn kernel_init(_hart_id: u64, shared_page_addr: u64) {
             core::ptr::write_volatile(shared_page_addr as *mut u64, GUEST_SHARE_PONG);
         }
     }
+
+    #[cfg(target_feature = "v")]
+    test_vector();
 
     // Try reading and writing MMIO.
     let write_ptr = GUEST_MMIO_ADDRESS as *mut u32;

--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -436,6 +436,11 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
                     sbi::TvmCpuExitCode::WaitForInterrupt => {
                         continue;
                     }
+                    sbi::TvmCpuExitCode::UnhandledException => {
+                        let cause0 = get_vcpu_reg(vmid, sbi::TvmCpuRegister::ExitCause0);
+                        println!("Tellus - Unhandled exception {:#x}", cause0);
+                        break;
+                    }
                     _ => {
                         println!("Tellus - Guest exited with status {:?}", cause);
                         break;


### PR DESCRIPTION
-added support for compiler target with vector extension
-various additions for vector registers
-runtime checking that we can support register width
-test code to check register restor and save
-extended some error messages in tellus