### PR TITLE
Use shared-memory to handle vCPU exits

### DIFF
--- a/device-tree/src/device_tree.rs
+++ b/device-tree/src/device_tree.rs
@@ -17,7 +17,7 @@ use crate::{DeviceTreeError, DeviceTreeResult, Fdt};
 fn copy_string_with_null_termination(dest: &mut Vec<u8>, src: &str) -> DeviceTreeResult<()> {
     let has_null = src.ends_with('\0');
     dest.truncate(0);
-    dest.try_reserve(src.len() + if has_null { 0 } else { 1 })?;
+    dest.try_reserve(src.len() + usize::from(!has_null))?;
     dest.splice(0.., src.bytes());
     if !has_null {
         dest.push(b'\0');

--- a/page-tracking/src/page_list.rs
+++ b/page-tracking/src/page_list.rs
@@ -94,6 +94,11 @@ impl<P: PhysPage> PageList<P> {
         self.len
     }
 
+    /// Returns the address of the page at the head of the list.
+    pub fn peek(&self) -> Option<SupervisorPageAddr> {
+        self.head
+    }
+
     /// Returns if the list of pages is contiguous.
     pub fn is_contiguous(&self) -> bool {
         if self.head.is_none() {

--- a/riscv-regs/src/regs.rs
+++ b/riscv-regs/src/regs.rs
@@ -17,8 +17,12 @@ pub struct GeneralPurposeRegisters([u64; 32]);
 pub enum GprIndex {
     Zero = 0,
     RA,
+    SP,
     GP,
     TP,
+    T0,
+    T1,
+    T2,
     S0,
     S1,
     A0,
@@ -39,14 +43,10 @@ pub enum GprIndex {
     S9,
     S10,
     S11,
-    T0,
-    T1,
-    T2,
     T3,
     T4,
     T5,
     T6,
-    SP,
 }
 
 impl GprIndex {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -25,7 +25,10 @@ use sbi::{
 
 use crate::guest_tracking::{GuestStateGuard, GuestVm, Guests, Result as GuestTrackingResult};
 use crate::smp;
-use crate::vm_cpu::{ActiveVmCpu, VirtualRegister, VmCpuExit, VmCpuStatus, VmCpus, VM_CPU_BYTES};
+use crate::vm_cpu::{
+    ActiveVmCpu, VirtualRegister, VmCpuExit, VmCpuStatus, VmCpus, VM_CPU_BYTES,
+    VM_CPU_SHARED_LAYOUT,
+};
 use crate::vm_pages::Error as VmPagesError;
 use crate::vm_pages::{
     ActiveVmPages, AnyVmPages, InstructionFetchError, PageFaultType, VmPages, VmPagesRef,
@@ -1040,7 +1043,18 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
             TvmCpuRun { guest_id, vcpu_id } => {
                 self.guest_run_vcpu(guest_id, vcpu_id, active_vcpu).into()
             }
-            TvmCpuGetMemLayout { .. } => Err(EcallError::Sbi(SbiError::NotSupported)).into(),
+            TvmCpuGetMemLayout {
+                guest_id,
+                layout_addr,
+                layout_len,
+            } => self
+                .guest_get_vcpu_mem_layout(
+                    guest_id,
+                    layout_addr,
+                    layout_len,
+                    active_vcpu.active_pages(),
+                )
+                .into(),
             TvmCpuCreate {
                 guest_id,
                 vcpu_id,
@@ -1321,6 +1335,34 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
         // TODO: Should the boot vCPU be specified explicilty?
         guest_vm.power_on_vcpu(0)?;
         Ok(0)
+    }
+
+    // Writes the vCPU shared-memory state area layout to `layout_addr`.
+    fn guest_get_vcpu_mem_layout(
+        &self,
+        guest_id: u64,
+        layout_addr: u64,
+        layout_len: u64,
+        active_pages: &ActiveVmPages<T>,
+    ) -> EcallResult<u64> {
+        // All guests have the same layout since we don't support customization of virtualized
+        // features currently, but make sure that the specified guest_id is at least valid.
+        self.guest_by_id(guest_id)?;
+
+        let required_len = VM_CPU_SHARED_LAYOUT.len() * mem::size_of::<sbi::RegisterSetLocation>();
+        if (layout_len as usize) < required_len {
+            return Err(EcallError::Sbi(SbiError::InsufficientBufferCapacity));
+        }
+        // Safety: VM_CPU_SHARED_LAYOUT is valid, properly initialized for `required_len` bytes,
+        // and is not mutated.
+        let layout_bytes = unsafe {
+            core::slice::from_raw_parts(VM_CPU_SHARED_LAYOUT.as_ptr().cast(), required_len)
+        };
+        let layout_addr = RawAddr::guest(layout_addr, self.page_owner_id());
+        active_pages
+            .copy_to_guest(layout_addr, layout_bytes)
+            .map_err(EcallError::from)?;
+        Ok(required_len as u64)
     }
 
     /// Adds a vCPU with `vcpu_id` to a guest VM.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1040,7 +1040,12 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
             TvmCpuRun { guest_id, vcpu_id } => {
                 self.guest_run_vcpu(guest_id, vcpu_id, active_vcpu).into()
             }
-            TvmCpuCreate { guest_id, vcpu_id } => self.guest_add_vcpu(guest_id, vcpu_id).into(),
+            TvmCpuGetMemLayout { .. } => Err(EcallError::Sbi(SbiError::NotSupported)).into(),
+            TvmCpuCreate {
+                guest_id,
+                vcpu_id,
+                shared_page_addr: _,
+            } => self.guest_add_vcpu(guest_id, vcpu_id).into(),
             TvmCpuSetRegister {
                 guest_id,
                 vcpu_id,

--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -328,7 +328,13 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     next_page += PAGE_SIZE_4K * NUM_TEE_PTE_PAGES;
 
     // Add vCPU0.
-    tsm::add_vcpu(vmid, 0).expect("Tellus - TvmCpuCreate returned error");
+    //
+    // TODO: Properly size and use vcpu_state once it's implemented on the TSM side.
+    let vcpu_state_addr = next_page;
+    next_page += PAGE_SIZE_4K;
+    // Safety: We own `vcpu_state_addr` and will only access it through volatile reads/writes.
+    unsafe { tsm::add_vcpu(vmid, 0, vcpu_state_addr) }
+        .expect("Tellus - TvmCpuCreate returned error");
 
     let has_aia = base::probe_sbi_extension(EXT_TEE_AIA).is_ok();
     // CPU0, guest interrupt file 0.


### PR DESCRIPTION
This patch defines the shared-memory structure used to communicate non-confidential state between the TSM and host, and the API to register it.

Two open questions:
 - Should we try to replicate more standard RISC-V registers, or continue to use the custom fields/values we've defined previously? i.e. use sanitized `scause`, `htval`, `htinst`, etc values rather than our custom `exit_cause0`/`exit_cause1` plus associated enums. The former will have better re-use with any sort of nested virtualization extension (and existing KVM code in general), while the latter will be more space efficient and theoretically mean less work for the OS/VMM to do on vCPU exit (e.g. no need to decode instructions again, or look up if a page fault is confidential or not). I ended up going with the standard RISC-V register approach here to reduce the overall surface area of the API. (I realize that my re-use of `htinst` for WFI isn't standard-compliant.)
  - Do we want to reserve entire pages for these shared memory structs, or let the OS/VMM place them wherever they want (in non-confidential memory, of course)? I'm leaning towards the latter since it's mostly informational for the OS/VMM, i.e. causing the structs to overlap or otherwise place them somewhere where they could be freely read/written won't violate the confidentiality of a TVM.

Thoughts?