### PR TITLE
Use wrapper types to encode Vm & VmPages state

### DIFF
--- a/src/host_vm_loader.rs
+++ b/src/host_vm_loader.rs
@@ -11,7 +11,7 @@ use riscv_page_tables::GuestStagePagingMode;
 use riscv_pages::*;
 use s_mode_utils::print::*;
 
-use crate::vm::{HostVm, VmStateFinalized, VmStateInitializing};
+use crate::vm::HostVm;
 
 // Where the kernel, initramfs, and FDT will be located in the guest physical address space.
 //
@@ -146,7 +146,7 @@ pub struct HostVmLoader<T: GuestStagePagingMode> {
     hypervisor_dt: DeviceTree,
     kernel: HwMemRegion,
     initramfs: Option<HwMemRegion>,
-    vm: HostVm<T, VmStateInitializing>,
+    vm: HostVm<T>,
     fdt_pages: FdtPages,
     zero_pages: PageList<Page<ConvertedClean>>,
     guest_ram_base: GuestPhysAddr,
@@ -247,7 +247,7 @@ impl<T: GuestStagePagingMode> HostVmLoader<T> {
     }
 
     /// Constructs the address space for the host VM, returning a `HostVm` that is ready to run.
-    pub fn build_address_space(mut self) -> HostVm<T, VmStateFinalized> {
+    pub fn build_address_space(mut self) -> HostVm<T> {
         let imsic = Imsic::get();
         let cpu_info = CpuInfo::get();
         // Map the IMSIC interrupt files into the guest address space. The host VM's interrupt
@@ -360,6 +360,7 @@ impl<T: GuestStagePagingMode> HostVmLoader<T> {
                 .unwrap(),
             self.guest_ram_base.checked_increment(FDT_OFFSET).unwrap(),
         );
-        self.vm.finalize().unwrap()
+        self.vm.finalize().unwrap();
+        self.vm
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,8 @@
     asm_const,
     ptr_sub_ptr,
     slice_ptr_get,
-    let_chains
+    let_chains,
+    is_some_with
 )]
 
 use core::alloc::{Allocator, GlobalAlloc, Layout};

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -29,7 +29,7 @@ use crate::smp;
 use crate::vm_cpu::{ActiveVmCpu, VirtualRegister, VmCpuExit, VmCpuStatus, VmCpus, VM_CPU_BYTES};
 use crate::vm_pages::Error as VmPagesError;
 use crate::vm_pages::{
-    ActiveVmPages, InstructionFetchError, PageFaultType, VmPages, VmRegionList, VmRegionType,
+    ActiveVmPages, InstructionFetchError, PageFaultType, VmPages, VmRegionList,
     TVM_REGION_LIST_PAGES, TVM_STATE_PAGES,
 };
 
@@ -1851,7 +1851,7 @@ impl<T: GuestStagePagingMode> HostVm<T, VmStateInitializing> {
         let mapper = self
             .inner
             .vm_pages
-            .map_pages(to_addr, pages.len() as u64, VmRegionType::Confidential)
+            .map_measured_pages(to_addr, pages.len() as u64)
             .unwrap();
         for (page, vm_addr) in pages.zip(to_addr.iter_from()) {
             assert_eq!(page.size(), PageSize::Size4k);
@@ -1863,7 +1863,7 @@ impl<T: GuestStagePagingMode> HostVm<T, VmStateInitializing> {
                 .assign_page_for_mapping(page, self.inner.page_owner_id())
                 .unwrap();
             mapper
-                .map_page_with_measurement(vm_addr, mappable, &self.inner.attestation_mgr)
+                .map_page(vm_addr, mappable, &self.inner.attestation_mgr)
                 .unwrap();
         }
     }
@@ -1879,7 +1879,7 @@ impl<T: GuestStagePagingMode> HostVm<T, VmStateInitializing> {
         let mapper = self
             .inner
             .vm_pages
-            .map_pages(to_addr, pages.len() as u64, VmRegionType::Confidential)
+            .map_zero_pages(to_addr, pages.len() as u64)
             .unwrap();
         for (page, vm_addr) in pages.zip(to_addr.iter_from()) {
             assert_eq!(page.size(), PageSize::Size4k);
@@ -1917,7 +1917,7 @@ impl<T: GuestStagePagingMode> HostVm<T, VmStateInitializing> {
         let mapper = self
             .inner
             .vm_pages
-            .map_pages(to_addr, pages.len() as u64, VmRegionType::Imsic)
+            .map_imsic_pages(to_addr, pages.len() as u64)
             .unwrap();
         let page_tracker = self.inner.vm_pages.page_tracker();
         for (i, (page, vm_addr)) in pages.zip(to_addr.iter_from()).enumerate() {
@@ -1936,7 +1936,7 @@ impl<T: GuestStagePagingMode> HostVm<T, VmStateInitializing> {
             let mappable = page_tracker
                 .assign_page_for_mapping(page, self.inner.page_owner_id())
                 .unwrap();
-            mapper.map_imsic_page(vm_addr, mappable).unwrap();
+            mapper.map_page(vm_addr, mappable).unwrap();
         }
     }
 
@@ -1951,7 +1951,7 @@ impl<T: GuestStagePagingMode> HostVm<T, VmStateInitializing> {
         let mapper = self
             .inner
             .vm_pages
-            .map_pages(to_addr, pages.len() as u64, VmRegionType::Pci)
+            .map_pci_pages(to_addr, pages.len() as u64)
             .unwrap();
         for (page, vm_addr) in pages.zip(to_addr.iter_from()) {
             assert_eq!(page.size(), PageSize::Size4k);

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -761,6 +761,11 @@ impl<T: GuestStagePagingMode> VmPages<T> {
         self.page_owner_id
     }
 
+    /// Returns the global page tracking structure.
+    pub fn page_tracker(&self) -> PageTracker {
+        self.page_tracker.clone()
+    }
+
     /// Returns a `VmPagesRef` to `self` in state `S`. The caller must ensure that `S` matches
     /// the current state of the VM to which this `VmPages` belongs.
     pub fn as_ref<S>(&self) -> VmPagesRef<T, S> {
@@ -797,7 +802,7 @@ impl<'a, T: GuestStagePagingMode, S> VmPagesRef<'a, T, S> {
 
     /// Returns the global page tracking structure.
     pub fn page_tracker(&self) -> PageTracker {
-        self.inner.page_tracker.clone()
+        self.inner.page_tracker()
     }
 
     /// Returns this VM's IMSIC geometry if it was set up for IMSIC virtualization.
@@ -1043,7 +1048,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVmPages<'a, T> {
         state_addr: GuestPageAddr,
         vcpus_addr: GuestPageAddr,
         num_vcpu_pages: u64,
-    ) -> Result<(Vm<T, VmStateInitializing>, Page<InternalClean>)> {
+    ) -> Result<(Vm<T>, Page<InternalClean>)> {
         if (page_root_addr.bits() as *const u64).align_offset(T::TOP_LEVEL_ALIGN as usize) != 0 {
             return Err(Error::UnalignedAddress);
         }


### PR DESCRIPTION
While encoding the state of the VM as a type parameter in `Vm` and `VmPages` creates clean separation between the APIs in each state, it means that transitions between states require consuming (and as a result, copying) these large structs. Introduce wrapper `VmRef` / `VmPagesRef` types which expose the appropriate functionality for the current state of the VM instead, which still gets us the nice API separation with an extra layer of indirection. This is a pre-requisite to #65, and will enable us to do in-place initialization of these structs.

Patches 1-3 are small cleanups which enable patch 4 (wrapper state types for `VmPages`) and patch 5 (wrapper state types for `Vm`).