### PR TITLE
PageBox: Support sequential pages as backing

### DIFF
--- a/page-tracking/src/collections/page_arc.rs
+++ b/page-tracking/src/collections/page_arc.rs
@@ -71,7 +71,7 @@ impl<T> PageArc<T> {
         // Safety: PageArcInner is repr(C) with data as the first field, therefore a pointer to data
         // is a page-aligned and properly initialized pointer to T.
         let boxed =
-            unsafe { PageBox::from_raw(Self::as_ptr(&this) as *mut T, page_size, page_tracker) };
+            unsafe { PageBox::from_raw(Self::as_ptr(&this) as *mut T, page_size, 1, page_tracker) };
         core::mem::forget(this);
         Ok(boxed)
     }


### PR DESCRIPTION
First PR to check early I am on the right path.

This PR is the first step to being able to put a vCPU structure (that's already bigger than a page and expected to grow rather than shrink) inside a page box. 

1. Use SequentialPages as backing rather than a single page.
2. Add test cases for single and multiple pages.