### PR TITLE
Rework vCPU shared memory register set enumeration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
 name = "test_workloads"
 version = "0.1.0"
 dependencies = [
+ "arrayvec",
  "attestation",
  "der",
  "device_tree",

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -317,18 +317,15 @@ pub struct VmCpuSharedState {
 pub const VM_CPU_SHARED_LAYOUT: &[sbi::RegisterSetLocation] = &[
     sbi::RegisterSetLocation {
         id: sbi::RegisterSetId::Gprs as u16,
-        version: 0,
-        offset: offset_of!(VmCpuSharedState, gprs) as u32,
+        offset: offset_of!(VmCpuSharedState, gprs) as u16,
     },
     sbi::RegisterSetLocation {
         id: sbi::RegisterSetId::SupervisorCsrs as u16,
-        version: 0,
-        offset: offset_of!(VmCpuSharedState, s_csrs) as u32,
+        offset: offset_of!(VmCpuSharedState, s_csrs) as u16,
     },
     sbi::RegisterSetLocation {
         id: sbi::RegisterSetId::HypervisorCsrs as u16,
-        version: 0,
-        offset: offset_of!(VmCpuSharedState, hs_csrs) as u32,
+        offset: offset_of!(VmCpuSharedState, hs_csrs) as u16,
     },
 ];
 

--- a/test-workloads/Cargo.toml
+++ b/test-workloads/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+arrayvec = { version = "0.7.2", default-features = false }
 attestation = { path = "../attestation" }
 der = "0.6.0"
 device_tree = { path = "../device-tree" }


### PR DESCRIPTION
Instead of having single call that writes the layout to host memory and that the host must retry if they provide insufficient buffer space, take an approach similar to the SBI PMU interface where a one call returns the number of register sets (TvmCpuNumRegisterSets) and another returns the location of a specific register set (TvmCpuGetRegisterSet).

As part of this change, RegisterSetLocation is compressed to a single u32 so that it's guaranteed to fit in a single general-purpose register. The version field is dropped and instead the versioning is implicit from the RegisterSetId.