### PR TITLE
Rename TEE-related SBI extensions

### DIFF
--- a/sbi/src/api/mod.rs
+++ b/sbi/src/api/mod.rs
@@ -9,10 +9,10 @@ pub mod reset;
 pub mod state;
 
 /// Host interfaces for confidential computing.
-pub mod tsm;
+pub mod tee_host;
 
 /// Host interfaces for confidential computing interrupt virtualization.
-pub mod tsm_aia;
+pub mod tee_interrupt;
 
 /// Host interfaces for PMU.
 pub mod pmu;

--- a/sbi/src/api/tee_interrupt.rs
+++ b/sbi/src/api/tee_interrupt.rs
@@ -2,13 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::TeeAiaFunction::*;
+use crate::TeeInterruptFunction::*;
 use crate::TvmAiaParams;
 use crate::{ecall_send, Result, SbiMessage};
 
 /// Configures AIA virtualization for `tvm_id` with the settings in `tvm_aia_params`.
 pub fn tvm_aia_init(tvm_id: u64, tvm_aia_params: TvmAiaParams) -> Result<()> {
-    let msg = SbiMessage::TeeAia(TvmAiaInit {
+    let msg = SbiMessage::TeeInterrupt(TvmAiaInit {
         tvm_id,
         params_addr: (&tvm_aia_params as *const TvmAiaParams) as u64,
         len: core::mem::size_of::<TvmAiaParams>() as u64,
@@ -21,7 +21,7 @@ pub fn tvm_aia_init(tvm_id: u64, tvm_aia_params: TvmAiaParams) -> Result<()> {
 
 /// Sets the guest physical address of the specified vCPU's virtualized IMSIC to `imsic_addr`.
 pub fn set_vcpu_imsic_addr(tvm_id: u64, vcpu_id: u64, imsic_addr: u64) -> Result<()> {
-    let msg = SbiMessage::TeeAia(TvmCpuSetImsicAddr {
+    let msg = SbiMessage::TeeInterrupt(TvmCpuSetImsicAddr {
         tvm_id,
         vcpu_id,
         imsic_addr,
@@ -37,7 +37,7 @@ pub fn set_vcpu_imsic_addr(tvm_id: u64, vcpu_id: u64, imsic_addr: u64) -> Result
 ///
 /// The caller must not access the guest interrupt file again until it has been reclaimed.
 pub unsafe fn convert_imsic(imsic_addr: u64) -> Result<()> {
-    let msg = SbiMessage::TeeAia(TsmConvertImsic { imsic_addr });
+    let msg = SbiMessage::TeeInterrupt(TsmConvertImsic { imsic_addr });
     // The caller must guarantee that they won't access the page at `imsic_addr`.
     ecall_send(&msg)?;
     Ok(())
@@ -46,7 +46,7 @@ pub unsafe fn convert_imsic(imsic_addr: u64) -> Result<()> {
 /// Reclaims the guest interrupt file at `imsic_addr` that was previously converted with
 /// `convert_imsic()`.
 pub fn reclaim_imsic(imsic_addr: u64) -> Result<()> {
-    let msg = SbiMessage::TeeAia(TsmReclaimImsic { imsic_addr });
+    let msg = SbiMessage::TeeInterrupt(TsmReclaimImsic { imsic_addr });
     // Safety: The referenced page is made available again, which is safe since it hasn't been
     // accessible since conversion.
     unsafe { ecall_send(&msg) }?;

--- a/sbi/src/consts.rs
+++ b/sbi/src/consts.rs
@@ -10,8 +10,8 @@ pub const EXT_BASE: u64 = 0x10;
 pub const EXT_HART_STATE: u64 = 0x48534D;
 pub const EXT_PMU: u64 = 0x504D55;
 pub const EXT_RESET: u64 = 0x53525354;
-pub const EXT_TEE: u64 = 0x41544545;
 pub const EXT_ATTESTATION: u64 = 0x41545354; // ATST
-pub const EXT_TEE_AIA: u64 = 0x54414941; // TAIA
+pub const EXT_TEE_HOST: u64 = 0x54454548; // TEEH
+pub const EXT_TEE_INTERRUPT: u64 = 0x54414949; // TEEI
 
 pub const SBI_SUCCESS: i64 = 0;

--- a/sbi/src/sbi.rs
+++ b/sbi/src/sbi.rs
@@ -128,9 +128,9 @@ impl SbiMessage {
             EXT_BASE => BaseFunction::from_regs(args).map(SbiMessage::Base),
             EXT_HART_STATE => StateFunction::from_regs(args).map(SbiMessage::HartState),
             EXT_RESET => ResetFunction::from_regs(args).map(SbiMessage::Reset),
-            EXT_TEE => TeeFunction::from_regs(args).map(SbiMessage::Tee),
+            EXT_TEE_HOST => TeeFunction::from_regs(args).map(SbiMessage::Tee),
             EXT_ATTESTATION => AttestationFunction::from_regs(args).map(SbiMessage::Attestation),
-            EXT_TEE_AIA => TeeAiaFunction::from_regs(args).map(SbiMessage::TeeAia),
+            EXT_TEE_INTERRUPT => TeeAiaFunction::from_regs(args).map(SbiMessage::TeeAia),
             EXT_PMU => PmuFunction::from_regs(args).map(SbiMessage::Pmu),
             _ => Err(Error::NotSupported),
         }
@@ -143,9 +143,9 @@ impl SbiMessage {
             SbiMessage::PutChar(_) => EXT_PUT_CHAR,
             SbiMessage::HartState(_) => EXT_HART_STATE,
             SbiMessage::Reset(_) => EXT_RESET,
-            SbiMessage::Tee(_) => EXT_TEE,
+            SbiMessage::Tee(_) => EXT_TEE_HOST,
             SbiMessage::Attestation(_) => EXT_ATTESTATION,
-            SbiMessage::TeeAia(_) => EXT_TEE_AIA,
+            SbiMessage::TeeAia(_) => EXT_TEE_INTERRUPT,
             SbiMessage::Pmu(_) => EXT_PMU,
         }
     }

--- a/sbi/src/sbi.rs
+++ b/sbi/src/sbi.rs
@@ -140,101 +140,123 @@ impl SbiMessage {
 
     /// Returns the register value for this `SbiMessage`.
     pub fn a7(&self) -> u64 {
+        use SbiMessage::*;
         match self {
-            SbiMessage::Base(_) => EXT_BASE,
-            SbiMessage::PutChar(_) => EXT_PUT_CHAR,
-            SbiMessage::HartState(_) => EXT_HART_STATE,
-            SbiMessage::Reset(_) => EXT_RESET,
-            SbiMessage::TeeHost(_) => EXT_TEE_HOST,
-            SbiMessage::TeeInterrupt(_) => EXT_TEE_INTERRUPT,
-            SbiMessage::Attestation(_) => EXT_ATTESTATION,
-            SbiMessage::Pmu(_) => EXT_PMU,
+            PutChar(_) => EXT_PUT_CHAR,
+            Base(_) => EXT_BASE,
+            HartState(_) => EXT_HART_STATE,
+            Reset(_) => EXT_RESET,
+            TeeHost(_) => EXT_TEE_HOST,
+            TeeInterrupt(_) => EXT_TEE_INTERRUPT,
+            Attestation(_) => EXT_ATTESTATION,
+            Pmu(_) => EXT_PMU,
         }
     }
 
+    // TODO: Consider using enum_dispatch to avoid the repetition.
+
     /// Returns the register value for this `SbiMessage`.
     pub fn a6(&self) -> u64 {
+        use SbiMessage::*;
         match self {
-            SbiMessage::Base(_) => 0, //TODO
-            SbiMessage::HartState(f) => f.a6(),
-            SbiMessage::PutChar(_) => 0,
-            SbiMessage::Reset(_) => 0,
-            SbiMessage::TeeHost(f) => f.a6(),
-            SbiMessage::TeeInterrupt(f) => f.a6(),
-            SbiMessage::Attestation(f) => f.a6(),
-            SbiMessage::Pmu(f) => f.a6(),
+            PutChar(_) => 0,
+            Base(f) => f.a6(),
+            HartState(f) => f.a6(),
+            Reset(f) => f.a6(),
+            TeeHost(f) => f.a6(),
+            TeeInterrupt(f) => f.a6(),
+            Attestation(f) => f.a6(),
+            Pmu(f) => f.a6(),
         }
     }
 
     /// Returns the register value for this `SbiMessage`.
     pub fn a5(&self) -> u64 {
+        use SbiMessage::*;
         match self {
-            SbiMessage::TeeHost(f) => f.a5(),
-            SbiMessage::TeeInterrupt(f) => f.a5(),
-            SbiMessage::Attestation(f) => f.a5(),
-            SbiMessage::Pmu(f) => f.a5(),
-            _ => 0,
+            PutChar(_) => 0,
+            Base(f) => f.a5(),
+            HartState(f) => f.a5(),
+            Reset(f) => f.a5(),
+            TeeHost(f) => f.a5(),
+            TeeInterrupt(f) => f.a5(),
+            Attestation(f) => f.a5(),
+            Pmu(f) => f.a5(),
         }
     }
 
     /// Returns the register value for this `SbiMessage`.
     pub fn a4(&self) -> u64 {
+        use SbiMessage::*;
         match self {
-            SbiMessage::TeeHost(f) => f.a4(),
-            SbiMessage::TeeInterrupt(f) => f.a4(),
-            SbiMessage::Attestation(f) => f.a4(),
-            SbiMessage::Pmu(f) => f.a4(),
-            _ => 0,
+            PutChar(_) => 0,
+            Base(f) => f.a4(),
+            HartState(f) => f.a4(),
+            Reset(f) => f.a4(),
+            TeeHost(f) => f.a4(),
+            TeeInterrupt(f) => f.a4(),
+            Attestation(f) => f.a4(),
+            Pmu(f) => f.a4(),
         }
     }
 
     /// Returns the register value for this `SbiMessage`.
     pub fn a3(&self) -> u64 {
+        use SbiMessage::*;
         match self {
-            SbiMessage::TeeHost(f) => f.a3(),
-            SbiMessage::TeeInterrupt(f) => f.a3(),
-            SbiMessage::Attestation(f) => f.a3(),
-            SbiMessage::Pmu(f) => f.a3(),
-            _ => 0,
+            PutChar(_) => 0,
+            Base(f) => f.a3(),
+            HartState(f) => f.a3(),
+            Reset(f) => f.a3(),
+            TeeHost(f) => f.a3(),
+            TeeInterrupt(f) => f.a3(),
+            Attestation(f) => f.a3(),
+            Pmu(f) => f.a3(),
         }
     }
 
     /// Returns the register value for this `SbiMessage`.
     pub fn a2(&self) -> u64 {
+        use SbiMessage::*;
         match self {
-            SbiMessage::HartState(f) => f.a2(),
-            SbiMessage::TeeHost(f) => f.a2(),
-            SbiMessage::TeeInterrupt(f) => f.a2(),
-            SbiMessage::Attestation(f) => f.a2(),
-            SbiMessage::Pmu(f) => f.a2(),
-            _ => 0,
+            PutChar(_) => 0,
+            Base(f) => f.a2(),
+            HartState(f) => f.a2(),
+            Reset(f) => f.a2(),
+            TeeHost(f) => f.a2(),
+            TeeInterrupt(f) => f.a2(),
+            Attestation(f) => f.a2(),
+            Pmu(f) => f.a2(),
         }
     }
 
     /// Returns the register value for this `SbiMessage`.
     pub fn a1(&self) -> u64 {
+        use SbiMessage::*;
         match self {
-            SbiMessage::Reset(r) => r.a1(),
-            SbiMessage::HartState(f) => f.a1(),
-            SbiMessage::TeeHost(f) => f.a1(),
-            SbiMessage::TeeInterrupt(f) => f.a1(),
-            SbiMessage::Attestation(f) => f.a1(),
-            SbiMessage::Pmu(f) => f.a1(),
-            _ => 0,
+            PutChar(_) => 0,
+            Base(f) => f.a1(),
+            HartState(f) => f.a1(),
+            Reset(f) => f.a1(),
+            TeeHost(f) => f.a1(),
+            TeeInterrupt(f) => f.a1(),
+            Attestation(f) => f.a1(),
+            Pmu(f) => f.a1(),
         }
     }
 
     /// Returns the register value for this `SbiMessage`.
     pub fn a0(&self) -> u64 {
+        use SbiMessage::*;
         match self {
-            SbiMessage::Reset(r) => r.a0(),
-            SbiMessage::PutChar(c) => *c,
-            SbiMessage::HartState(f) => f.a0(),
-            SbiMessage::TeeHost(f) => f.a0(),
-            SbiMessage::TeeInterrupt(f) => f.a0(),
-            SbiMessage::Attestation(f) => f.a0(),
-            SbiMessage::Pmu(f) => f.a0(),
-            _ => 0,
+            PutChar(c) => *c,
+            Base(f) => f.a0(),
+            Reset(f) => f.a0(),
+            HartState(f) => f.a0(),
+            TeeHost(f) => f.a0(),
+            TeeInterrupt(f) => f.a0(),
+            Attestation(f) => f.a0(),
+            Pmu(f) => f.a0(),
         }
     }
 

--- a/sbi/src/tee_host.rs
+++ b/sbi/src/tee_host.rs
@@ -221,9 +221,9 @@ impl TsmPageType {
     }
 }
 
-/// Functions provided by the TEE extension.
+/// Functions provided by the TEE Host extension.
 #[derive(Copy, Clone)]
-pub enum TeeFunction {
+pub enum TeeHostFunction {
     /// Creates a TVM from the parameters in the `TvmCreateParams` structure at the non-confidential
     /// physical address `params_addr`. Returns a guest ID that can be used to refer to the TVM in
     /// TVM management TEECALLs.
@@ -462,10 +462,10 @@ pub enum TeeFunction {
     },
 }
 
-impl TeeFunction {
+impl TeeHostFunction {
     /// Attempts to parse `Self` from the passed in `a0-a7`.
     pub(crate) fn from_regs(args: &[u64]) -> Result<Self> {
-        use TeeFunction::*;
+        use TeeHostFunction::*;
         match args[6] {
             0 => Ok(TvmCreate {
                 params_addr: args[0],
@@ -550,9 +550,9 @@ impl TeeFunction {
     }
 }
 
-impl SbiFunction for TeeFunction {
+impl SbiFunction for TeeHostFunction {
     fn a6(&self) -> u64 {
-        use TeeFunction::*;
+        use TeeHostFunction::*;
         match self {
             TvmCreate {
                 params_addr: _,
@@ -636,7 +636,7 @@ impl SbiFunction for TeeFunction {
     }
 
     fn a0(&self) -> u64 {
-        use TeeFunction::*;
+        use TeeHostFunction::*;
         match self {
             TvmCreate {
                 params_addr,
@@ -713,7 +713,7 @@ impl SbiFunction for TeeFunction {
     }
 
     fn a1(&self) -> u64 {
-        use TeeFunction::*;
+        use TeeHostFunction::*;
         match self {
             TvmCreate {
                 params_addr: _,
@@ -787,7 +787,7 @@ impl SbiFunction for TeeFunction {
     }
 
     fn a2(&self) -> u64 {
-        use TeeFunction::*;
+        use TeeHostFunction::*;
         match self {
             AddPageTablePages {
                 guest_id: _,
@@ -851,7 +851,7 @@ impl SbiFunction for TeeFunction {
     }
 
     fn a3(&self) -> u64 {
-        use TeeFunction::*;
+        use TeeHostFunction::*;
         match self {
             TvmAddZeroPages {
                 guest_id: _,
@@ -880,7 +880,7 @@ impl SbiFunction for TeeFunction {
     }
 
     fn a4(&self) -> u64 {
-        use TeeFunction::*;
+        use TeeHostFunction::*;
         match self {
             TvmAddZeroPages {
                 guest_id: _,
@@ -909,7 +909,7 @@ impl SbiFunction for TeeFunction {
     }
 
     fn a5(&self) -> u64 {
-        use TeeFunction::*;
+        use TeeHostFunction::*;
         match self {
             TvmAddMeasuredPages {
                 guest_id: _,

--- a/sbi/src/tee_interrupt.rs
+++ b/sbi/src/tee_interrupt.rs
@@ -39,9 +39,9 @@ pub struct TvmAiaParams {
     pub guests_per_hart: u32,
 }
 
-/// Functions provided by the TEE-AIA extension.
+/// Functions provided by the TEE Interrupt extension.
 #[derive(Copy, Clone)]
-pub enum TeeAiaFunction {
+pub enum TeeInterruptFunction {
     /// Configures AIA virtualization for the TVM identified by `tvm_id` from the parameters in
     /// the `TvmAiaParams` structure at the non-confidential physical address `params_addr`.
     ///
@@ -99,10 +99,10 @@ pub enum TeeAiaFunction {
     },
 }
 
-impl TeeAiaFunction {
+impl TeeInterruptFunction {
     /// Attempts to parse `Self` from the register values passed in `a0-a7`.
     pub(crate) fn from_regs(args: &[u64]) -> Result<Self> {
-        use TeeAiaFunction::*;
+        use TeeInterruptFunction::*;
         match args[6] {
             0 => Ok(TvmAiaInit {
                 tvm_id: args[0],
@@ -125,9 +125,9 @@ impl TeeAiaFunction {
     }
 }
 
-impl SbiFunction for TeeAiaFunction {
+impl SbiFunction for TeeInterruptFunction {
     fn a6(&self) -> u64 {
-        use TeeAiaFunction::*;
+        use TeeInterruptFunction::*;
         match self {
             TvmAiaInit { .. } => 0,
             TvmCpuSetImsicAddr { .. } => 1,
@@ -137,7 +137,7 @@ impl SbiFunction for TeeAiaFunction {
     }
 
     fn a0(&self) -> u64 {
-        use TeeAiaFunction::*;
+        use TeeInterruptFunction::*;
         match self {
             TvmAiaInit {
                 tvm_id,
@@ -155,7 +155,7 @@ impl SbiFunction for TeeAiaFunction {
     }
 
     fn a1(&self) -> u64 {
-        use TeeAiaFunction::*;
+        use TeeInterruptFunction::*;
         match self {
             TvmAiaInit {
                 tvm_id: _,
@@ -172,7 +172,7 @@ impl SbiFunction for TeeAiaFunction {
     }
 
     fn a2(&self) -> u64 {
-        use TeeAiaFunction::*;
+        use TeeInterruptFunction::*;
         match self {
             TvmAiaInit {
                 tvm_id: _,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -640,12 +640,12 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
             ),
             SbiMessage::Base(base_func) => EcallAction::Continue(self.handle_base_msg(base_func)),
             SbiMessage::HartState(hsm_func) => self.handle_hart_state_msg(hsm_func),
-            SbiMessage::Tee(tee_func) => self.handle_tee_msg(tee_func, active_vcpu),
+            SbiMessage::TeeHost(host_func) => self.handle_tee_host_msg(host_func, active_vcpu),
+            SbiMessage::TeeInterrupt(interrupt_func) => {
+                self.handle_tee_interrupt_msg(interrupt_func, active_vcpu.active_pages())
+            }
             SbiMessage::Attestation(attestation_func) => {
                 self.handle_attestation_msg(attestation_func, active_vcpu.active_pages())
-            }
-            SbiMessage::TeeAia(aia_func) => {
-                self.handle_aia_msg(aia_func, active_vcpu.active_pages())
             }
             SbiMessage::Pmu(pmu_func) => self.handle_pmu_msg(pmu_func, active_vcpu).into(),
         }
@@ -820,13 +820,13 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
         }
     }
 
-    fn handle_tee_msg(
+    fn handle_tee_host_msg(
         &self,
-        tee_func: TeeFunction,
+        host_func: TeeHostFunction,
         active_vcpu: &mut ActiveVmCpu<T>,
     ) -> EcallAction {
-        use TeeFunction::*;
-        match tee_func {
+        use TeeHostFunction::*;
+        match host_func {
             TsmGetInfo { dest_addr, len } => self
                 .get_tsm_info(dest_addr, len, active_vcpu.active_pages())
                 .into(),
@@ -988,13 +988,13 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
         }
     }
 
-    fn handle_aia_msg(
+    fn handle_tee_interrupt_msg(
         &self,
-        aia_func: TeeAiaFunction,
+        interrupt_func: TeeInterruptFunction,
         active_pages: &ActiveVmPages<T>,
     ) -> EcallAction {
-        use TeeAiaFunction::*;
-        match aia_func {
+        use TeeInterruptFunction::*;
+        match interrupt_func {
             TvmAiaInit {
                 tvm_id,
                 params_addr,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -790,9 +790,9 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
                 | sbi::EXT_BASE
                 | sbi::EXT_HART_STATE
                 | sbi::EXT_RESET
-                | sbi::EXT_TEE
-                | sbi::EXT_ATTESTATION
-                | sbi::EXT_TEE_AIA => 1,
+                | sbi::EXT_TEE_HOST
+                | sbi::EXT_TEE_INTERRUPT
+                | sbi::EXT_ATTESTATION => 1,
                 sbi::EXT_PMU if PmuInfo::get().is_ok() => 1,
                 _ => 0,
             },

--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -28,7 +28,7 @@ use s_mode_utils::{print::*, sbi_console::SbiConsole};
 use sbi::api::{base, pmu, reset, tsm, tsm_aia};
 use sbi::{
     PmuCounterConfigFlags, PmuCounterStartFlags, PmuCounterStopFlags, PmuEventType, PmuFirmware,
-    PmuHardware, SbiMessage, EXT_PMU, EXT_TEE, EXT_TEE_AIA,
+    PmuHardware, SbiMessage, EXT_PMU, EXT_TEE_HOST, EXT_TEE_INTERRUPT,
 };
 
 // Dummy global allocator - panic if anything tries to do an allocation.
@@ -407,7 +407,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
         mem_range.size()
     );
 
-    base::probe_sbi_extension(EXT_TEE).expect("Platform doesn't support TEE extension");
+    base::probe_sbi_extension(EXT_TEE_HOST).expect("Platform doesn't support TEE extension");
     let tsm_info = tsm::get_info().expect("Tellus - TsmGetInfo failed");
     let tvm_create_pages = 4
         + tsm_info.tvm_state_pages
@@ -476,7 +476,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     // and will not be used for any other purpose for the duration of `kernel_init()`.
     let vcpu = unsafe { TvmCpuSharedMem::new(vcpu_state_addr, vcpu_mem_layout) };
 
-    let has_aia = base::probe_sbi_extension(EXT_TEE_AIA).is_ok();
+    let has_aia = base::probe_sbi_extension(EXT_TEE_INTERRUPT).is_ok();
     // CPU0, guest interrupt file 0.
     let imsic_file_addr = IMSIC_START_ADDRESS + PAGE_SIZE_4K;
     if has_aia {


### PR DESCRIPTION
Re-assign the TEE extension IDs with the "TEE" prefix, e.g. "TEEH" for the host-side API (patch 1) and update the various module names and enums to use this naming scheme (patch 2). Patch 3 is a minor fix to guard against potential errors when adding future SBI extensions.

Note that `TEE_INTERRUPT` may end up getting combined with `TEE_HOST` at some point, but that's beyond the scope of this PR for now.