### PR TITLE
Minor VM exit cleanups

### DIFF
--- a/sbi/src/api/tee_host.rs
+++ b/sbi/src/api/tee_host.rs
@@ -119,15 +119,13 @@ pub fn tvm_destroy(vmid: u64) -> Result<()> {
 }
 
 /// Runs the given vcpu of the specified TVM.
-pub fn tvm_run(vmid: u64, vcpu_id: u64) -> Result<()> {
+pub fn tvm_run(vmid: u64, vcpu_id: u64) -> Result<u64> {
     let msg = SbiMessage::TeeHost(TvmCpuRun {
         guest_id: vmid,
         vcpu_id,
     });
-    // Safety: running a VM will only write to the TvmCpuSharedState struct registered in
-    // add_vcpu().
-    unsafe { ecall_send(&msg) }?;
-    Ok(())
+    // Safety: running a VM will only write to the shared-memory area registered in add_vcpu().
+    unsafe { ecall_send(&msg) }
 }
 
 /// Adds pages to be used for page table entries of the given vmid.

--- a/sbi/src/attestation.rs
+++ b/sbi/src/attestation.rs
@@ -143,7 +143,7 @@ impl MeasurementRegisterDescriptor {
 }
 
 /// Functions provided by the attestation extension.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum AttestationFunction {
     /// Get the SBI implementation attestation capabilities.
     /// The attestation capabilities let the SBI implementations expose which

--- a/sbi/src/base.rs
+++ b/sbi/src/base.rs
@@ -6,7 +6,7 @@ use crate::error::*;
 use crate::function::*;
 
 /// Functions defined for the Base extension
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum BaseFunction {
     /// Returns the implemented version of the SBI standard.
     GetSpecificationVersion,

--- a/sbi/src/pmu.rs
+++ b/sbi/src/pmu.rs
@@ -8,7 +8,7 @@ use ConfigFlagsValues::*;
 
 /// Functions for the Performance Monitoring Unit (PMU) extension
 /// Specific details can be found in the SBI documentation for the PMU extension.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum PmuFunction {
     /// Returns the total number of performance counters (hardware and firmware).
     GetNumCounters,
@@ -56,7 +56,7 @@ pub enum PmuFunction {
 
 /// This encapsulates the bit-fields for PMU config_flags parameter as described in the SBI documentation
 /// for sbi_pmu_counter_config_matching
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Default, Debug)]
 pub struct PmuCounterConfigFlags(u64);
 
 #[derive(Copy, Clone)]

--- a/sbi/src/reset.rs
+++ b/sbi/src/reset.rs
@@ -6,7 +6,7 @@ use crate::error::*;
 use crate::function::*;
 
 /// Functions for the Reset extension
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum ResetFunction {
     /// Performs a system reset.
     Reset {

--- a/sbi/src/sbi.rs
+++ b/sbi/src/sbi.rs
@@ -98,7 +98,7 @@ pub enum SbiReturnType {
 }
 
 /// SBI Message used to invoke the specified SBI extension in the firmware.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum SbiMessage {
     /// The base SBI extension functions.
     Base(BaseFunction),

--- a/sbi/src/state.rs
+++ b/sbi/src/state.rs
@@ -6,7 +6,7 @@ use crate::error::*;
 use crate::function::*;
 
 /// Functions defined for the State extension
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum StateFunction {
     /// Starts the given hart.
     HartStart {

--- a/sbi/src/tee_host.rs
+++ b/sbi/src/tee_host.rs
@@ -281,6 +281,12 @@ pub enum TeeHostFunction {
     },
     /// Runs the given vCPU in the TVM
     ///
+    /// Returns 0 if the vCPU can be resumed via a subsequent call to `TvmCpuRun`, or a value other
+    /// than 0 if the vCPU was terminated and is no longer runnable.
+    ///
+    /// Returns an error if the specified TVM or vCPU does not exist, or if the vCPU exists but
+    /// is not currently runnable.
+    ///
     /// a6 = 5
     TvmCpuRun {
         /// a0 = guest id

--- a/sbi/src/tee_host.rs
+++ b/sbi/src/tee_host.rs
@@ -183,7 +183,7 @@ pub struct TvmCreateParams {
 
 /// Types of pages allowed to used for creating or managing confidential VMs.
 #[repr(u64)]
-#[derive(Copy, Clone, PartialEq, Eq, Default)]
+#[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
 pub enum TsmPageType {
     #[default]
     /// Standard 4k pages.
@@ -222,7 +222,7 @@ impl TsmPageType {
 }
 
 /// Functions provided by the TEE Host extension.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum TeeHostFunction {
     /// Creates a TVM from the parameters in the `TvmCreateParams` structure at the non-confidential
     /// physical address `params_addr`. Returns a guest ID that can be used to refer to the TVM in

--- a/sbi/src/tee_interrupt.rs
+++ b/sbi/src/tee_interrupt.rs
@@ -40,7 +40,7 @@ pub struct TvmAiaParams {
 }
 
 /// Functions provided by the TEE Interrupt extension.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum TeeInterruptFunction {
     /// Configures AIA virtualization for the TVM identified by `tvm_id` from the parameters in
     /// the `TvmAiaParams` structure at the non-confidential physical address `params_addr`.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -131,7 +131,7 @@ pub enum VmExitCause {
 #[derive(Clone, Copy, Debug)]
 enum EcallError {
     Sbi(SbiError),
-    PageFault(PageFaultType),
+    PageFault(PageFaultType, Exception, GuestPhysAddr),
 }
 
 type EcallResult<T> = core::result::Result<T, EcallError>;
@@ -139,7 +139,7 @@ type EcallResult<T> = core::result::Result<T, EcallError>;
 impl From<VmPagesError> for EcallError {
     fn from(error: VmPagesError) -> EcallError {
         match error {
-            VmPagesError::PageFault(pf) => EcallError::PageFault(pf),
+            VmPagesError::PageFault(pf, e, addr) => EcallError::PageFault(pf, e, addr),
             // TODO: Map individual error types. InvalidAddress is likely not the right value for
             // each error.
             _ => EcallError::Sbi(SbiError::InvalidAddress),
@@ -181,14 +181,15 @@ impl From<EcallResult<u64>> for EcallAction {
         match result {
             Ok(val) => Continue(SbiReturn::success(val)),
             Err(EcallError::Sbi(e)) => Continue(e.into()),
-            Err(EcallError::PageFault(pf)) => {
+            Err(EcallError::PageFault(pf, e, addr)) => {
+                let addr = PageAddr::with_round_down(addr, PageSize::Size4k);
                 use PageFaultType::*;
                 match pf {
-                    // Unhandleable page faults or page faults in MMIO space just result in an error to
-                    // the caller.
-                    Unmapped(..) | Mmio(..) => Continue(SbiReturn::from(SbiError::InvalidAddress)),
-                    Confidential(e, addr) => Retry(VmExitCause::ConfidentialPageFault(e, addr)),
-                    Shared(e, addr) => Retry(VmExitCause::SharedPageFault(e, addr)),
+                    // Unhandleable page faults or page faults in MMIO space just result in an
+                    // error to the caller.
+                    Unmapped | Mmio => Continue(SbiReturn::from(SbiError::InvalidAddress)),
+                    Confidential => Retry(VmExitCause::ConfidentialPageFault(e, addr)),
+                    Shared => Retry(VmExitCause::SharedPageFault(e, addr)),
                 }
             }
         }
@@ -533,13 +534,19 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
                         .get_page_fault_cause(exception, fault_addr);
                     use PageFaultType::*;
                     match pf {
-                        Confidential(e, addr) => {
-                            break VmExitCause::ConfidentialPageFault(e, addr);
+                        Confidential => {
+                            break VmExitCause::ConfidentialPageFault(
+                                exception,
+                                PageAddr::with_round_down(fault_addr, PageSize::Size4k),
+                            );
                         }
-                        Shared(e, addr) => {
-                            break VmExitCause::SharedPageFault(e, addr);
+                        Shared => {
+                            break VmExitCause::SharedPageFault(
+                                exception,
+                                PageAddr::with_round_down(fault_addr, PageSize::Size4k),
+                            );
                         }
-                        Mmio(e, addr) => {
+                        Mmio => {
                             // We need the faulting instruction for MMIO faults.
                             use InstructionFetchError::*;
                             let inst = match active_vcpu
@@ -576,10 +583,12 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
                                 }
                             };
 
-                            break VmExitCause::MmioPageFault(e, addr, mmio_op);
+                            break VmExitCause::MmioPageFault(exception, fault_addr, mmio_op);
                         }
-                        Unmapped(e) => {
-                            break VmExitCause::UnhandledTrap(Trap::Exception(e).to_scause());
+                        Unmapped => {
+                            break VmExitCause::UnhandledTrap(
+                                Trap::Exception(exception).to_scause(),
+                            );
                         }
                     };
                 }

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -767,21 +767,10 @@ impl<'vcpu, 'pages, 'prev, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, '
         let shared = self.vcpu.shared_area();
         use VmExitCause::*;
         match cause {
-            PowerOff(reset_type, reason) => {
-                let msg = SbiMessage::Reset(sbi::ResetFunction::Reset { reset_type, reason });
-                shared.update_with_ecall_exit(msg);
-                self.power_off = true;
-            }
-            CpuStart(hart_id) => {
-                let msg = SbiMessage::HartState(sbi::StateFunction::HartStart {
-                    hart_id,
-                    start_addr: 0,
-                    opaque: 0,
-                });
+            ResumableEcall(msg) => {
                 shared.update_with_ecall_exit(msg);
             }
-            CpuStop => {
-                let msg = SbiMessage::HartState(sbi::StateFunction::HartStop);
+            FatalEcall(msg) => {
                 shared.update_with_ecall_exit(msg);
                 self.power_off = true;
             }

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -770,6 +770,7 @@ impl<'vcpu, 'pages, 'prev, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, '
             PowerOff(reset_type, reason) => {
                 let msg = SbiMessage::Reset(sbi::ResetFunction::Reset { reset_type, reason });
                 shared.update_with_ecall_exit(msg);
+                self.power_off = true;
             }
             CpuStart(hart_id) => {
                 let msg = SbiMessage::HartState(sbi::StateFunction::HartStart {
@@ -782,6 +783,7 @@ impl<'vcpu, 'pages, 'prev, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, '
             CpuStop => {
                 let msg = SbiMessage::HartState(sbi::StateFunction::HartStop);
                 shared.update_with_ecall_exit(msg);
+                self.power_off = true;
             }
             ConfidentialPageFault(exception, page_addr) => {
                 shared.update_with_pf_exit(exception, page_addr.into());
@@ -813,6 +815,7 @@ impl<'vcpu, 'pages, 'prev, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, '
             }
             UnhandledTrap(scause) => {
                 shared.update_with_unhandled_exit(scause);
+                self.power_off = true;
             }
         };
     }

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -785,13 +785,10 @@ impl<'vcpu, 'pages, 'prev, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, '
                 shared.update_with_ecall_exit(msg);
                 self.power_off = true;
             }
-            ConfidentialPageFault(exception, page_addr) => {
+            PageFault(exception, page_addr) => {
                 shared.update_with_pf_exit(exception, page_addr.into());
             }
-            SharedPageFault(exception, page_addr) => {
-                shared.update_with_pf_exit(exception, page_addr.into());
-            }
-            MmioPageFault(exception, addr, mmio_op) => {
+            MmioFault(exception, addr, mmio_op) => {
                 shared.update_with_pf_exit(exception, addr);
 
                 // The MMIO instruction is transformed as an ordinary load/store to/from A0, so


### PR DESCRIPTION
A series of minor cleanups around the various types relating to VM exits, mostly to do with removing redundant information. Patch 1 fixes an issue where vCPUs weren't properly marked as powered-off after taking a fatal exit (oops), patches 2-8 are the aforementioned minor changes, and patch 9 makes the `TvmCpuRun` return value indicate whether or not the vCPU is still runnable, which is something that came up when talking through the spec with @atulkharerivos.