### PR TITLE
Move MMIO and shared memory region registration to the guest

### DIFF
--- a/sbi/src/api/mod.rs
+++ b/sbi/src/api/mod.rs
@@ -14,6 +14,9 @@ pub mod tee_host;
 /// Host interfaces for confidential computing interrupt virtualization.
 pub mod tee_interrupt;
 
+/// Guest interfaces for confidential computing.
+pub mod tee_guest;
+
 /// Host interfaces for PMU.
 pub mod pmu;
 

--- a/sbi/src/api/tee_guest.rs
+++ b/sbi/src/api/tee_guest.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::TeeGuestFunction::*;
+use crate::{ecall_send, Result, SbiMessage, TeeMemoryRegion};
+
+/// Registers an emulated MMIO region in a previously-unused range of guest physical address space.
+/// Future accesses in the specified address range will trap to the host, allowing it to emulate
+/// the access.
+pub fn add_emulated_mmio_region(addr: u64, len: u64) -> Result<()> {
+    let msg = SbiMessage::TeeGuest(AddMemoryRegion {
+        region_type: TeeMemoryRegion::EmulatedMmio,
+        addr,
+        len,
+    });
+    // Safety: AddMemoryRegion does not directly access our memory. The specified range of
+    // address space must have been previously inaccessible for the call to succeed, after which
+    // accesses to that range have well-defined behavior.
+    unsafe { ecall_send(&msg) }?;
+    Ok(())
+}
+
+/// Registers a shared memory region in a previously-unused range of guest physical address space.
+/// Future accesses in the specified address range will trap to to the host, allowing it to insert
+/// pages of shared memory.
+pub fn add_shared_memory_region(addr: u64, len: u64) -> Result<()> {
+    let msg = SbiMessage::TeeGuest(AddMemoryRegion {
+        region_type: TeeMemoryRegion::Shared,
+        addr,
+        len,
+    });
+    // Safety: AddMemoryRegion does not directly access our memory. The specified range of
+    // address space must have been previously inaccessible for the call to succeed, after which
+    // accesses to that range have well-defined behavior.
+    unsafe { ecall_send(&msg) }?;
+    Ok(())
+}

--- a/sbi/src/api/tee_host.rs
+++ b/sbi/src/api/tee_host.rs
@@ -191,31 +191,6 @@ pub fn add_confidential_memory_region(vmid: u64, guest_addr: u64, len: u64) -> R
     Ok(())
 }
 
-/// Declares an address range to be used for emulating MMIO accesses in the guest.
-pub fn add_emulated_mmio_region(vmid: u64, guest_addr: u64, len: u64) -> Result<()> {
-    let msg = SbiMessage::TeeHost(TvmAddEmulatedMmioRegion {
-        guest_id: vmid,
-        guest_addr,
-        len,
-    });
-    // Safety: Doesn't touch this host's memory.
-    unsafe { ecall_send(&msg) }?;
-    Ok(())
-}
-
-/// Declares a region that will can be filled with share pages for communication between a TVM and
-/// the host(e.g. virito).
-pub fn add_shared_memory_region(vmid: u64, guest_addr: u64, len: u64) -> Result<()> {
-    let msg = SbiMessage::TeeHost(TvmAddSharedMemoryRegion {
-        guest_id: vmid,
-        guest_addr,
-        len,
-    });
-    // Safety: `TvmAddSharedMemoryRegion` doesn't affect host memory
-    unsafe { ecall_send(&msg) }?;
-    Ok(())
-}
-
 /// Copies the data from the pages backing `src_data` to the guest and records their measurement for
 /// attestation.  src_data must be aligned to the given page size.
 pub fn add_measured_pages(

--- a/sbi/src/api/tee_host.rs
+++ b/sbi/src/api/tee_host.rs
@@ -4,7 +4,7 @@
 
 use crate::TeeHostFunction::*;
 use crate::{ecall_send, Error, Result, SbiMessage};
-use crate::{RegisterSetLocation, TsmInfo, TsmPageType, TvmCreateParams};
+use crate::{RegisterSetLocation, TeeMemoryRegion, TsmInfo, TsmPageType, TvmCreateParams};
 
 /// Initiates a TSM fence on this CPU.
 pub fn initiate_fence() -> Result<()> {
@@ -181,8 +181,9 @@ pub unsafe fn add_vcpu(vmid: u64, vcpu_id: u64, shared_page_addr: u64) -> Result
 
 /// Declares the confidential region of the guest's physical address space.
 pub fn add_confidential_memory_region(vmid: u64, guest_addr: u64, len: u64) -> Result<()> {
-    let msg = SbiMessage::TeeHost(TvmAddConfidentialMemoryRegion {
+    let msg = SbiMessage::TeeHost(TvmAddMemoryRegion {
         guest_id: vmid,
+        region_type: TeeMemoryRegion::Confidential,
         guest_addr,
         len,
     });

--- a/sbi/src/consts.rs
+++ b/sbi/src/consts.rs
@@ -13,5 +13,6 @@ pub const EXT_RESET: u64 = 0x53525354;
 pub const EXT_ATTESTATION: u64 = 0x41545354; // ATST
 pub const EXT_TEE_HOST: u64 = 0x54454548; // TEEH
 pub const EXT_TEE_INTERRUPT: u64 = 0x54414949; // TEEI
+pub const EXT_TEE_GUEST: u64 = 0x54454547; // TEEG
 
 pub const SBI_SUCCESS: i64 = 0;

--- a/sbi/src/sbi.rs
+++ b/sbi/src/sbi.rs
@@ -31,6 +31,9 @@ pub use tee_host::*;
 // The TEE interrupt SBI extension
 mod tee_interrupt;
 pub use tee_interrupt::*;
+// The TEE guest SBI extension
+mod tee_guest;
+pub use tee_guest::*;
 // The PMU SBI extension
 mod pmu;
 pub use pmu::*;
@@ -112,6 +115,8 @@ pub enum SbiMessage {
     TeeHost(TeeHostFunction),
     /// Provides interrupt virtualization for confidential virtual machines.
     TeeInterrupt(TeeInterruptFunction),
+    /// Provides capabilities for enlightened confidential virtual machines.
+    TeeGuest(TeeGuestFunction),
     /// The extension for getting attestation evidences and extending measurements.
     Attestation(AttestationFunction),
     /// The extension for getting performance counter state.
@@ -132,6 +137,7 @@ impl SbiMessage {
             EXT_TEE_INTERRUPT => {
                 TeeInterruptFunction::from_regs(args).map(SbiMessage::TeeInterrupt)
             }
+            EXT_TEE_GUEST => TeeGuestFunction::from_regs(args).map(SbiMessage::TeeGuest),
             EXT_ATTESTATION => AttestationFunction::from_regs(args).map(SbiMessage::Attestation),
             EXT_PMU => PmuFunction::from_regs(args).map(SbiMessage::Pmu),
             _ => Err(Error::NotSupported),
@@ -148,6 +154,7 @@ impl SbiMessage {
             Reset(_) => EXT_RESET,
             TeeHost(_) => EXT_TEE_HOST,
             TeeInterrupt(_) => EXT_TEE_INTERRUPT,
+            TeeGuest(_) => EXT_TEE_GUEST,
             Attestation(_) => EXT_ATTESTATION,
             Pmu(_) => EXT_PMU,
         }
@@ -165,6 +172,7 @@ impl SbiMessage {
             Reset(f) => f.a6(),
             TeeHost(f) => f.a6(),
             TeeInterrupt(f) => f.a6(),
+            TeeGuest(f) => f.a6(),
             Attestation(f) => f.a6(),
             Pmu(f) => f.a6(),
         }
@@ -180,6 +188,7 @@ impl SbiMessage {
             Reset(f) => f.a5(),
             TeeHost(f) => f.a5(),
             TeeInterrupt(f) => f.a5(),
+            TeeGuest(f) => f.a5(),
             Attestation(f) => f.a5(),
             Pmu(f) => f.a5(),
         }
@@ -195,6 +204,7 @@ impl SbiMessage {
             Reset(f) => f.a4(),
             TeeHost(f) => f.a4(),
             TeeInterrupt(f) => f.a4(),
+            TeeGuest(f) => f.a4(),
             Attestation(f) => f.a4(),
             Pmu(f) => f.a4(),
         }
@@ -210,6 +220,7 @@ impl SbiMessage {
             Reset(f) => f.a3(),
             TeeHost(f) => f.a3(),
             TeeInterrupt(f) => f.a3(),
+            TeeGuest(f) => f.a3(),
             Attestation(f) => f.a3(),
             Pmu(f) => f.a3(),
         }
@@ -225,6 +236,7 @@ impl SbiMessage {
             Reset(f) => f.a2(),
             TeeHost(f) => f.a2(),
             TeeInterrupt(f) => f.a2(),
+            TeeGuest(f) => f.a2(),
             Attestation(f) => f.a2(),
             Pmu(f) => f.a2(),
         }
@@ -240,6 +252,7 @@ impl SbiMessage {
             Reset(f) => f.a1(),
             TeeHost(f) => f.a1(),
             TeeInterrupt(f) => f.a1(),
+            TeeGuest(f) => f.a1(),
             Attestation(f) => f.a1(),
             Pmu(f) => f.a1(),
         }
@@ -255,6 +268,7 @@ impl SbiMessage {
             HartState(f) => f.a0(),
             TeeHost(f) => f.a0(),
             TeeInterrupt(f) => f.a0(),
+            TeeGuest(f) => f.a0(),
             Attestation(f) => f.a0(),
             Pmu(f) => f.a0(),
         }

--- a/sbi/src/tee_guest.rs
+++ b/sbi/src/tee_guest.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::*;
+use crate::function::*;
+use crate::TeeMemoryRegion;
+
+/// Functions provided by the TEE Guest extension to TVM guests.
+#[derive(Copy, Clone, Debug)]
+pub enum TeeGuestFunction {
+    /// Adds a memory region to the calling TVM at the specified range of guest physical address
+    /// space. Both `addr` and `len` must be 4kB-aligned and must not overlap with any
+    /// previously-added regions.
+    ///
+    /// Only `Shared` and `EmulatedMmio` regions may be added by the TVM.
+    ///
+    /// a6 = 0
+    AddMemoryRegion {
+        /// a0 = type of memory region
+        region_type: TeeMemoryRegion,
+        /// a1 = start of the region
+        addr: u64,
+        /// a2 = length of the region
+        len: u64,
+    },
+}
+
+impl TeeGuestFunction {
+    /// Attempts to parse `Self` from the passed in `a0-a7`.
+    pub(crate) fn from_regs(args: &[u64]) -> Result<Self> {
+        use TeeGuestFunction::*;
+        match args[6] {
+            0 => Ok(AddMemoryRegion {
+                region_type: TeeMemoryRegion::from_reg(args[0])?,
+                addr: args[1],
+                len: args[2],
+            }),
+            _ => Err(Error::NotSupported),
+        }
+    }
+}
+
+impl SbiFunction for TeeGuestFunction {
+    fn a6(&self) -> u64 {
+        use TeeGuestFunction::*;
+        match self {
+            AddMemoryRegion { .. } => 0,
+        }
+    }
+
+    fn a0(&self) -> u64 {
+        use TeeGuestFunction::*;
+        match self {
+            AddMemoryRegion {
+                region_type,
+                addr: _,
+                len: _,
+            } => *region_type as u64,
+        }
+    }
+
+    fn a1(&self) -> u64 {
+        use TeeGuestFunction::*;
+        match self {
+            AddMemoryRegion {
+                region_type: _,
+                addr,
+                len: _,
+            } => *addr,
+        }
+    }
+
+    fn a2(&self) -> u64 {
+        use TeeGuestFunction::*;
+        match self {
+            AddMemoryRegion {
+                region_type: _,
+                addr: _,
+                len,
+            } => *len,
+        }
+    }
+}

--- a/sbi/src/tee_host.rs
+++ b/sbi/src/tee_host.rs
@@ -221,6 +221,38 @@ impl TsmPageType {
     }
 }
 
+/// Types of memory regions that can be created in a TVM.
+#[repr(u64)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TeeMemoryRegion {
+    /// A region of memory where a TVM's host may insert pages of confidential memory. The region
+    /// is initially unpopulated. Accesses by the TVM to unmapped pages in the regino will cause
+    /// a guest page fault exit with the faulting page address reported to the TVM's host.
+    Confidential = 0,
+    /// A region of memory where a TVM's host may insert pages of shared, non-confidential memory.
+    /// The region is initially unpopulated. Accesses by the TVM to unmapped pages in the region
+    /// will cause a guest page fault exit with the faulting page address reported to the TVM's
+    /// host.
+    Shared = 1,
+    /// An unpopulated region of memory where accesses by the TVM will cause guest page fault
+    /// exit with the faulting address and a transformed version of the faulting instruction
+    /// reported to the TVM's host, allowing the host to emulate the faulting memory access.
+    EmulatedMmio = 2,
+}
+
+impl TeeMemoryRegion {
+    /// Returns the `TeeMemoryRegion` corresponding to the value.
+    pub fn from_reg(reg: u64) -> Result<Self> {
+        use TeeMemoryRegion::*;
+        match reg {
+            0 => Ok(Confidential),
+            1 => Ok(Shared),
+            2 => Ok(EmulatedMmio),
+            _ => Err(Error::InvalidParam),
+        }
+    }
+}
+
 /// Functions provided by the TEE Host extension.
 #[derive(Copy, Clone, Debug)]
 pub enum TeeHostFunction {

--- a/src/host_vm_loader.rs
+++ b/src/host_vm_loader.rs
@@ -280,16 +280,6 @@ impl<T: GuestStagePagingMode> HostVmLoader<T> {
             }
         }
 
-        // Set up MMIO emulation for the PCIe config space.
-        let config_mem = pci.config_space();
-        let config_gpa = PageAddr::new(RawAddr::guest(
-            config_mem.base().bits(),
-            PageOwnerId::host(),
-        ))
-        .unwrap();
-        self.vm
-            .add_mmio_region(config_gpa, config_mem.length_bytes());
-
         // Host guarantees that the host pages it returns start at T::TOP_LEVEL_ALIGN-aligned block,
         // and because we built the HwMemMap with a minimum region alignment of T::TOP_LEVEL_ALIGN
         // any discontiguous ranges are also guaranteed to be aligned.
@@ -361,6 +351,17 @@ impl<T: GuestStagePagingMode> HostVmLoader<T> {
             self.guest_ram_base.checked_increment(FDT_OFFSET).unwrap(),
         );
         self.vm.finalize().unwrap();
+
+        // Set up MMIO emulation for the PCIe config space.
+        let config_mem = pci.config_space();
+        let config_gpa = PageAddr::new(RawAddr::guest(
+            config_mem.base().bits(),
+            PageOwnerId::host(),
+        ))
+        .unwrap();
+        self.vm
+            .add_mmio_region(config_gpa, config_mem.length_bytes());
+
         self.vm
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1600,7 +1600,9 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
         }
         let page_addr = self.guest_addr_from_raw(page_addr)?;
         let guest = self.guest_by_id(guest_id)?;
-        let guest_vm = guest.as_any_vm();
+        let guest_vm = guest
+            .as_finalized_vm()
+            .ok_or(EcallError::Sbi(SbiError::InvalidParam))?;
         let guest_addr = guest_vm.guest_addr_from_raw(guest_addr)?;
         self.vm_pages()
             .add_shared_pages_to(page_addr, num_pages, guest_vm.vm_pages(), guest_addr)

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1813,12 +1813,6 @@ impl<T: GuestStagePagingMode> HostVm<T> {
             .unwrap();
     }
 
-    /// Adds an emulated MMIO region to the host VM.
-    pub fn add_mmio_region(&mut self, addr: GuestPageAddr, len: u64) {
-        let vm = self.inner.as_initializing_vm().unwrap();
-        vm.vm_pages().add_mmio_region(addr, len).unwrap();
-    }
-
     /// Adds a PCI BAR memory region to the host VM.
     pub fn add_pci_region(&mut self, addr: GuestPageAddr, len: u64) {
         let vm = self.inner.as_initializing_vm().unwrap();
@@ -1953,6 +1947,12 @@ impl<T: GuestStagePagingMode> HostVm<T> {
     /// Completes intialization of the host VM, making it runnable.
     pub fn finalize(&self) -> GuestTrackingResult<()> {
         self.inner.finalize()
+    }
+
+    /// Adds an emulated MMIO region to the host VM.
+    pub fn add_mmio_region(&mut self, addr: GuestPageAddr, len: u64) {
+        let vm = self.inner.as_finalized_vm().unwrap();
+        vm.vm_pages().add_mmio_region(addr, len).unwrap();
     }
 
     /// Run the host VM's vCPU with ID `vcpu_id`. Does not return.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -661,6 +661,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
             SbiMessage::TeeInterrupt(interrupt_func) => {
                 self.handle_tee_interrupt_msg(interrupt_func, active_vcpu.active_pages())
             }
+            SbiMessage::TeeGuest(_) => todo!(),
             SbiMessage::Attestation(attestation_func) => {
                 self.handle_attestation_msg(attestation_func, active_vcpu.active_pages())
             }

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -923,18 +923,6 @@ impl<'a, T: GuestStagePagingMode, S> VmPagesRef<'a, T, S> {
         .ok_or(Error::UnalignedAddress)?;
         self.inner.regions.add(page_addr, end, region_type)
     }
-
-    /// Adds a shared memory region of `len` bytes starting at `page_addr` to this VM's address
-    /// space.
-    pub fn add_shared_memory_region(&self, page_addr: GuestPageAddr, len: u64) -> Result<()> {
-        self.do_add_region(page_addr, len, VmRegionType::Shared)
-    }
-
-    /// Adds an emulated MMIO region of `len` bytes starting at `page_addr` to this VM's address
-    /// space.
-    pub fn add_mmio_region(&self, page_addr: GuestPageAddr, len: u64) -> Result<()> {
-        self.do_add_region(page_addr, len, VmRegionType::Mmio)
-    }
 }
 
 impl<'a, T: GuestStagePagingMode, S> Clone for VmPagesRef<'a, T, S> {
@@ -952,6 +940,18 @@ pub type AnyVmPages<'a, T> = VmPagesRef<'a, T, VmStateAny>;
 pub type FinalizedVmPages<'a, T> = VmPagesRef<'a, T, VmStateFinalized>;
 
 impl<'a, T: GuestStagePagingMode> FinalizedVmPages<'a, T> {
+    /// Adds a shared memory region of `len` bytes starting at `page_addr` to this VM's address
+    /// space.
+    pub fn add_shared_memory_region(&self, page_addr: GuestPageAddr, len: u64) -> Result<()> {
+        self.do_add_region(page_addr, len, VmRegionType::Shared)
+    }
+
+    /// Adds an emulated MMIO region of `len` bytes starting at `page_addr` to this VM's address
+    /// space.
+    pub fn add_mmio_region(&self, page_addr: GuestPageAddr, len: u64) -> Result<()> {
+        self.do_add_region(page_addr, len, VmRegionType::Mmio)
+    }
+
     // Returns a list of converted and locked pages created from `num_pages` starting at
     // `page_addr`.
     fn get_converted_pages(

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -881,15 +881,6 @@ impl<'a, T: GuestStagePagingMode, S> VmPagesRef<'a, T, S> {
         self.do_map_pages(page_addr, count, VmRegionType::Confidential)
     }
 
-    /// Same as `map_zero_pages()`, but for pages in shared (non-confidential) regions.
-    pub fn map_shared_pages(
-        &self,
-        page_addr: GuestPageAddr,
-        count: u64,
-    ) -> Result<SharedPagesMapper<'a, T>> {
-        self.do_map_pages(page_addr, count, VmRegionType::Shared)
-    }
-
     /// Same as `map_zero_pages()`, but for IMSIC guest interrupt file pages.
     pub fn map_imsic_pages(
         &self,
@@ -950,6 +941,15 @@ impl<'a, T: GuestStagePagingMode> FinalizedVmPages<'a, T> {
     /// space.
     pub fn add_mmio_region(&self, page_addr: GuestPageAddr, len: u64) -> Result<()> {
         self.do_add_region(page_addr, len, VmRegionType::Mmio)
+    }
+
+    /// Same as `map_zero_pages()`, but for pages in shared (non-confidential) regions.
+    pub fn map_shared_pages(
+        &self,
+        page_addr: GuestPageAddr,
+        count: u64,
+    ) -> Result<SharedPagesMapper<'a, T>> {
+        self.do_map_pages(page_addr, count, VmRegionType::Shared)
     }
 
     // Returns a list of converted and locked pages created from `num_pages` starting at
@@ -1217,7 +1217,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVmPages<'a, T> {
         &self,
         from_addr: GuestPageAddr,
         count: u64,
-        to: AnyVmPages<T>,
+        to: FinalizedVmPages<T>,
         to_addr: GuestPageAddr,
     ) -> Result<()> {
         let shared_list = self

--- a/test-workloads/src/bin/consts.rs
+++ b/test-workloads/src/bin/consts.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Not all constants are used in both binaries.
+#![allow(dead_code)]
+
+/// Constants defining the layout of the Tellus & GuestVM address space.
+///
+/// The composite Tellus + Guest VM image has this layout in physical memory:
+///
+/// +-------------------------+ 0x8020_0000
+/// | Tellus image            |
+/// +-------------------------+ +NUM_TELLUS_IMAGE_PAGES
+/// | Guest image             |
+/// +-------------------------+
+///
+/// The guest VM's address space is constructed to look like this:
+///
+/// +-------------------------+ 0x1000_0000
+/// | MMIO (4kB)              |
+/// |-------------------------|
+/// | <empty>                 |
+/// |-------------------------| 0x2800_0000
+/// | IMSIC (1MB)             |
+/// |-------------------------|
+/// | <empty>                 |
+/// |-------------------------| 0x8020_0000
+/// | Guest image             |
+/// |-------------------------| +NUM_GUEST_DATA_PAGES
+/// | Guest zero pages        |
+/// |-------------------------| +NUM_GUEST_ZERO_PAGES
+/// | <empty>                 |
+/// |-------------------------| 0x1_0000_0000
+/// | Shared pages            |
+/// +-------------------------+ +NUM_GUEST_SHARED_PAGES
+
+pub const PAGE_SIZE_4K: u64 = 4096;
+pub const NUM_TELLUS_IMAGE_PAGES: u64 = 32;
+pub const GUEST_MMIO_START_ADDRESS: u64 = 0x1000_8000;
+pub const GUEST_MMIO_END_ADDRESS: u64 = GUEST_MMIO_START_ADDRESS + PAGE_SIZE_4K - 1;
+pub const IMSIC_START_ADDRESS: u64 = 0x2800_0000;
+pub const USABLE_RAM_START_ADDRESS: u64 = 0x8020_0000;
+pub const NUM_GUEST_DATA_PAGES: u64 = 160;
+pub const GUEST_ZERO_PAGES_START_ADDRESS: u64 =
+    USABLE_RAM_START_ADDRESS + NUM_GUEST_DATA_PAGES * PAGE_SIZE_4K;
+pub const NUM_GUEST_ZERO_PAGES: u64 = 10;
+pub const PRE_FAULTED_ZERO_PAGES: u64 = 2;
+pub const GUEST_ZERO_PAGES_END_ADDRESS: u64 =
+    GUEST_ZERO_PAGES_START_ADDRESS + NUM_GUEST_ZERO_PAGES * PAGE_SIZE_4K - 1;
+pub const GUEST_SHARED_PAGES_START_ADDRESS: u64 = 0x1_0000_0000;
+pub const NUM_GUEST_SHARED_PAGES: u64 = 1;
+pub const GUEST_SHARED_PAGES_END_ADDRESS: u64 =
+    GUEST_SHARED_PAGES_START_ADDRESS + NUM_GUEST_SHARED_PAGES * PAGE_SIZE_4K - 1;
+pub const GUEST_SHARE_PING: u64 = 0xBAAD_F00D;
+pub const GUEST_SHARE_PONG: u64 = 0xF00D_BAAD;


### PR DESCRIPTION
Per the rationale described in #104, make MMIO and shared memory region registration a guest-side function.

Patch 1 adds the new TEE-Guest SBI extension with these functions, patch 2 wires them up, patches 3 & 4 convert existing users of the host-side equivalents, and patch 5 removes those host-side functions.

Fixes #104 