### PR TITLE
Require that zero pages only be added to finalized TVMs

### DIFF
--- a/sbi/src/tee_host.rs
+++ b/sbi/src/tee_host.rs
@@ -288,7 +288,8 @@ pub enum TeeHostFunction {
     },
     /// Maps `num_pages` zero-filled pages of confidential memory starting at `page_addr` into the
     /// specified guest's address space at `guest_addr`. The mapping must lie within a region of
-    /// confidential memory created with `TvmAddMemoryRegion`. Zero pages may be added at any time.
+    /// confidential memory created with `TvmAddMemoryRegion`. Zero pages may only be added after
+    /// the TVM has been finalized.
     ///
     /// a6 = 3
     TvmAddZeroPages {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1300,17 +1300,12 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
 
         let from_page_addr = self.guest_addr_from_raw(page_addr)?;
         let guest = self.guest_by_id(guest_id)?;
-        let to_page_addr = PageAddr::new(RawAddr::guest(guest_addr, guest.page_owner_id()))
+        let guest_vm = guest
+            .as_finalized_vm()
             .ok_or(EcallError::Sbi(SbiError::InvalidParam))?;
-
-        // Zero pages may be added to either running or initialized VMs.
+        let to_page_addr = guest_vm.guest_addr_from_raw(guest_addr)?;
         self.vm_pages()
-            .add_zero_pages_to(
-                from_page_addr,
-                num_pages,
-                guest.as_any_vm().vm_pages(),
-                to_page_addr,
-            )
+            .add_zero_pages_to(from_page_addr, num_pages, guest_vm.vm_pages(), to_page_addr)
             .map_err(EcallError::from)?;
 
         Ok(num_pages)

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -870,17 +870,6 @@ impl<'a, T: GuestStagePagingMode, S> VmPagesRef<'a, T, S> {
         VmPagesMapper::new_in_region(self.inner, page_addr, count, region_type)
     }
 
-    /// Locks `count` 4kB pages starting at `page_addr` for mapping of zero-filled pages in a
-    /// region of confidential memory, returning a `VmPagesMapper` that can be used to insert
-    /// the pages.
-    pub fn map_zero_pages(
-        &self,
-        page_addr: GuestPageAddr,
-        count: u64,
-    ) -> Result<ZeroPagesMapper<'a, T>> {
-        self.do_map_pages(page_addr, count, VmRegionType::Confidential)
-    }
-
     /// Same as `map_zero_pages()`, but for IMSIC guest interrupt file pages.
     pub fn map_imsic_pages(
         &self,
@@ -941,6 +930,17 @@ impl<'a, T: GuestStagePagingMode> FinalizedVmPages<'a, T> {
     /// space.
     pub fn add_mmio_region(&self, page_addr: GuestPageAddr, len: u64) -> Result<()> {
         self.do_add_region(page_addr, len, VmRegionType::Mmio)
+    }
+
+    /// Locks `count` 4kB pages starting at `page_addr` for mapping of zero-filled pages in a
+    /// region of confidential memory, returning a `VmPagesMapper` that can be used to insert
+    /// the pages.
+    pub fn map_zero_pages(
+        &self,
+        page_addr: GuestPageAddr,
+        count: u64,
+    ) -> Result<ZeroPagesMapper<'a, T>> {
+        self.do_map_pages(page_addr, count, VmRegionType::Confidential)
     }
 
     /// Same as `map_zero_pages()`, but for pages in shared (non-confidential) regions.
@@ -1192,7 +1192,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVmPages<'a, T> {
         &self,
         from_addr: GuestPageAddr,
         count: u64,
-        to: AnyVmPages<T>,
+        to: FinalizedVmPages<T>,
         to_addr: GuestPageAddr,
     ) -> Result<u64> {
         let converted_pages = self.get_converted_pages(from_addr, count)?;


### PR DESCRIPTION
In order to be consistent with existing confidential-computing solutions and to guarantee that all mappings made pre-finalization are measured, require that zero pages only be inserted post-finalization. Patches 1&2 update the host VM and tellus to be compliant with this requirement, patch 3 enforces it.

Fixes #105 