### PR TITLE
Allocate vCPU state on vCPU creation.

### DIFF
--- a/page-tracking/src/collections/page_arc.rs
+++ b/page-tracking/src/collections/page_arc.rs
@@ -8,7 +8,7 @@ use core::ops::Deref;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use riscv_pages::{InternalClean, InternalDirty, Page, PageAddr, PageSize, PhysPage, RawAddr};
+use riscv_pages::{InternalClean, InternalDirty, PageAddr, PageSize, RawAddr, SequentialPages};
 
 use crate::collections::PageBox;
 use crate::PageTracker;
@@ -18,6 +18,7 @@ struct PageArcInner<T> {
     data: T,
     rc: AtomicUsize,
     page_size: PageSize,
+    page_count: u64,
     page_tracker: PageTracker,
 }
 
@@ -32,20 +33,41 @@ struct PageArcInner<T> {
 pub struct PageArc<T>(NonNull<PageArcInner<T>>);
 
 impl<T> PageArc<T> {
+    /// Try to create a `PageArc` that wraps the given data using
+    /// `pages` to store it, returning it to its previous owner on
+    /// `drop()` using `page_tracker`. Returns `None` if not enough
+    /// pages are supplied.
+    pub fn try_new(
+        data: T,
+        pages: SequentialPages<InternalClean>,
+        page_tracker: PageTracker,
+    ) -> Option<Self> {
+        if core::mem::size_of::<PageArcInner<T>>() <= pages.length_bytes() as usize {
+            Some(Self::new_with(data, pages, page_tracker))
+        } else {
+            None
+        }
+    }
+
     /// Creates a `PageArc` that wraps the given data using `page` as the backing store. The page is
     /// released back to the previous owner when the last reference is dropped using `page_tracker`.
-    pub fn new_with(data: T, page: Page<InternalClean>, page_tracker: PageTracker) -> Self {
-        let ptr = page.addr().bits() as *mut PageArcInner<T>;
+    pub fn new_with(
+        data: T,
+        pages: SequentialPages<InternalClean>,
+        page_tracker: PageTracker,
+    ) -> Self {
+        let ptr = pages.base().bits() as *mut PageArcInner<T>;
         assert!(!ptr.is_null()); // Explicitly ban pages at zero address.
         let inner = PageArcInner {
             data,
             rc: AtomicUsize::new(1),
-            page_size: page.size(),
+            page_size: pages.page_size(),
+            page_count: pages.len(),
             page_tracker,
         };
-        assert!(core::mem::size_of::<PageArcInner<T>>() <= page.size() as usize);
         unsafe {
             // Safe as the memory is totally owned and PageArcInner<T> fits in the page.
+            assert!(core::mem::size_of::<PageArcInner<T>>() <= pages.length_bytes() as usize);
             core::ptr::write(ptr, inner);
         }
         Self(NonNull::new(ptr).unwrap())
@@ -67,11 +89,18 @@ impl<T> PageArc<T> {
         this.inner().rc.load(Ordering::Acquire);
 
         let page_size = this.inner().page_size;
+        let page_count = this.inner().page_count;
         let page_tracker = this.inner().page_tracker.clone();
         // Safety: PageArcInner is repr(C) with data as the first field, therefore a pointer to data
         // is a page-aligned and properly initialized pointer to T.
-        let boxed =
-            unsafe { PageBox::from_raw(Self::as_ptr(&this) as *mut T, page_size, 1, page_tracker) };
+        let boxed = unsafe {
+            PageBox::from_raw(
+                Self::as_ptr(&this) as *mut T,
+                page_size,
+                page_count,
+                page_tracker,
+            )
+        };
         core::mem::forget(this);
         Ok(boxed)
     }
@@ -91,6 +120,23 @@ impl<T> PageArc<T> {
         // Safe since we were initialized to point to a valid PageArcInner in the constructor and
         // if we still hold a reference the structure we point to must still be alive.
         unsafe { self.0.as_ref() }
+    }
+
+    /// Returns the `SequentialPages` backing this `PageArc`.
+    ///
+    /// # Safety
+    ///
+    /// This method semantically takes ownership of the backing storage of this container without
+    /// preventing further usage. It is the caller's responsibility to ensure that this `PageArc`
+    /// is never used again.
+    unsafe fn take_pages(&mut self) -> SequentialPages<InternalDirty> {
+        // Unwrap ok, the backing pages must've been contiguous.
+        SequentialPages::from_mem_range(
+            PageAddr::new(RawAddr::supervisor(self.0.as_ptr() as u64)).unwrap(),
+            self.inner().page_size,
+            self.inner().page_count,
+        )
+        .unwrap()
     }
 }
 
@@ -124,17 +170,13 @@ impl<T> Drop for PageArc<T> {
         }
 
         let page_tracker = self.inner().page_tracker.clone();
-        let page_size = self.inner().page_size;
-        // Safe because we now have unique ownership of the page this PageArc was constructed with.
-        let page: Page<InternalDirty> = unsafe {
-            Page::new_with_size(
-                PageAddr::new(RawAddr::supervisor(self.0.as_ptr() as u64)).unwrap(),
-                page_size,
-            )
-        };
+        // Safe because we're in drop() and this PageArc can no longer be used.
+        let pages = unsafe { self.take_pages() };
 
-        // Unwrap ok: we have unique ownership of the page so we must be able to release it.
-        page_tracker.release_page(page).unwrap();
+        for p in pages {
+            // Unwrap ok: we have unique ownership of the page so we must be able to release it.
+            page_tracker.release_page(p).unwrap();
+        }
     }
 }
 
@@ -181,27 +223,24 @@ mod tests {
     use crate::TlbVersion;
     use riscv_pages::*;
 
-    fn stub_page() -> (PageTracker, Page<InternalClean>) {
+    fn stub_pages(n: usize) -> (PageTracker, SequentialPages<InternalClean>) {
         let (page_tracker, mut pages) = PageTracker::new_in_test();
-        let assigned_page = pages
-            .by_ref()
-            .take(1)
-            .map(|p| {
-                page_tracker
-                    .assign_page_for_internal_state(p, PageOwnerId::host())
-                    .unwrap()
-            })
-            .next()
-            .unwrap();
-        (page_tracker, assigned_page)
+        let assigned_pages = SequentialPages::from_pages(pages.by_ref().take(n).map(|p| {
+            page_tracker
+                .assign_page_for_internal_state(p, PageOwnerId::host())
+                .unwrap()
+        }))
+        .unwrap();
+        (page_tracker, assigned_pages)
     }
 
     #[test]
     fn lifecycle() {
-        let (page_tracker, backing_page) = stub_page();
-        let addr = backing_page.addr();
+        const TEST_PAGE_COUNT: usize = 1;
+        let (page_tracker, backing_pages) = stub_pages(TEST_PAGE_COUNT);
+        let addr = backing_pages.base();
         {
-            let arc = PageArc::new_with([5u8; 128], backing_page, page_tracker.clone());
+            let arc = PageArc::new_with([5u8; 128], backing_pages, page_tracker.clone());
             assert_eq!(PageArc::ref_count(&arc), 1);
             {
                 let copy = arc.clone();
@@ -221,6 +260,40 @@ mod tests {
             .is_ok());
     }
 
+    #[test]
+    #[should_panic]
+    fn new_with_not_enough_backing_pages_should_panic() {
+        const TEST_PAGE_COUNT: usize = 3;
+        const TEST_BYTES: usize = 1 + TEST_PAGE_COUNT * PageSize::Size4k as usize /* 1 byte bigger than backing pages */;
+        let (page_tracker, mut pages) = PageTracker::new_in_test();
+        let assigned_pages =
+            SequentialPages::from_pages(pages.by_ref().take(TEST_PAGE_COUNT).map(|p| {
+                page_tracker
+                    .assign_page_for_internal_state(p, PageOwnerId::host())
+                    .unwrap()
+            }))
+            .unwrap();
+
+        let _pb = PageArc::new_with([5u8; TEST_BYTES], assigned_pages, page_tracker.clone());
+    }
+
+    #[test]
+    fn try_new_not_enough_backing_pages_should_fail() {
+        const TEST_PAGE_COUNT: usize = 3;
+        const TEST_BYTES: usize = 1 + TEST_PAGE_COUNT * PageSize::Size4k as usize /* 1 byte bigger than backing pages */;
+        let (page_tracker, mut pages) = PageTracker::new_in_test();
+        let assigned_pages =
+            SequentialPages::from_pages(pages.by_ref().take(TEST_PAGE_COUNT).map(|p| {
+                page_tracker
+                    .assign_page_for_internal_state(p, PageOwnerId::host())
+                    .unwrap()
+            }))
+            .unwrap();
+
+        let pb = PageArc::try_new([5u8; TEST_BYTES], assigned_pages, page_tracker.clone());
+        assert!(pb.is_none());
+    }
+
     #[derive(Debug)]
     struct ArcTest<'a> {
         flag: &'a mut bool,
@@ -234,14 +307,14 @@ mod tests {
 
     #[test]
     fn destructor() {
-        let (page_tracker, backing_page) = stub_page();
+        let (page_tracker, backing_pages) = stub_pages(3);
         let mut destroyed = false;
         {
             let arc = PageArc::new_with(
                 ArcTest {
                     flag: &mut destroyed,
                 },
-                backing_page,
+                backing_pages,
                 page_tracker.clone(),
             );
             assert_eq!(PageArc::ref_count(&arc), 1);

--- a/sbi/src/api/tee_host.rs
+++ b/sbi/src/api/tee_host.rs
@@ -73,24 +73,10 @@ pub fn reclaim_pages(addr: u64, num_pages: u64) -> Result<()> {
 ///
 /// - tvm_state_addr: The base physical address of the confidential memory region to be used to hold
 /// the TVM's global state. Must be page-aligned and `TsmInfo::tvm_state_pages` pages in length.
-///
-/// - tvm_num_vcpus: The maximum number of vCPUs that will be created for this TVM. Must be less
-/// than or equal to `TsmInfo::tvm_max_vcpus`.
-///
-/// - tvm_vcpu_addr: The base physical address of the confidential memory region to be used to hold
-/// the TVM's vCPU state. Must be page-aligned and `TsmInfo::tvm_bytes_per_vcpu` * `tvm_num_vcpus`
-/// bytes in length, rounded up to the nearest multiple of 4kB.
-pub fn tvm_create(
-    tvm_page_directory_addr: u64,
-    tvm_state_addr: u64,
-    tvm_num_vcpus: u64,
-    tvm_vcpu_addr: u64,
-) -> Result<u64> {
+pub fn tvm_create(tvm_page_directory_addr: u64, tvm_state_addr: u64) -> Result<u64> {
     let tvm_create_params = TvmCreateParams {
         tvm_page_directory_addr,
         tvm_state_addr,
-        tvm_num_vcpus,
-        tvm_vcpu_addr,
     };
     let msg = SbiMessage::TeeHost(TvmCreate {
         params_addr: (&tvm_create_params as *const TvmCreateParams) as u64,
@@ -169,10 +155,16 @@ pub fn get_vcpu_register_set(vmid: u64, index: u64) -> Result<RegisterSetLocatio
 /// sufficient to hold the structure layout returned from `get_vcpu_mem_layout()`. Since memory
 /// within the shared-memory state area may be read or written by the TSM at any time, the caller
 /// must treat the memory as volatile for the lifetime of the TVM.
-pub unsafe fn add_vcpu(vmid: u64, vcpu_id: u64, shared_page_addr: u64) -> Result<()> {
+pub unsafe fn add_vcpu(
+    vmid: u64,
+    vcpu_id: u64,
+    state_addr: u64,
+    shared_page_addr: u64,
+) -> Result<()> {
     let msg = SbiMessage::TeeHost(TvmCpuCreate {
         guest_id: vmid,
         vcpu_id,
+        state_addr,
         shared_page_addr,
     });
     ecall_send(&msg)?;

--- a/sbi/src/tee_host.rs
+++ b/sbi/src/tee_host.rs
@@ -159,8 +159,8 @@ pub struct TsmInfo {
     pub tvm_state_pages: u64,
     /// The maximum number of vCPUs a TVM can support.
     pub tvm_max_vcpus: u64,
-    /// The number of bytes per vCPU which must be donated to the TSM when creating a new TVM.
-    pub tvm_bytes_per_vcpu: u64,
+    /// The number of 4kB pages which must be donated to the TSM when creating a new VCPU.
+    pub tvm_vcpu_state_pages: u64,
 }
 
 /// Parameters used for creating a new confidential VM.
@@ -172,13 +172,6 @@ pub struct TvmCreateParams {
     /// The base physical address of the confidential memory region to be used to hold the TVM's
     /// global state. Must be page-aligned and `TsmInfo::tvm_state_pages` pages in length.
     pub tvm_state_addr: u64,
-    /// The maximum number of vCPUs that will be created for this TVM. Must be less than or equal
-    /// to `TsmInfo::tvm_max_vcpus`.
-    pub tvm_num_vcpus: u64,
-    /// The base physical address of the confidential memory region to be used to hold the TVM's
-    /// vCPU state. Must be page-aligned and `TsmInfo::tvm_bytes_per_vcpu` * `tvm_num_vcpus` bytes
-    /// in length, rounded up to the nearest multiple of 4kB.
-    pub tvm_vcpu_addr: u64,
 }
 
 /// Types of pages allowed to used for creating or managing confidential VMs.
@@ -352,6 +345,9 @@ pub enum TeeHostFunction {
     /// Adds a vCPU with ID `vcpu_id` to the guest `guest_id`, registering `shared_page_addr` as
     /// the location of the shared-memory state area for this vCPU.
     ///
+    /// `state_addr` must be page-aligned and point to a confidential memory region to be used to
+    /// hold the TVM's vCPU state. Must be `TsmInfo::tvm_vcpu_state_pages` pages in length.
+    ///
     /// `shared_page_addr` must be page-aligned and point to a sufficient number of non-confidential
     /// pages to hold a structure with the layout specified by the register set enumeration process
     /// described above. These pages are "pinned" in the non-confidential state (i.e. cannot be
@@ -365,7 +361,9 @@ pub enum TeeHostFunction {
         guest_id: u64,
         /// a1 = vCPU id
         vcpu_id: u64,
-        /// a2 = page address of shared state structure
+        /// a2 = address of the first page donated for the vCPU
+        state_addr: u64,
+        /// a3 = page address of shared state structure
         shared_page_addr: u64,
     },
     /// Writes up to `len` bytes of the `TsmInfo` structure to the non-confidential physical address
@@ -504,7 +502,8 @@ impl TeeHostFunction {
             8 => Ok(TvmCpuCreate {
                 guest_id: args[0],
                 vcpu_id: args[1],
-                shared_page_addr: args[2],
+                state_addr: args[2],
+                shared_page_addr: args[3],
             }),
             10 => Ok(TsmGetInfo {
                 dest_addr: args[0],
@@ -582,6 +581,7 @@ impl SbiFunction for TeeHostFunction {
             TvmCpuCreate {
                 guest_id: _,
                 vcpu_id: _,
+                state_addr: _,
                 shared_page_addr: _,
             } => 8,
             TsmGetInfo {
@@ -657,6 +657,7 @@ impl SbiFunction for TeeHostFunction {
             TvmCpuCreate {
                 guest_id,
                 vcpu_id: _,
+                state_addr: _,
                 shared_page_addr: _,
             } => *guest_id,
             TsmGetInfo { dest_addr, len: _ } => *dest_addr,
@@ -723,6 +724,7 @@ impl SbiFunction for TeeHostFunction {
             TvmCpuCreate {
                 guest_id: _,
                 vcpu_id,
+                state_addr: _,
                 shared_page_addr: _,
             } => *vcpu_id,
             TsmGetInfo { dest_addr: _, len } => *len,
@@ -780,8 +782,9 @@ impl SbiFunction for TeeHostFunction {
             TvmCpuCreate {
                 guest_id: _,
                 vcpu_id: _,
-                shared_page_addr,
-            } => *shared_page_addr,
+                state_addr,
+                shared_page_addr: _,
+            } => *state_addr,
             TvmAddMeasuredPages {
                 guest_id: _,
                 src_addr: _,
@@ -827,6 +830,12 @@ impl SbiFunction for TeeHostFunction {
                 num_pages,
                 guest_addr: _,
             } => *num_pages,
+            TvmCpuCreate {
+                guest_id: _,
+                vcpu_id: _,
+                state_addr: _,
+                shared_page_addr,
+            } => *shared_page_addr,
             TvmAddMeasuredPages {
                 guest_id: _,
                 src_addr: _,

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -4,14 +4,12 @@
 
 use core::arch::global_asm;
 use core::{marker::PhantomData, mem::size_of, ptr, ptr::NonNull};
-use drivers::{imsic::ImsicFileId, imsic::ImsicLocation, CpuId, CpuInfo};
+use drivers::{imsic::ImsicFileId, imsic::ImsicLocation, CpuId, CpuInfo, MAX_CPUS};
 use memoffset::offset_of;
-use page_tracking::collections::PageVec;
-use page_tracking::{PageTracker, TlbVersion};
+use page_tracking::collections::PageBox;
+use page_tracking::TlbVersion;
 use riscv_page_tables::GuestStagePagingMode;
-use riscv_pages::{
-    GuestPhysAddr, GuestVirtAddr, InternalClean, PageOwnerId, PageSize, RawAddr, SequentialPages,
-};
+use riscv_pages::{GuestPhysAddr, GuestVirtAddr, PageOwnerId, PageSize, RawAddr};
 use riscv_regs::*;
 use sbi::{self, SbiMessage, SbiReturnType};
 use spin::{Mutex, MutexGuard, Once, RwLock, RwLockReadGuard};
@@ -30,7 +28,6 @@ pub enum Error {
     VmCpuRunning,
     VmCpuOff,
     VmCpuAlreadyPowered,
-    InsufficientVmCpuStorage,
     WrongAddressSpace,
     InvalidSharedStatePtr,
     InsufficientSharedStatePages,
@@ -38,9 +35,8 @@ pub enum Error {
 
 pub type Result<T> = core::result::Result<T, Error>;
 
-/// The number of bytes required to hold the state of a single vCPU. We include the overhead for the
-/// `PageVec<>` itself to ensure enough bytes are donated for it as well.
-pub const VM_CPU_BYTES: u64 = (size_of::<VmCpusInner>() + size_of::<PageVec<VmCpusInner>>()) as u64;
+/// The number of 4k pages required to hold the data associated with a single vCPU.
+pub const VM_CPU_STATE_PAGES: u64 = PageSize::num_4k_pages(size_of::<Mutex<VmCpu>>() as u64);
 
 /// Host GPR and CSR state which must be saved/restored when entering/exiting virtualization.
 #[derive(Default)]
@@ -519,7 +515,7 @@ struct CurrentCpu {
 pub struct VmCpu {
     state: VmCpuState,
     // Initialized in add_vcpu().
-    shared_area: Once<VmCpuSharedArea>,
+    shared_area: VmCpuSharedArea,
     imsic_location: Option<ImsicLocation>,
     pmu_state: VmPmuState,
     current_cpu: Option<CurrentCpu>,
@@ -533,7 +529,7 @@ pub struct VmCpu {
 
 impl VmCpu {
     // Creates a new vCPU.
-    fn new(vcpu_id: u64, guest_id: PageOwnerId) -> Self {
+    pub fn new(vcpu_id: u64, guest_id: PageOwnerId, shared_area: VmCpuSharedArea) -> Self {
         let mut state = VmCpuState::default();
 
         // A0 holds the hart ID on entry.
@@ -564,7 +560,7 @@ impl VmCpu {
 
         Self {
             state,
-            shared_area: Once::new(),
+            shared_area,
             imsic_location: None,
             pmu_state: VmPmuState::default(),
             current_cpu: None,
@@ -578,7 +574,7 @@ impl VmCpu {
     // Returns a reference to the shared-memory state area for this vCPU.
     fn shared_area(&self) -> &VmCpuSharedArea {
         // Unwrap ok: shared_area must've been initialized for this vCPU to have been activated.
-        self.shared_area.get().unwrap()
+        &self.shared_area
     }
 }
 
@@ -1023,7 +1019,7 @@ impl<T: GuestStagePagingMode> Drop for ActiveVmCpu<'_, '_, '_, T> {
         // Return this vCPU to the `VmCpus` container.
         let entry = self
             .container
-            .inner
+            .vcpus
             .get(self.vcpu.vcpu_id as usize)
             .unwrap();
         let mut status = entry.status.write();
@@ -1102,63 +1098,69 @@ pub enum VmCpuStatus {
 struct VmCpusInner {
     // Locking: status must be locked before vcpu.
     status: RwLock<VmCpuStatus>,
-    vcpu: Mutex<VmCpu>,
+    vcpu: Once<PageBox<Mutex<VmCpu>>>,
+}
+
+impl Default for VmCpusInner {
+    fn default() -> Self {
+        VmCpusInner {
+            status: RwLock::new(VmCpuStatus::NotPresent),
+            vcpu: Once::new(),
+        }
+    }
 }
 
 /// The set of vCPUs in a VM.
 pub struct VmCpus {
-    inner: PageVec<VmCpusInner>,
+    num: RwLock<usize>,
+    vcpus: [VmCpusInner; MAX_CPUS],
 }
 
 impl VmCpus {
     /// Creates a new vCPU tracking structure backed by `pages`.
-    pub fn new(
-        guest_id: PageOwnerId,
-        pages: SequentialPages<InternalClean>,
-        page_tracker: PageTracker,
-    ) -> Result<Self> {
-        let num_vcpus = pages.length_bytes() / VM_CPU_BYTES;
-        if num_vcpus == 0 {
-            return Err(Error::InsufficientVmCpuStorage);
+    pub fn new() -> Self {
+        let vcpus = [(); MAX_CPUS].map(|_| VmCpusInner::default());
+        Self {
+            num: RwLock::new(0),
+            vcpus,
         }
-        let mut inner = PageVec::new(pages, page_tracker);
-        for i in 0..num_vcpus {
-            let entry = VmCpusInner {
-                status: RwLock::new(VmCpuStatus::NotPresent),
-                vcpu: Mutex::new(VmCpu::new(i, guest_id)),
-            };
-            inner.push(entry);
-        }
-        Ok(Self { inner })
     }
 
     /// Returns the number of vCPUs in this `VmCpus`.
     pub fn num_vcpus(&self) -> usize {
-        self.inner.len()
+        *self.num.read()
     }
 
     /// Adds the vCPU at `vcpu_id` as an available vCPU using `shared_area` as the vCPU's shared
     /// state-memory state area.
-    pub fn add_vcpu(&self, vcpu_id: u64, shared_area: VmCpuSharedArea) -> Result<()> {
-        let entry = self.inner.get(vcpu_id as usize).ok_or(Error::BadCpuId)?;
+    pub fn add_vcpu(&self, vcpu_id: u64, vcpu_box: PageBox<Mutex<VmCpu>>) -> Result<()> {
+        let entry = self.vcpus.get(vcpu_id as usize).ok_or(Error::BadCpuId)?;
         let mut status = entry.status.write();
         if *status != VmCpuStatus::NotPresent {
             return Err(Error::VmCpuExists);
         }
-        entry.vcpu.lock().shared_area.call_once(|| shared_area);
         *status = VmCpuStatus::PoweredOff;
+
+        assert!(!entry.vcpu.is_completed());
+        entry.vcpu.call_once(|| vcpu_box);
+
+        {
+            let mut n = self.num.write();
+            *n += 1;
+        }
+
         Ok(())
     }
 
     /// Returns a reference to the vCPU with `vcpu_id` if it exists and is not currently running.
     /// The returned `IdleVmCpu` is guaranteed not to change state until it is dropped.
     pub fn get_vcpu(&self, vcpu_id: u64) -> Result<IdleVmCpu> {
-        let entry = self.inner.get(vcpu_id as usize).ok_or(Error::BadCpuId)?;
+        let entry = self.vcpus.get(vcpu_id as usize).ok_or(Error::BadCpuId)?;
         let status = entry.status.read();
         match *status {
             VmCpuStatus::PoweredOff | VmCpuStatus::Runnable => Ok(IdleVmCpu {
                 _status: status,
-                vcpu: entry.vcpu.lock(),
+                vcpu: entry.vcpu.get().unwrap().lock(),
             }),
             VmCpuStatus::Running => Err(Error::VmCpuRunning),
             VmCpuStatus::NotPresent => Err(Error::VmCpuNotFound),
@@ -1168,14 +1170,14 @@ impl VmCpus {
     /// Marks the vCPU with `vcpu_id` as powered on and runnable and returns a reference to it.
     /// The returned `IdleVmCpu` is guaranteed not to change state until it is dropped.
     pub fn power_on_vcpu(&self, vcpu_id: u64) -> Result<IdleVmCpu> {
-        let entry = self.inner.get(vcpu_id as usize).ok_or(Error::BadCpuId)?;
+        let entry = self.vcpus.get(vcpu_id as usize).ok_or(Error::BadCpuId)?;
         let mut status = entry.status.write();
         match *status {
             VmCpuStatus::PoweredOff => {
                 *status = VmCpuStatus::Runnable;
                 Ok(IdleVmCpu {
                     _status: status.downgrade(),
-                    vcpu: entry.vcpu.lock(),
+                    vcpu: entry.vcpu.get().unwrap().lock(),
                 })
             }
             VmCpuStatus::Running | VmCpuStatus::Runnable => Err(Error::VmCpuAlreadyPowered),
@@ -1192,11 +1194,11 @@ impl VmCpus {
         vm_pages: FinalizedVmPages<'pages, T>,
         mut parent_vcpu: Option<&'prev mut ActiveVmCpu<T>>,
     ) -> Result<ActiveVmCpu<'vcpu, 'pages, 'prev, T>> {
-        let entry = self.inner.get(vcpu_id as usize).ok_or(Error::BadCpuId)?;
+        let entry = self.vcpus.get(vcpu_id as usize).ok_or(Error::BadCpuId)?;
         let mut status = entry.status.write();
         match *status {
             VmCpuStatus::Runnable => {
-                let vcpu = entry.vcpu.lock();
+                let vcpu = entry.vcpu.get().unwrap().lock();
                 if vcpu.guest_id != vm_pages.page_owner_id() {
                     return Err(Error::WrongAddressSpace);
                 }
@@ -1216,7 +1218,7 @@ impl VmCpus {
 
     /// Returns the status of the specified vCPU.
     pub fn get_vcpu_status(&self, vcpu_id: u64) -> Result<VmCpuStatus> {
-        let entry = self.inner.get(vcpu_id as usize).ok_or(Error::BadCpuId)?;
+        let entry = self.vcpus.get(vcpu_id as usize).ok_or(Error::BadCpuId)?;
         Ok(*entry.status.read())
     }
 }

--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -335,7 +335,6 @@ fn check_vectors() {
 /// The entry point of the Rust part of the kernel.
 #[no_mangle]
 extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
-    const NUM_VCPUS: u64 = 1;
     const NUM_TEE_PTE_PAGES: u64 = 10;
 
     if hart_id != 0 {
@@ -361,9 +360,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
 
     base::probe_sbi_extension(EXT_TEE_HOST).expect("Platform doesn't support TEE extension");
     let tsm_info = tee_host::get_info().expect("Tellus - TsmGetInfo failed");
-    let tvm_create_pages = 4
-        + tsm_info.tvm_state_pages
-        + ((NUM_VCPUS * tsm_info.tvm_bytes_per_vcpu) + PAGE_SIZE_4K - 1) / PAGE_SIZE_4K;
+    let tvm_create_pages = 4 + tsm_info.tvm_state_pages;
     println!("Donating {} pages for TVM creation", tvm_create_pages);
 
     // Make sure TsmGetInfo fails if we pass it a bogus address.
@@ -386,14 +383,9 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     let state_pages_base = next_page;
     let tvm_page_directory_addr = state_pages_base;
     let tvm_state_addr = tvm_page_directory_addr + 4 * PAGE_SIZE_4K;
-    let tvm_vcpu_addr = tvm_state_addr + tsm_info.tvm_state_pages * PAGE_SIZE_4K;
-    let vmid = tee_host::tvm_create(
-        tvm_page_directory_addr,
-        tvm_state_addr,
-        NUM_VCPUS,
-        tvm_vcpu_addr,
-    )
-    .expect("Tellus - TvmCreate returned error");
+
+    let vmid = tee_host::tvm_create(tvm_page_directory_addr, tvm_state_addr)
+        .expect("Tellus - TvmCreate returned error");
     println!("Tellus - TvmCreate Success vmid: {vmid:x}");
     next_page += PAGE_SIZE_4K * tvm_create_pages;
 
@@ -420,10 +412,19 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     let num_vcpu_shared_pages = TvmCpuSharedMem::required_pages(&vcpu_mem_layout);
 
     // Add vCPU0.
+
+    // Safety: The passed-in pages are unmapped and we do not access them again until they're
+    // reclaimed.
+    let vcpu_pages_base = next_page;
+    unsafe {
+        convert_pages(vcpu_pages_base, tsm_info.tvm_vcpu_state_pages);
+    }
+    next_page += PAGE_SIZE_4K * tsm_info.tvm_vcpu_state_pages;
+
     let vcpu_state_addr = next_page;
     next_page += num_vcpu_shared_pages * PAGE_SIZE_4K;
     // Safety: We own `vcpu_state_addr` and will only access it through volatile reads/writes.
-    unsafe { tee_host::add_vcpu(vmid, 0, vcpu_state_addr) }
+    unsafe { tee_host::add_vcpu(vmid, 0, vcpu_pages_base, vcpu_state_addr) }
         .expect("Tellus - TvmCpuCreate returned error");
     // Safety: `vcpu_state_addr` points to a sufficient number of pages to hold the requested layout
     // and will not be used for any other purpose for the duration of `kernel_init()`.
@@ -702,6 +703,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
         NUM_GUEST_DATA_PAGES + NUM_GUEST_ZERO_PAGES,
     );
     reclaim_pages(state_pages_base, tvm_create_pages);
+    reclaim_pages(vcpu_pages_base, tsm_info.tvm_vcpu_state_pages);
     if has_aia {
         tee_interrupt::reclaim_imsic(imsic_file_addr).expect("Tellus - TsmReclaimImsic failed");
     }


### PR DESCRIPTION
This PR adds support for vCPUs state to be donated from the host at vCPU creation, not at TVM creation.

Lots of things going on here, in broad strokes:

1. TvmCpuCreate and TvmCreate interface are modified. TvmCreate doesn't need to know the number of vCPUs nor pass a global vcpu state address for all the future vcpus.
2. VmCpus is modified to hold a static array of MAX_VCPUS of what are essentially pointers to future vCPUs.
3. Given the previous point, the tvm state is now bigger than a page, so PageArc has to be modified to support SequentialPages as backing. This work is in line with what has been done to PageBox to hold the vCPU state.
4. A chunk allocator is added to Sequential Pages to allow to iterate on chunks of fixed number of pages at the time.
