### PR TITLE
Add support for binding/unbding vCPUs to interrupt files

### DIFF
--- a/drivers/src/imsic/error.rs
+++ b/drivers/src/imsic/error.rs
@@ -41,6 +41,8 @@ pub enum Error {
     InvalidCpu(CpuId),
     /// Guest files for this CPU have already been taken.
     GuestFilesTaken(CpuId),
+    /// The provided IMSIC file ID was not a valid guest interrupt file.
+    InvalidGuestFile,
 }
 
 /// Holds the result of IMSIC operations.

--- a/drivers/src/imsic/mod.rs
+++ b/drivers/src/imsic/mod.rs
@@ -5,8 +5,10 @@
 mod core;
 mod error;
 mod geometry;
+mod sw_file;
 
 pub use self::core::{Imsic, ImsicGuestPage, ImsicGuestPageIter, ImsicInterruptId};
 pub use error::Error as ImsicError;
 pub use error::Result as ImsicResult;
 pub use geometry::*;
+pub use sw_file::SwFile;

--- a/drivers/src/imsic/sw_file.rs
+++ b/drivers/src/imsic/sw_file.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A single EIE/EIP pair.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+struct SwFileEntry {
+    pending: u64,
+    enable: u64,
+}
+
+/// The number of 64-bit EIE/EIP pairs in an interrupt file, as mandated by the AIA specification.
+pub const SW_FILE_ENTRIES: usize = 32;
+
+/// Holds the software-visible state of an IMSIC guest interrupt file. Used when a guest interrupt
+/// file is swapped out.
+///
+/// This is meant to resemble the memory-resident interrupt file (MRIF) structure described in chapter
+/// 9 of the AIA specification. Since we don't yet support those on the IOMMU side, this is simply
+/// a for-CPU-access-only version of that structure.
+///
+/// TODO: Actual MRIFs need to be 512-byte aligned and use atomic ops when manipulating the EIP bits.
+#[repr(C)]
+#[derive(Default)]
+pub struct SwFile {
+    entries: [SwFileEntry; SW_FILE_ENTRIES],
+    eidelivery: u64,
+    eithreshold: u64,
+}
+
+impl SwFile {
+    /// Creates an empty `SwFile`.
+    pub fn new() -> Self {
+        Self {
+            entries: [SwFileEntry::default(); 32],
+            eidelivery: 0,
+            eithreshold: 0,
+        }
+    }
+
+    /// Returns the saved value of the EIDEILVERY register.
+    pub fn eidelivery(&self) -> u64 {
+        self.eidelivery
+    }
+
+    /// Sets the saved value of the EIDELIVERY register.
+    pub fn set_eidelivery(&mut self, val: u64) {
+        self.eidelivery = val;
+    }
+
+    /// Returns the saved value of the EITHRESHOLD register.
+    pub fn eithreshold(&self) -> u64 {
+        self.eithreshold
+    }
+
+    /// Sets the saved value of the EITHRESHOLD register.
+    pub fn set_eithreshold(&mut self, val: u64) {
+        self.eithreshold = val;
+    }
+
+    /// Returns the saved value of the EIP register at `index`.
+    pub fn eip(&self, index: usize) -> u64 {
+        self.entries[index].pending
+    }
+
+    /// Sets the saved value of the EIP register at `index`.
+    pub fn set_eip(&mut self, index: usize, val: u64) {
+        self.entries[index].pending = val;
+    }
+
+    /// Returns the saved value of the EIE register at `index`.
+    pub fn eie(&self, index: usize) -> u64 {
+        self.entries[index].enable
+    }
+
+    /// Sets the saved value of the EIE register at `index`.
+    pub fn set_eie(&mut self, index: usize, val: u64) {
+        self.entries[index].enable = val;
+    }
+}

--- a/page-tracking/src/page_info.rs
+++ b/page-tracking/src/page_info.rs
@@ -37,11 +37,17 @@ pub enum PageState {
     /// data structures or as a page-table page for the VM.
     VmState,
 
-    /// Page has been invalidated and started the conversion operation at the given TLB version.
+    /// Page has been invalidated and started the conversion operation at the given TLB version in
+    /// the current owner's address space.
     Converting(TlbVersion),
 
-    /// Page has completed the conversion operation and is eligible for assignment or to be reclaimed.
-    /// The page must be locked exclusively before it can be assigned or reclaimed.
+    /// Page has been invalidated and started the unassignment operation at the given TLB version in
+    /// the current owner's address space. Upon completion, the page is returned to the previous owner
+    /// in the `Converted` state.
+    Unassigning(TlbVersion),
+
+    /// Page has completed the conversion or unassignment operation and is eligible for assignment or
+    /// to be reclaimed. The page must be locked exclusively before it can be assigned or reclaimed.
     Converted,
 }
 
@@ -110,7 +116,7 @@ impl PageInfo {
     pub fn owner(&self) -> Option<PageOwnerId> {
         use PageState::*;
         match self.state {
-            Converting(_) | Converted | Mapped | VmState | Shared(_) => {
+            Converting(_) | Unassigning(_) | Converted | Mapped | VmState | Shared(_) => {
                 if !self.owners.is_empty() {
                     Some(self.owners[self.owners.len() - 1])
                 } else {
@@ -146,7 +152,7 @@ impl PageInfo {
     pub fn release(&mut self) -> PageTrackingResult<()> {
         use PageState::*;
         match self.state {
-            Mapped | VmState | Converted | Converting(_) => {
+            Mapped | VmState | Converted | Converting(_) | Unassigning(_) => {
                 // Locked pages cannot be released
                 if self.locked {
                     return Err(PageTrackingError::PageLocked);
@@ -180,7 +186,7 @@ impl PageInfo {
         use PageState::*;
         if !matches!(new_state, Mapped | VmState | Converted) {
             // Going back to free/reserved isn't allowed, nor does it make sense for a page to
-            // immediately enter the "Converting" state.
+            // immediately enter the "Converting" or "Unassigning" state.
             return Err(PageTrackingError::InvalidStateTransition);
         }
         match self.state {
@@ -248,6 +254,49 @@ impl PageInfo {
         use PageState::*;
         match self.state {
             Converting(version) => version < tlb_version,
+            _ => false,
+        }
+    }
+
+    /// Transitions the page to Unassigning at `tlb_version` if it is currently Mapped.
+    pub fn begin_unassignment(&mut self, tlb_version: TlbVersion) -> PageTrackingResult<()> {
+        use PageState::*;
+        match self.state {
+            Mapped => {
+                self.state = Unassigning(tlb_version);
+                Ok(())
+            }
+            _ => Err(PageTrackingError::PageNotUnassignable),
+        }
+    }
+
+    /// Transitions the page to Converted and returns it to the previous owner if it is Unassigning
+    /// with a TLB version older than `tlb_version`. The page may then be reassigned to child VMs.
+    pub fn complete_unassignment(&mut self, tlb_version: TlbVersion) -> PageTrackingResult<()> {
+        use PageState::*;
+        match self.state {
+            Unassigning(version) => {
+                if version < tlb_version {
+                    if self.owners.is_empty() {
+                        Err(PageTrackingError::OwnerUnderflow)
+                    } else {
+                        self.owners.pop().unwrap();
+                        self.state = Converted;
+                        Ok(())
+                    }
+                } else {
+                    Err(PageTrackingError::PageNotUnassignable)
+                }
+            }
+            _ => Err(PageTrackingError::PageNotUnassignable),
+        }
+    }
+
+    /// Returns if the page is Unassigning and can complete unassignment at the given `tlb_version`.
+    pub fn is_unassignable(&self, tlb_version: TlbVersion) -> bool {
+        use PageState::*;
+        match self.state {
+            Unassigning(version) => version < tlb_version,
             _ => false,
         }
     }
@@ -715,9 +764,14 @@ mod tests {
         assert!(page.lock_for_assignment().is_ok());
         let guest_id = PageOwnerId::new(2).unwrap();
         assert!(page.assign(guest_id, PageState::Mapped).is_ok());
-        assert_eq!(page.release().unwrap(), ());
-        assert!(page.lock_for_assignment().is_ok());
+        let guest_version = TlbVersion::new();
+        assert!(page.begin_unassignment(guest_version).is_ok());
+        assert_eq!(page.state(), PageState::Unassigning(guest_version));
+        let guest_version = version.increment();
+        assert!(page.is_unassignable(guest_version));
+        assert!(page.complete_unassignment(guest_version).is_ok());
         assert_eq!(page.state(), PageState::Converted);
+        assert!(page.lock_for_assignment().is_ok());
         assert!(page.reclaim().is_ok());
 
         let mut page = PageInfo::new_reserved();

--- a/sbi/src/api/tee_host.rs
+++ b/sbi/src/api/tee_host.rs
@@ -7,9 +7,17 @@ use crate::{ecall_send, Error, Result, SbiMessage};
 use crate::{RegisterSetLocation, TeeMemoryRegion, TsmInfo, TsmPageType, TvmCreateParams};
 
 /// Initiates a TSM fence on this CPU.
-pub fn initiate_fence() -> Result<()> {
+pub fn tsm_initiate_fence() -> Result<()> {
     let msg = SbiMessage::TeeHost(TsmInitiateFence);
     // Safety: TsmInitiateFence doesn't read or write any memory we have access to.
+    unsafe { ecall_send(&msg) }?;
+    Ok(())
+}
+
+/// Initiates a fence for the given TVM.
+pub fn tvm_initiate_fence(vmid: u64) -> Result<()> {
+    let msg = SbiMessage::TeeHost(TvmInitiateFence { guest_id: vmid });
+    // Safety: TvmInitiateFence doesn't read or write any memory we have access to.
     unsafe { ecall_send(&msg) }?;
     Ok(())
 }

--- a/sbi/src/tee_host.rs
+++ b/sbi/src/tee_host.rs
@@ -456,8 +456,11 @@ pub enum TeeHostFunction {
     /// Returns 0 if the vCPU can be resumed via a subsequent call to `TvmCpuRun`, or a value other
     /// than 0 if the vCPU was terminated and is no longer runnable.
     ///
-    /// Returns an error if the specified TVM or vCPU does not exist, or if the vCPU exists but
-    /// is not currently runnable.
+    /// Returns an error if:
+    ///   - the specified TVM or vCPU does not exist
+    ///   - the vCPU exists but is not currently runnable
+    ///   - if hardware AIA virtualization is enabled for the TVM and the vCPU is not bound to
+    ///     this physical CPU
     ///
     /// a6 = 16
     TvmCpuRun {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1669,6 +1669,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
                 .into(),
             TsmConvertImsic { imsic_addr } => self.convert_imsic(imsic_addr).into(),
             TsmReclaimImsic { imsic_addr } => self.reclaim_imsic(imsic_addr).into(),
+            _ => Err(EcallError::Sbi(SbiError::NotSupported)).into(),
         }
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -945,6 +945,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
             } => self
                 .guest_add_shared_pages(guest_id, page_addr, page_type, num_pages, guest_addr)
                 .into(),
+            TvmInitiateFence { .. } => Err(EcallError::Sbi(SbiError::NotSupported)).into(),
         }
     }
 

--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -167,7 +167,7 @@ unsafe fn convert_pages(addr: u64, num_pages: u64) {
     // Fence the pages we just converted.
     //
     // TODO: Boot secondary CPUs and test the invalidation flow with multiple CPUs.
-    tee_host::initiate_fence().expect("Tellus - TsmInitiateFence failed");
+    tee_host::tsm_initiate_fence().expect("Tellus - TsmInitiateFence failed");
 }
 
 fn reclaim_pages(addr: u64, num_pages: u64) {
@@ -463,7 +463,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
         // touching this page at all in this program.
         unsafe { tee_interrupt::convert_imsic(imsic_file_addr) }
             .expect("Tellus - TsmConvertImsic failed");
-        tee_host::initiate_fence().expect("Tellus - TsmInitiateFence failed");
+        tee_host::tsm_initiate_fence().expect("Tellus - TsmInitiateFence failed");
     } else {
         println!("Platform doesn't support TEE AIA extension");
     }


### PR DESCRIPTION
Define the necessary TEE-Host and TEE-Interrupt APIs for binding and unbinding a vCPU to guest interrupt file(s). The actual mechanics of saving/restoring state from an interrupt file are described in more detail in the AIA specification, but roughly the process looks like this:

Bind:
- Map in IMSIC interrupt files in the VM's page tables.
- Restore IMSIC state from software interrupt file.

Unbind:
- Invalidate IMSIC interrupt files in the VM's page tables.
- Save IMSIC state to software interrupt file.

`tvm_cpu_bind_imsic()` implements the former, and `tvm_cpu_unbind_imsic_{begin,end}()` implement the latter. As the unbind process requires a TLB flush, it is broken into `begin()` and `end()` calls between which the host must complete a TLB fence procedure for the TVM. The fence is initiated by a newly-introduced `tvm_initiate_fence()` call which will bump the TLB version for the target TVM much like `tsm_initiate_fence()` does for the calling VM. Instead of requiring the host to enter the TSM on every CPU however, it can complete the TVM fence by causing on exit on each vCPU that was running prior to the call to `tvm_initiate_fence()`.

Some other notes on the API / planned implementation:
 - No MRIFs for now since we don't have emulation support for those yet. We'll just save state to an MRIF-like software interrupt file.
 - No IMSIC emulation by the TSM. vCPUs must be bound to an interrupt file in order to run, and IPIs targeting an unbound vCPU will cause a guest page fault.
 - We protect for nested IMSIC virtualization by specifying an interrupt file mask in `tvm_cpu_bind_imsic()`. 
 - We'll eventually need a way for the host to inject interrupts (e.g. for virtio). That'll be through a separate API, and the TSM can choose the proper way to inject the interrupt depending on whether or not the vCPU is bound.