### PR TITLE
cargo doc runs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,3 +34,5 @@ jobs:
       run: make format
     - name: Run tests
       run: make check
+    - name: Generate Docs
+      run: make doc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,6 @@ dependencies = [
  "sbi",
  "sha2 0.10.2",
  "spin",
- "test_workloads",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ s_mode_utils = { path = "./s-mode-utils" }
 sbi = { path = "./sbi" }
 spin = { version = "*", default-features = false }
 sha2 = {version = "0.10", default-features = false }
-test_workloads = { path = "./test-workloads" }
 
 [workspace]
 

--- a/Makefile
+++ b/Makefile
@@ -149,5 +149,10 @@ lint:
 format:
 	cargo fmt -- --check --config format_code_in_doc_comments=true
 
+# Currently (Nightly 1.65) the test_workloads crate causes rustdoc to panic, so exclude it.
+.PHONY: doc
+doc:
+	cargo doc --workspace --exclude test_workloads
+
 .PHONY: ci
-ci: salus guestvm tellus lint format check
+ci: salus guestvm tellus lint format check doc

--- a/drivers/src/pci/registers.rs
+++ b/drivers/src/pci/registers.rs
@@ -723,7 +723,7 @@ fn _assert_register_layout() {
 /// This is as hairy as it is because of the limitations of match arm range patterns and constant
 /// expressions in Rust. Ideally we would be able to reuse `memoffset::span_of()!` to implmenet this,
 /// however it's currently not possible to use `span_of!()`/`offset_of!()` in const expressions, see
-/// https://github.com/Gilnaa/memoffset/issues/4#issuecomment-1069658383.
+/// <https://github.com/Gilnaa/memoffset/issues/4#issuecomment-1069658383>.
 ///
 /// TODO: Replace this with `span_of!()` when it's possible to use it in const expressions.
 #[macro_export]

--- a/sbi/src/api/attestation.rs
+++ b/sbi/src/api/attestation.rs
@@ -32,12 +32,12 @@ pub fn get_capabilities() -> Result<AttestationCapabilities> {
 ///
 /// # Arguments
 ///
-/// * `cert_request` - The [Certificate Signing Request]((https://datatracker.ietf.org/doc/html/rfc2986) buffer.
+/// * `cert_request` - The [Certificate Signing Request](https://datatracker.ietf.org/doc/html/rfc2986) buffer.
 /// * `request_data` - A data blob that will be included in the generated
-///                    certificate, as [UserNotice]((https://datatracker.ietf.org/doc/html/rfc2986)
+///                    certificate, as [UserNotice](https://datatracker.ietf.org/doc/html/rfc2986)
 ///                    X.509 certificate extension. This is typically used to
 ///                    pass a cryptographic nonce.
-/// * `evidence_format` - The format of the attestation evidence as defined by [`EvidenceFormat`](crate::api::attestation::EvidenceFormat).
+/// * `evidence_format` - The format of the attestation evidence as defined by [`EvidenceFormat`](crate::EvidenceFormat).
 pub fn get_evidence(
     cert_request: &[u8],
     request_data: &[u8],

--- a/sbi/src/attestation.rs
+++ b/sbi/src/attestation.rs
@@ -162,7 +162,7 @@ pub enum AttestationFunction {
     },
 
     /// Get an attestion evidence from a Certificate Signing Request (CSR)
-    /// (https://datatracker.ietf.org/doc/html/rfc2986).
+    /// <https://datatracker.ietf.org/doc/html/rfc2986>.
     /// The caller passes the CSR and its length through the first 2 arguments.
     /// The third argument is the address where the caller places a data blob
     /// that will be included in the generated certificate. Typically, this is a


### PR DESCRIPTION
fix some warnings and exlude test_workloads as it crashes rustdoc.

closes #97 