### PR TITLE
Fix lint errors

### DIFF
--- a/drivers/src/imsic/core.rs
+++ b/drivers/src/imsic/core.rs
@@ -295,7 +295,7 @@ impl Imsic {
         // The actual number of guest files may be less than 2^(guest_index_bits) - 1; we need to
         // interrogate HGEIE.
         let guests_per_hart = get_guests_per_hart(guest_index_bits);
-        if guests_per_hart == 0 || (guests_per_hart as usize) > MAX_GUEST_FILES {
+        if guests_per_hart == 0 || guests_per_hart > MAX_GUEST_FILES {
             return Err(Error::InvalidGuestsPerHart(guests_per_hart));
         }
 

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -853,7 +853,7 @@ impl<'vcpu, 'pages, 'prev, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, '
             }
             SbiReturnType::Standard(ret) => {
                 self.set_gpr(GprIndex::A0, ret.error_code as u64);
-                self.set_gpr(GprIndex::A1, ret.return_value as u64);
+                self.set_gpr(GprIndex::A1, ret.return_value);
             }
         }
     }


### PR DESCRIPTION
This fixes new clippy warnings related to `clippy::unnecessary-cast`