### PR TITLE
vCPU allocation on add_vcpu (take 2)

### DIFF
--- a/page-tracking/src/collections/page_box.rs
+++ b/page-tracking/src/collections/page_box.rs
@@ -56,8 +56,13 @@ pub struct PageBox<T> {
 }
 
 impl<T> PageBox<T> {
+    /// Return the number of pages that must be supplied to create a `PageBox` for type `T`.
+    pub const fn required_pages() -> u64 {
+        PageSize::num_4k_pages(core::mem::size_of::<T>() as u64)
+    }
+
     /// Creates a `PageBox` that wraps the given data using `pages` to store it, returning it to its
-    /// previous owner on `drop()` using `page_tracker`.
+    /// previous owner on `drop()` using `page_tracker`. Caller must ensure enough pages are supplied.
     pub fn new_with(
         data: T,
         pages: SequentialPages<InternalClean>,
@@ -138,7 +143,7 @@ impl<T> PageBox<T> {
         }
     }
 
-    /// Returns the `Page` backing this `PageBox`.
+    /// Returns the `SequentialPages` backing this `PageBox`.
     ///
     /// # Safety
     ///

--- a/src/guest_tracking.rs
+++ b/src/guest_tracking.rs
@@ -91,8 +91,15 @@ impl<T: GuestStagePagingMode> Clone for GuestVm<T> {
 }
 
 impl<T: GuestStagePagingMode> GuestVm<T> {
+    /// Return required pages necessary to create a GuestVM.
+    pub const fn required_pages() -> u64 {
+        PageArc::<RwLock<GuestVmInner<T>>>::required_pages()
+    }
+
     /// Creates a new initializing `GuestVm` from `vm`, using `page` as storage.
     pub fn new(vm: Vm<T>, page: Page<InternalClean>) -> Self {
+        // assert it fits in a single page for now.
+        assert!(Self::required_pages() == 1);
         let page_tracker = vm.page_tracker();
         Self {
             inner: PageArc::new_with(

--- a/src/guest_tracking.rs
+++ b/src/guest_tracking.rs
@@ -95,7 +95,11 @@ impl<T: GuestStagePagingMode> GuestVm<T> {
     pub fn new(vm: Vm<T>, page: Page<InternalClean>) -> Self {
         let page_tracker = vm.page_tracker();
         Self {
-            inner: PageArc::new_with(RwLock::new(GuestVmInner::new(vm)), page, page_tracker),
+            inner: PageArc::new_with(
+                RwLock::new(GuestVmInner::new(vm)),
+                page.into(),
+                page_tracker,
+            ),
         }
     }
 


### PR DESCRIPTION
This PR adds support for vCPUs state to be donated from the host at vCPU creation, not at TVM creation.

Suggested reviewing is commit-by-commit. The preparation commits introduce various helpers. Then a few hardwired values are removed, and finally the patch that introduces the vcpu allocation.

Notes on the last patch:

1. VmCpus is now a fixed array of once, rather than a pagevec. This removes the need for variable allocation. The GuestVm structure increse from one to two 4k pages.
2. As opposed to the first patch, vm_cpu.rs is now much more similar to the baseline. VmCpusInner is called VmCpusEntry, and it is the bit that is allocated in a PageBox.
3. A vcpu is not present when the Once in the array hasn't been set.
4. num_vcpus() is gone, at least for now. Given the use we currently make, VmCpus should return an iterator (that can start from an arbitrary vcpu_id) for the present vcpus. This patch was becoming too long, and fixing things that were not part of the scope of this PR, so this is pushed to future work.

As a final note, I made about 20 different branches trying to get the type system to help us showing the relationship between status and vcpu state. There were a lot of subtle and not-so subtle problems. It can be done but it made this patch huge, and distracted from the mechanism that should be for review here. Definitely future work.
