### PR TITLE
Remove page_type from TsmConvert/Reclaim pages

### DIFF
--- a/sbi/src/api/tee_host.rs
+++ b/sbi/src/api/tee_host.rs
@@ -42,7 +42,6 @@ pub fn get_info() -> Result<TsmInfo> {
 pub unsafe fn convert_pages(addr: u64, num_pages: u64) -> Result<()> {
     let msg = SbiMessage::TeeHost(TsmConvertPages {
         page_addr: addr,
-        page_type: TsmPageType::Page4k,
         num_pages,
     });
     // Safety: The passed-in pages are unmapped and we do not access them again until they're
@@ -55,7 +54,6 @@ pub unsafe fn convert_pages(addr: u64, num_pages: u64) -> Result<()> {
 pub fn reclaim_pages(addr: u64, num_pages: u64) -> Result<()> {
     let msg = SbiMessage::TeeHost(TsmReclaimPages {
         page_addr: addr,
-        page_type: TsmPageType::Page4k,
         num_pages,
     });
     // Safety: The referenced pages are made accessible again, which is safe since we haven't


### PR DESCRIPTION
The page_type parameter in the TsmConvertPages and TsmReclaimPages was hardcoded to PageSize4K for all intents and purposes. The consensus following an internal discussion about the APIs was that we should remove the page_type parameter in APIs that don't directly affect page tables.


The rationale behind the change is that the HW mechanism for protecting confidential memory is not necessarily page-table based (example: PMP). Furthermore, even for page-table based implementations, there may be a mismatch between the requested page size and what the implementation can reasonably provide, resulting in additional complexity in both the host and TSM. Note that the TSM implementation is still free to internally optimize conversion of greater than 4kB-sized ranges if HW
support is available.