### PR TITLE
Forward IMSIC page faults to host

### DIFF
--- a/device-tree/src/device_tree.rs
+++ b/device-tree/src/device_tree.rs
@@ -334,7 +334,7 @@ impl DeviceTreeNode {
         // TODO: Use identation to make this prettier.
         writeln!(f, "{} {{", self.name())?;
         for p in self.props() {
-            writeln!(f, "{}", p)?;
+            writeln!(f, "{p}")?;
         }
         for &n in self.children() {
             let node = tree.get_node(n).unwrap();
@@ -566,13 +566,13 @@ impl fmt::Display for DeviceTreeProp {
         }
 
         if let Some(s) = self.value_str().filter(|&s| printable(s)) {
-            write!(f, "{} = \"{}\";", self.name(), s)?;
+            write!(f, "{} = \"{s}\";", self.name())?;
         } else if self.value_raw().is_empty() {
             write!(f, "{};", self.name())?;
         } else {
             write!(f, "{} =", self.name())?;
             for v in self.value_u32() {
-                write!(f, " 0x{:08x}", v)?;
+                write!(f, " 0x{v:08x}")?;
             }
             write!(f, ";")?;
         }

--- a/device-tree/src/error.rs
+++ b/device-tree/src/error.rs
@@ -44,12 +44,12 @@ impl From<DevTreeError> for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
         match self {
-            Error::StrError(e) => write!(f, "String error: {}", e),
+            Error::StrError(e) => write!(f, "String error: {e}"),
             Error::InvalidNodeId => write!(f, "Invalid node ID"),
             Error::MalformedFdt => write!(f, "Malformed FDT"),
             Error::PropNotFound => write!(f, "Property not found"),
-            Error::FdtError(e) => write!(f, "FDT error: {}", e),
-            Error::AllocError(e) => write!(f, "Memory allocation error: {}", e),
+            Error::FdtError(e) => write!(f, "FDT error: {e}"),
+            Error::AllocError(e) => write!(f, "Memory allocation error: {e}"),
         }
     }
 }

--- a/drivers/src/cpu.rs
+++ b/drivers/src/cpu.rs
@@ -237,7 +237,7 @@ impl CpuInfo {
         // VM to ease translation.
         for (i, &phandle) in self.intc_phandles.iter().enumerate() {
             let mut cpu_name = ArrayString::<16>::new();
-            fmt::write(&mut cpu_name, format_args!("cpu@{:x}", i)).unwrap();
+            fmt::write(&mut cpu_name, format_args!("cpu@{i:x}")).unwrap();
             let cpu_node_id = dt.add_node(cpu_name.as_str(), Some(cpus_id))?;
             let cpu_node = dt.get_mut_node(cpu_node_id).unwrap();
             cpu_node.add_prop("device_type")?.set_value_str("cpu")?;

--- a/drivers/src/pci/device.rs
+++ b/drivers/src/pci/device.rs
@@ -80,7 +80,7 @@ impl fmt::Display for HeaderType {
             HeaderType::Endpoint => write!(f, "Endpoint"),
             HeaderType::PciBridge => write!(f, "PciBridge"),
             HeaderType::CardBusBridge => write!(f, "CardBusBridge"),
-            HeaderType::Unknown(h) => write!(f, "Unknown(0x{:x})", h),
+            HeaderType::Unknown(h) => write!(f, "Unknown(0x{h:x})"),
         }
     }
 }

--- a/page-tracking/src/hw_mem_map.rs
+++ b/page-tracking/src/hw_mem_map.rs
@@ -371,8 +371,8 @@ impl fmt::Display for HwMemRegionType {
     fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
         match &self {
             HwMemRegionType::Available => write!(f, "available"),
-            HwMemRegionType::Reserved(r) => write!(f, "reserved ({})", r),
-            HwMemRegionType::Mmio(d) => write!(f, "mmio ({})", d),
+            HwMemRegionType::Reserved(r) => write!(f, "reserved ({r})"),
+            HwMemRegionType::Mmio(d) => write!(f, "mmio ({d})"),
         }
     }
 }

--- a/riscv-pages/src/memory_type.rs
+++ b/riscv-pages/src/memory_type.rs
@@ -32,7 +32,7 @@ impl fmt::Display for MemType {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match &self {
             MemType::Ram => write!(f, "RAM"),
-            MemType::Mmio(d) => write!(f, "MMIO ({}", d),
+            MemType::Mmio(d) => write!(f, "MMIO ({d})"),
         }
     }
 }

--- a/riscv-regs/src/csrs/traps.rs
+++ b/riscv-regs/src/csrs/traps.rs
@@ -263,8 +263,8 @@ impl Exception {
 impl fmt::Display for Trap {
     fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
         match self {
-            Trap::Interrupt(i) => write!(f, "{} interrupt", i),
-            Trap::Exception(e) => write!(f, "{} exception", e),
+            Trap::Interrupt(i) => write!(f, "{i} interrupt"),
+            Trap::Exception(e) => write!(f, "{e} exception"),
         }
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -204,7 +204,7 @@ impl From<EcallResult<u64>> for EcallAction {
                 match pf {
                     // Unhandleable page faults or page faults in MMIO space just result in an
                     // error to the caller.
-                    Unmapped | Mmio => Continue(SbiReturn::from(SbiError::InvalidAddress)),
+                    Unmapped | Mmio | Imsic => Continue(SbiReturn::from(SbiError::InvalidAddress)),
                     Confidential | Shared => {
                         let addr = PageAddr::with_round_down(addr, PageSize::Size4k);
                         Retry(VmExitCause::PageFault(e, addr))
@@ -548,7 +548,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
                         .get_page_fault_cause(exception, fault_addr);
                     use PageFaultType::*;
                     match pf {
-                        Confidential | Shared => {
+                        Confidential | Shared | Imsic => {
                             break VmExitCause::PageFault(
                                 exception,
                                 PageAddr::with_round_down(fault_addr, PageSize::Size4k),


### PR DESCRIPTION
Meant to include this in #122; this is necessary to support IPIs within TVMs.
