### PR TITLE
Add debug console extension

### DIFF
--- a/s-mode-utils/src/sbi_console.rs
+++ b/s-mode-utils/src/sbi_console.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use sbi::api::debug_console::console_puts;
 use sbi::SbiMessage;
 
 use crate::ecall::ecall_send;
@@ -20,6 +21,26 @@ impl SbiConsole {
 }
 
 impl ConsoleWriter for SbiConsole {
+    /// Write an entire byte sequence to the SBI console.
+    fn write_bytes(&self, bytes: &[u8]) {
+        // Ignore errors as there isn't currently a way to report them if the console doesn't work.
+        let _ = console_puts(bytes);
+    }
+}
+
+/// Driver for the legacy SBI console from v0.1 of the SBI spec.
+pub struct SbiConsoleV01 {}
+
+static SBI_CONSOLE_V01: SbiConsoleV01 = SbiConsoleV01 {};
+
+impl SbiConsoleV01 {
+    /// Sets the SBI legacy console as the system console.
+    pub fn set_as_console() {
+        Console::set_writer(&SBI_CONSOLE_V01);
+    }
+}
+
+impl ConsoleWriter for SbiConsoleV01 {
     /// Write an entire byte sequence to the SBI console.
     fn write_bytes(&self, bytes: &[u8]) {
         for &b in bytes {

--- a/sbi/src/api/debug_console.rs
+++ b/sbi/src/api/debug_console.rs
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{ecall_send, DebugConsoleFunction, Result, SbiMessage};
+
+/// Prints the given string in a platfrom-dependent way.
+pub fn console_puts(chars: &[u8]) -> Result<()> {
+    let msg = SbiMessage::DebugConsole(DebugConsoleFunction::PutString {
+        len: chars.len() as u64,
+        addr: chars.as_ptr() as u64,
+    });
+
+    // Safety: The sbi implementation is trusted not to write memory when printing to the console.
+    unsafe { ecall_send(&msg) }?;
+
+    Ok(())
+}

--- a/sbi/src/api/mod.rs
+++ b/sbi/src/api/mod.rs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Debug Console for printing strings through SBI.
+pub mod debug_console;
+
 /// Host interfaces for reset extension.
 pub mod reset;
 

--- a/sbi/src/consts.rs
+++ b/sbi/src/consts.rs
@@ -10,9 +10,11 @@ pub const EXT_BASE: u64 = 0x10;
 pub const EXT_HART_STATE: u64 = 0x48534D;
 pub const EXT_PMU: u64 = 0x504D55;
 pub const EXT_RESET: u64 = 0x53525354;
+pub const EXT_DBCN: u64 = 0x4442434E; // DBCN
 pub const EXT_ATTESTATION: u64 = 0x41545354; // ATST
 pub const EXT_TEE_HOST: u64 = 0x54454548; // TEEH
 pub const EXT_TEE_INTERRUPT: u64 = 0x54454549; // TEEI
 pub const EXT_TEE_GUEST: u64 = 0x54454547; // TEEG
 
 pub const SBI_SUCCESS: i64 = 0;
+pub const SBI_ERR_INVALID_ADDRESS: i64 = -5;

--- a/sbi/src/debug_console.rs
+++ b/sbi/src/debug_console.rs
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::*;
+use crate::function::*;
+
+/// Functions for the Debug Console extension
+#[derive(Copy, Clone, Debug)]
+pub enum DebugConsoleFunction {
+    /// Prints the given string to the system console.
+    PutString {
+        /// The length of the string to print.
+        len: u64,
+        /// The address of the string.
+        addr: u64,
+    },
+}
+
+impl DebugConsoleFunction {
+    /// Attempts to parse `Self` from the passed in `a0-a7`.
+    pub(crate) fn from_regs(args: &[u64]) -> Result<Self> {
+        Ok(match args[6] {
+            0 => DebugConsoleFunction::PutString {
+                len: args[0],
+                addr: args[1],
+            },
+            _ => return Err(Error::NotSupported),
+        })
+    }
+}
+
+impl SbiFunction for DebugConsoleFunction {
+    fn a0(&self) -> u64 {
+        match self {
+            DebugConsoleFunction::PutString { len, addr: _ } => *len,
+        }
+    }
+
+    fn a1(&self) -> u64 {
+        match self {
+            DebugConsoleFunction::PutString { len: _, addr } => *addr,
+        }
+    }
+}

--- a/sbi/src/sbi.rs
+++ b/sbi/src/sbi.rs
@@ -9,6 +9,8 @@
 
 mod consts;
 pub use consts::*;
+mod debug_console;
+pub use debug_console::*;
 mod error;
 pub use error::*;
 mod function;
@@ -111,6 +113,8 @@ pub enum SbiMessage {
     HartState(StateFunction),
     /// Handles system reset.
     Reset(ResetFunction),
+    /// Handles output to the console for debug.
+    DebugConsole(DebugConsoleFunction),
     /// Provides capabilities for starting confidential virtual machines.
     TeeHost(TeeHostFunction),
     /// Provides interrupt virtualization for confidential virtual machines.
@@ -133,6 +137,7 @@ impl SbiMessage {
             EXT_BASE => BaseFunction::from_regs(args).map(SbiMessage::Base),
             EXT_HART_STATE => StateFunction::from_regs(args).map(SbiMessage::HartState),
             EXT_RESET => ResetFunction::from_regs(args).map(SbiMessage::Reset),
+            EXT_DBCN => DebugConsoleFunction::from_regs(args).map(SbiMessage::DebugConsole),
             EXT_TEE_HOST => TeeHostFunction::from_regs(args).map(SbiMessage::TeeHost),
             EXT_TEE_INTERRUPT => {
                 TeeInterruptFunction::from_regs(args).map(SbiMessage::TeeInterrupt)
@@ -152,6 +157,7 @@ impl SbiMessage {
             Base(_) => EXT_BASE,
             HartState(_) => EXT_HART_STATE,
             Reset(_) => EXT_RESET,
+            DebugConsole(_) => EXT_DBCN,
             TeeHost(_) => EXT_TEE_HOST,
             TeeInterrupt(_) => EXT_TEE_INTERRUPT,
             TeeGuest(_) => EXT_TEE_GUEST,
@@ -170,6 +176,7 @@ impl SbiMessage {
             Base(f) => f.a6(),
             HartState(f) => f.a6(),
             Reset(f) => f.a6(),
+            DebugConsole(f) => f.a6(),
             TeeHost(f) => f.a6(),
             TeeInterrupt(f) => f.a6(),
             TeeGuest(f) => f.a6(),
@@ -186,6 +193,7 @@ impl SbiMessage {
             Base(f) => f.a5(),
             HartState(f) => f.a5(),
             Reset(f) => f.a5(),
+            DebugConsole(f) => f.a5(),
             TeeHost(f) => f.a5(),
             TeeInterrupt(f) => f.a5(),
             TeeGuest(f) => f.a5(),
@@ -202,6 +210,7 @@ impl SbiMessage {
             Base(f) => f.a4(),
             HartState(f) => f.a4(),
             Reset(f) => f.a4(),
+            DebugConsole(f) => f.a4(),
             TeeHost(f) => f.a4(),
             TeeInterrupt(f) => f.a4(),
             TeeGuest(f) => f.a4(),
@@ -218,6 +227,7 @@ impl SbiMessage {
             Base(f) => f.a3(),
             HartState(f) => f.a3(),
             Reset(f) => f.a3(),
+            DebugConsole(f) => f.a3(),
             TeeHost(f) => f.a3(),
             TeeInterrupt(f) => f.a3(),
             TeeGuest(f) => f.a3(),
@@ -234,6 +244,7 @@ impl SbiMessage {
             Base(f) => f.a2(),
             HartState(f) => f.a2(),
             Reset(f) => f.a2(),
+            DebugConsole(f) => f.a2(),
             TeeHost(f) => f.a2(),
             TeeInterrupt(f) => f.a2(),
             TeeGuest(f) => f.a2(),
@@ -250,6 +261,7 @@ impl SbiMessage {
             Base(f) => f.a1(),
             HartState(f) => f.a1(),
             Reset(f) => f.a1(),
+            DebugConsole(f) => f.a1(),
             TeeHost(f) => f.a1(),
             TeeInterrupt(f) => f.a1(),
             TeeGuest(f) => f.a1(),
@@ -265,6 +277,7 @@ impl SbiMessage {
             PutChar(c) => *c,
             Base(f) => f.a0(),
             Reset(f) => f.a0(),
+            DebugConsole(f) => f.a0(),
             HartState(f) => f.a0(),
             TeeHost(f) => f.a0(),
             TeeInterrupt(f) => f.a0(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ use riscv_regs::{
 };
 use s_mode_utils::abort::abort;
 use s_mode_utils::print::*;
-use s_mode_utils::sbi_console::SbiConsole;
+use s_mode_utils::sbi_console::SbiConsoleV01;
 use smp::PerCpu;
 use spin::Once;
 use vm::HostVm;
@@ -429,7 +429,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     // Reset CSRs to a sane state.
     setup_csrs();
 
-    SbiConsole::set_as_console();
+    SbiConsoleV01::set_as_console();
     println!("Salus: Boot test VM");
 
     // Safe because we trust that the firmware passed a valid FDT.


### PR DESCRIPTION
fixes #123 

This still assumes that the console is owned by Salus. File #146 to address that.

We also need to uprev the supported SBI version, filed #147