### PR TITLE
Update to latest QEMU & Linux integration branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ BOOTARGS := keep_bootcon earlycon=sbi
 # QEMU options:
 #
 #  NCPU: Number of CPUs to boot with. Default: 1
-#  MEM_SIZE: RAM size for the emulated system. Default: 4GB
+#  MEM_SIZE: RAM size for the emulated system. Default: 2GB
 #  EXTRA_QEMU_ARGS: Any extra flags to pass to QEMU (e.g. other devices).
 
 NCPU ?= 1
-MEM_SIZE ?= 4096
+MEM_SIZE ?= 2048
 EXTRA_QEMU_ARGS ?=
 
 ifneq ($(VECTORS),)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ DEBUG_BINS := target/riscv64gc-unknown-none-elf/debug/
 
 KERNEL_ADDR := 0xc0200000
 INITRD_ADDR := 0xc2200000
-BOOTARGS := console=hvc0 earlycon=sbi
+BOOTARGS := keep_bootcon earlycon=sbi
 
 # QEMU options:
 #

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ else
 CPU_TYPE := rv64
 endif
 
-CPU_ARGS := $(CPU_TYPE),x-aia=true,sscofpmf=true
+CPU_ARGS := $(CPU_TYPE),x-smaia=true,x-ssaia=true,sscofpmf=true
 
 MACH_ARGS := -M virt,aia=aplic-imsic,aia-guests=4 -cpu $(CPU_ARGS)
 MACH_ARGS += -smp $(NCPU) -m $(MEM_SIZE) -nographic

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Latest known-working branches:
 
 | Project | Branch |
 | ------- | ------ |
-| QEMU    | https://github.com/rivosinc/qemu/tree/salus-integration-08232022 |
-| Linux   | https://github.com/rivosinc/linux/tree/salus-integration-08172022 |
+| QEMU    | https://github.com/rivosinc/qemu/tree/salus-integration-10312022 |
+| Linux   | https://github.com/rivosinc/linux/tree/salus-integration-10312022 |
 
 ### Linux VM
 

--- a/drivers/src/iommu/core.rs
+++ b/drivers/src/iommu/core.rs
@@ -44,7 +44,7 @@ static IOMMU: Once<Iommu> = Once::new();
 
 // Identifiers from the QEMU RFC implementation.
 const IOMMU_VENDOR_ID: u16 = 0x1efd;
-const IOMMU_DEVICE_ID: u16 = 0x8001;
+const IOMMU_DEVICE_ID: u16 = 0xedf1;
 
 impl Iommu {
     /// Probes for and initializes the IOMMU device on the given PCI root. Uses `get_page` to

--- a/drivers/src/iommu/device_directory.rs
+++ b/drivers/src/iommu/device_directory.rs
@@ -159,7 +159,7 @@ struct NonLeafEntry(u64);
 
 const NL_PFN_BITS: u64 = 44;
 const NL_PFN_MASK: u64 = (1 << NL_PFN_BITS) - 1;
-const NL_PFN_SHIFT: u64 = 12;
+const NL_PFN_SHIFT: u64 = 10;
 const NL_VALID: u64 = 1;
 
 impl NonLeafEntry {

--- a/drivers/src/iommu/registers.rs
+++ b/drivers/src/iommu/registers.rs
@@ -24,14 +24,14 @@ register_bitfields![u64,
     ],
 
     pub DirectoryPointer [
-        Ppn OFFSET(0) NUMBITS(44),
-        Busy OFFSET(59) NUMBITS(1),
-        Mode OFFSET(60) NUMBITS(4),
+        Mode OFFSET(0) NUMBITS(4),
+        Busy OFFSET(4) NUMBITS(1),
+        Ppn OFFSET(10) NUMBITS(44),
     ],
 
     pub QueueBase [
         Log2SzMinus1 OFFSET(0) NUMBITS(5),
-        Ppn OFFSET(5) NUMBITS(44),
+        Ppn OFFSET(10) NUMBITS(44),
     ],
 ];
 

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -101,7 +101,7 @@ mod tests {
                 .unwrap();
             node.add_prop("riscv,isa")
                 .unwrap()
-                .set_value_str("rv64imafdcvsuh_sstc")
+                .set_value_str("rv64imafdcvsuh_sstc_ssaia")
                 .unwrap();
             node.add_prop("mmu-type")
                 .unwrap()
@@ -119,7 +119,7 @@ mod tests {
             intc_node
                 .add_prop("compatible")
                 .unwrap()
-                .set_value_str("riscv,cpu-intc-aia\0riscv,cpu-intc")
+                .set_value_str("riscv,cpu-intc")
                 .unwrap();
             intc_node
                 .add_prop("phandle")

--- a/src/main.rs
+++ b/src/main.rs
@@ -461,6 +461,10 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     // Discover the CPU topology.
     CpuInfo::parse_from(&hyp_dt);
     let cpu_info = CpuInfo::get();
+    if !cpu_info.has_aia() {
+        // We require AIA support for interrupts and SMP support; no point continuing without it.
+        panic!("CPU does not support AIA");
+    }
     if cpu_info.has_sstc() {
         println!("Sstc support present");
         // Only write henvcfg when Sstc is present to avoid blowing up on versions of QEMU which

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -45,6 +45,10 @@ pub type Result<T> = core::result::Result<T, Error>;
 // confuses us with BBL/OpenSBI.
 const SBI_IMPL_ID_SALUS: u64 = 7;
 
+// Report ourselves as being SBI v1.0 compliant.
+const SBI_SPEC_MAJOR_VERSION_SHIFT: u64 = 24;
+const SBI_SPEC_VERSION: u64 = 1 << SBI_SPEC_MAJOR_VERSION_SHIFT;
+
 // Pages used by the `PageVec` for the Host VM guest tracking.
 const HOSTVM_GUEST_TRACKING_PAGES: usize = 2;
 
@@ -803,7 +807,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
     fn handle_base_msg(&self, base_func: BaseFunction) -> SbiReturn {
         use BaseFunction::*;
         let ret = match base_func {
-            GetSpecificationVersion => 3,
+            GetSpecificationVersion => SBI_SPEC_VERSION,
             GetImplementationID => SBI_IMPL_ID_SALUS,
             GetImplementationVersion => 0,
             ProbeSbiExtension(ext) => match ext {


### PR DESCRIPTION
Rebase the QEMU & Linux branches on v7.1 and v6.1-rc3, respectively, pulling in the necessary patch sets. The new integrations branches are at `salus-integration-10312022` in each repository.

Notable changes:
- AIA extension rename (patch 3)
- Support for DBCN (patches 1 & 2)
- IOMMU spec changes (patch 4)

Patch 5 updates the README to point to the new branches.

Tested with `make run_debian` using 2 CPUs.