### PR TITLE
page-tracking: Add missing tick

### DIFF
--- a/page-tracking/src/collections/mod.rs
+++ b/page-tracking/src/collections/mod.rs
@@ -12,7 +12,7 @@
 //! codebase.
 //!
 //! Each page is given to the hypervisor for a specific purpose. For example, a page can be used to
-//! hold a guest's state(`PageBox<State>`), or a list of children VMs (`PageVec<Guest>).
+//! hold a guest's state(`PageBox<State>`), or a list of children VMs (`PageVec<Guest>`).
 
 extern crate alloc;
 


### PR DESCRIPTION
A code quote wasn't closed and was causing a warning generating docs.

Signed-off-by: Dylan Reid <dgreid@rivosinc.com>