### PR TITLE
Report vstimecmp CSR in shared memory

### DIFF
--- a/sbi/src/tee_host.rs
+++ b/sbi/src/tee_host.rs
@@ -25,6 +25,8 @@ pub enum RegisterSetId {
     SupervisorCsrs = 1,
     /// HS-level CSRs.
     HypervisorCsrs = 2,
+    /// Sstc extension CSRs.
+    SstcCsrs = 3,
 }
 
 impl RegisterSetId {
@@ -34,6 +36,7 @@ impl RegisterSetId {
             0 => Ok(RegisterSetId::Gprs),
             1 => Ok(RegisterSetId::SupervisorCsrs),
             2 => Ok(RegisterSetId::HypervisorCsrs),
+            3 => Ok(RegisterSetId::SstcCsrs),
             _ => Err(Error::InvalidParam),
         }
     }
@@ -44,6 +47,7 @@ impl RegisterSetId {
             RegisterSetId::Gprs => core::mem::size_of::<Gprs>(),
             RegisterSetId::SupervisorCsrs => core::mem::size_of::<SupervisorCsrs>(),
             RegisterSetId::HypervisorCsrs => core::mem::size_of::<HypervisorCsrs>(),
+            RegisterSetId::SstcCsrs => core::mem::size_of::<SstcCsrs>(),
         }
     }
 }
@@ -129,6 +133,14 @@ pub struct HypervisorCsrs {
     ///    register in `gprs` corresponding to the 'rs2' register in the instruction upon return
     ///    from `TvmCpuRun`.
     pub htinst: u64,
+}
+
+/// Sstc extension CSRs. Structure for register sets of type `RegisterSetId::SstcCsrs`.
+#[repr(C)]
+#[derive(Default)]
+pub struct SstcCsrs {
+    /// VS-level `stimecmp` CSR for a TVM vCPU. Written by the TSM upon return from `TvmCpuRun`.
+    pub vstimecmp: u64,
 }
 
 /// Provides the state of the confidential VM supervisor.

--- a/src/main.rs
+++ b/src/main.rs
@@ -465,12 +465,13 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
         // We require AIA support for interrupts and SMP support; no point continuing without it.
         panic!("CPU does not support AIA");
     }
-    if cpu_info.has_sstc() {
-        println!("Sstc support present");
-        // Only write henvcfg when Sstc is present to avoid blowing up on versions of QEMU which
-        // don't support the *envcfg registers.
-        CSR.henvcfg.modify(henvcfg::stce.val(1));
+    if !cpu_info.has_sstc() {
+        // We don't implement or use the SBI timer extension and thus require Sstc for timers.
+        panic!("CPU does not support Sstc");
     }
+    // Only write henvcfg when Sstc is present to avoid blowing up on versions of QEMU which
+    // don't support the *envcfg registers.
+    CSR.henvcfg.modify(henvcfg::stce.val(1));
     if cpu_info.has_sscofpmf() {
         // Only probe for PMU counters if we have Sscofpmf; we can't expose counters to guests
         // unless we have support for per-mode filtering.

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -939,9 +939,7 @@ impl<'vcpu, 'pages, 'prev, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, '
         vcpu_csrs.vscause = CSR.vscause.get();
         vcpu_csrs.vstval = CSR.vstval.get();
         vcpu_csrs.vsatp = CSR.vsatp.get();
-        if CpuInfo::get().has_sstc() {
-            vcpu_csrs.vstimecmp = CSR.vstimecmp.get();
-        }
+        vcpu_csrs.vstimecmp = CSR.vstimecmp.get();
     }
 
     // Restores the VS-level CSRs.
@@ -957,9 +955,7 @@ impl<'vcpu, 'pages, 'prev, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, '
         CSR.vscause.set(vcpu_csrs.vscause);
         CSR.vstval.set(vcpu_csrs.vstval);
         CSR.vsatp.set(vcpu_csrs.vsatp);
-        if CpuInfo::get().has_sstc() {
-            CSR.vstimecmp.set(vcpu_csrs.vstimecmp);
-        }
+        CSR.vstimecmp.set(vcpu_csrs.vstimecmp);
     }
 
     // Restores the VM's address space.


### PR DESCRIPTION
Add an Sstc register set to report the `vstimecmp` CSR in the vCPU shared memory state area to help hosts determine when to next schedule a TVM.

Patch 1 mandates the Sstc extension in Salus since TVMs are pretty limited without it. Patches 2 & 3 define and use the new register set.