### PR TITLE
Rework vCPU locking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,8 @@
     ptr_sub_ptr,
     slice_ptr_get,
     let_chains,
-    is_some_and
+    is_some_and,
+    negative_impls
 )]
 
 use core::alloc::{Allocator, GlobalAlloc, Layout};

--- a/src/smp.rs
+++ b/src/smp.rs
@@ -126,6 +126,9 @@ impl PerCpu {
     }
 }
 
+// PerCpu state obviously cannot be shared between threads.
+impl !Sync for PerCpu {}
+
 /// Halts this CPU until an interrupt (for example, delivered via `kick_cpu()`) is received.
 pub fn wfi() {
     CSR.sstatus.modify(sstatus::sie.val(1));

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -1013,6 +1013,10 @@ impl<T: GuestStagePagingMode> Drop for ActiveVmCpu<'_, '_, '_, T> {
     }
 }
 
+// ActiveVmCpu is used to guard CSR and TLB state which is local to the current physical CPU and
+// thus cannot be safely shared between threads.
+impl<T: GuestStagePagingMode> !Sync for ActiveVmCpu<'_, '_, '_, T> {}
+
 // State of binding a vCPU to a physical CPU.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum BindStatus {


### PR DESCRIPTION
Patch 1 reworks locking within VmCpu in preparation for interrupt injection (#91), while patch 2 is a trivial change to prevent accidental sharing of per-CPU state between threads.