### PR TITLE
Fix makefile so that objcopy can be specified via environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #  DEBIAN: Path to a pre-baked Debian image.
 
 RV64_PREFIX ?= riscv64-unknown-elf-
-OBJCOPY := $(RV64_PREFIX)objcopy
+OBJCOPY ?= $(RV64_PREFIX)objcopy
 
 QEMU ?=
 ifneq ($(QEMU),)


### PR DESCRIPTION
If you are developing on !linux and need to use a different `objcopy`, it's not possible. This changes a `:=` to `?=` to make it possible to specify the path in an environment variable.