### PR TITLE
Fix lint error with int_log being stable in nightly

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -5,13 +5,7 @@
 //! # Hardware drivers
 
 #![no_std]
-#![feature(
-    allocator_api,
-    int_log,
-    result_option_inspect,
-    iter_advance_by,
-    let_chains
-)]
+#![feature(allocator_api, result_option_inspect, iter_advance_by, let_chains)]
 
 extern crate alloc;
 


### PR DESCRIPTION
Recently, int_log became stable feature in nightly, causing a lint failure. Removed from #[feature(...)]