### PR TITLE
Pin nightly toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2022-11-10"
 components = []
 targets = ["riscv64gc-unknown-none-elf"]
 profile = "minimal"


### PR DESCRIPTION
This will make sure everyone is building with the same toolchain, allowing there to be a common set of nightly features that need to be declared and avoiding having to get everyone to upgrade when features are stabilized.

Signed-off-by: Dylan Reid <dgreid@rivosinc.com>