### PR TITLE
Support external interrupt injection

### DIFF
--- a/drivers/src/imsic/error.rs
+++ b/drivers/src/imsic/error.rs
@@ -45,6 +45,8 @@ pub enum Error {
     GuestFilesTaken(CpuId),
     /// The provided IMSIC file ID was not a valid guest interrupt file.
     InvalidGuestFile,
+    /// The provided IMSIC interrupt ID was out of range.
+    InvalidInterruptId(u32),
 }
 
 /// Holds the result of IMSIC operations.

--- a/drivers/src/imsic/error.rs
+++ b/drivers/src/imsic/error.rs
@@ -13,6 +13,8 @@ pub enum Error {
     MissingProperty(&'static str),
     /// Unexpected number of parent interrupts specified in the device tree.
     InvalidParentInterruptCount(usize),
+    /// Invalid number of external interrupt IDs.
+    InvalidInterruptIds(usize),
     /// Invalid number of guest files per hart specified in the IMSIC geometry.
     InvalidGuestsPerHart(usize),
     /// Invalid group index shift specified in the IMSIC geometry.

--- a/drivers/src/imsic/mod.rs
+++ b/drivers/src/imsic/mod.rs
@@ -7,7 +7,9 @@ mod error;
 mod geometry;
 mod sw_file;
 
-pub use self::core::{Imsic, ImsicGuestPage, ImsicGuestPageIter, ImsicInterruptId};
+pub use self::core::{
+    Imsic, ImsicGuestPage, ImsicGuestPageIter, ImsicInterruptId, MAX_INTERRUPT_IDS,
+};
 pub use error::Error as ImsicError;
 pub use error::Result as ImsicResult;
 pub use geometry::*;

--- a/drivers/src/imsic/sw_file.rs
+++ b/drivers/src/imsic/sw_file.rs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::core::MAX_INTERRUPT_IDS;
+
 // A single EIE/EIP pair.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
@@ -11,7 +13,7 @@ struct SwFileEntry {
 }
 
 /// The number of 64-bit EIE/EIP pairs in an interrupt file, as mandated by the AIA specification.
-pub const SW_FILE_ENTRIES: usize = 32;
+pub const SW_FILE_ENTRIES: usize = MAX_INTERRUPT_IDS / 64;
 
 /// Holds the software-visible state of an IMSIC guest interrupt file. Used when a guest interrupt
 /// file is swapped out.

--- a/drivers/src/imsic/sw_file.rs
+++ b/drivers/src/imsic/sw_file.rs
@@ -71,6 +71,11 @@ impl SwFile {
         self.entries[index].pending = val;
     }
 
+    /// Sets the bit corresponding to `id` in the EIP register array.
+    pub fn set_eip_bit(&mut self, id: usize) {
+        self.entries[id / 64].pending |= 1 << (id % 64);
+    }
+
     /// Returns the saved value of the EIE register at `index`.
     pub fn eie(&self, index: usize) -> u64 {
         self.entries[index].enable

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -31,7 +31,7 @@ pub use cpu::{CpuId, CpuInfo, MAX_CPUS};
 
 #[cfg(test)]
 mod tests {
-    use super::imsic::Imsic;
+    use super::imsic::{Imsic, ImsicFileId};
     use super::*;
     use alloc::vec::Vec;
     use device_tree::DeviceTree;
@@ -253,14 +253,18 @@ mod tests {
         let group0_addr = geometry.base_addr();
         assert_eq!(group0_addr.bits(), 0x4000_0000);
         let per_hart_pages = 1 << GUEST_BITS as u64;
-        let cpu1_loc = imsic.supervisor_file_location(CpuId::new(1)).unwrap();
+        let cpu1_loc = imsic
+            .phys_file_location(CpuId::new(1), ImsicFileId::Supervisor)
+            .unwrap();
         assert_eq!(
             geometry.location_to_addr(cpu1_loc).unwrap(),
             group0_addr.checked_add_pages(per_hart_pages).unwrap()
         );
         let group1_addr =
             PageAddr::new(RawAddr::supervisor(group0_addr.bits() + (1 << GROUP_SHIFT))).unwrap();
-        let cpu2_loc = imsic.supervisor_file_location(CpuId::new(2)).unwrap();
+        let cpu2_loc = imsic
+            .phys_file_location(CpuId::new(2), ImsicFileId::Supervisor)
+            .unwrap();
         assert_eq!(geometry.location_to_addr(cpu2_loc).unwrap(), group1_addr);
 
         // Make sure `HwMemMap` got updated.

--- a/sbi/src/api/tee_guest.rs
+++ b/sbi/src/api/tee_guest.rs
@@ -36,3 +36,35 @@ pub fn add_shared_memory_region(addr: u64, len: u64) -> Result<()> {
     unsafe { ecall_send(&msg) }?;
     Ok(())
 }
+
+/// Allows injection of the specified external interrupt ID by the host to the calling CPU.
+pub fn allow_external_interrupt(id: u64) -> Result<()> {
+    let msg = SbiMessage::TeeGuest(AllowExternalInterrupt { id: id as i64 });
+    // Safety: AllowExternalInterrupt doesn't access our memory.
+    unsafe { ecall_send(&msg) }?;
+    Ok(())
+}
+
+/// Allows injection of all external interrupts by the host to the calling CPU.
+pub fn allow_all_external_interrupts() -> Result<()> {
+    let msg = SbiMessage::TeeGuest(AllowExternalInterrupt { id: -1 });
+    // Safety: AllowExternalInterrupt doesn't access our memory.
+    unsafe { ecall_send(&msg) }?;
+    Ok(())
+}
+
+/// Denies injection of the specified external interrupt ID by the host to the calling CPU.
+pub fn deny_external_interrupt(id: u64) -> Result<()> {
+    let msg = SbiMessage::TeeGuest(DenyExternalInterrupt { id: id as i64 });
+    // Safety: DenyExternalInterrupt doesn't access our memory.
+    unsafe { ecall_send(&msg) }?;
+    Ok(())
+}
+
+/// Denies injection of all external interrupts by the host to the calling CPU.
+pub fn deny_all_external_interrupts() -> Result<()> {
+    let msg = SbiMessage::TeeGuest(DenyExternalInterrupt { id: -1 });
+    // Safety: DenyExternalInterrupt doesn't access our memory.
+    unsafe { ecall_send(&msg) }?;
+    Ok(())
+}

--- a/sbi/src/api/tee_interrupt.rs
+++ b/sbi/src/api/tee_interrupt.rs
@@ -85,3 +85,16 @@ pub fn unbind_vcpu_imsic_end(tvm_id: u64, vcpu_id: u64) -> Result<()> {
     unsafe { ecall_send(&msg) }?;
     Ok(())
 }
+
+/// Injects an external interrupt into the specified vCPU. The interrupt ID must have been
+/// allowed with `allow_external_interrupt()` by the guest.
+pub fn inject_external_interrupt(tvm_id: u64, vcpu_id: u64, interrupt_id: u64) -> Result<()> {
+    let msg = SbiMessage::TeeInterrupt(TvmCpuInjectExternalInterrupt {
+        tvm_id,
+        vcpu_id,
+        interrupt_id,
+    });
+    // Safety: Does not access host memory.
+    unsafe { ecall_send(&msg) }?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod trap;
 mod vm;
 mod vm_cpu;
 mod vm_id;
+mod vm_interrupts;
 mod vm_pages;
 mod vm_pmu;
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2135,7 +2135,9 @@ impl<T: GuestStagePagingMode> HostVm<T> {
                 let vcpu_box = PageBox::new_with(vcpu, vcpu_pages, page_tracker.clone());
                 init_vm.add_vcpu(vcpu_box).unwrap();
 
-                let imsic_loc = imsic.supervisor_file_location(CpuId::new(i)).unwrap();
+                let imsic_loc = imsic
+                    .phys_file_location(CpuId::new(i), ImsicFileId::Supervisor)
+                    .unwrap();
                 init_vm
                     .set_vcpu_imsic_location(i as u64, imsic_loc)
                     .unwrap();

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1751,6 +1751,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
             TvmCpuUnbindImsicEnd { tvm_id, vcpu_id } => {
                 self.guest_unbind_vcpu_end(tvm_id, vcpu_id).into()
             }
+            _ => Err(EcallError::Sbi(SbiError::NotSupported)).into(),
         }
     }
 
@@ -2004,6 +2005,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
                     Err(_) => result.into(),
                 }
             }
+            _ => Err(EcallError::Sbi(SbiError::NotSupported)).into(),
         }
     }
 

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -39,6 +39,7 @@ pub enum Error {
     Unbinding(vm_interrupts::Error),
     AllowingInterrupt(vm_interrupts::Error),
     DenyingInterrupt(vm_interrupts::Error),
+    InjectingInterrupt(vm_interrupts::Error),
 }
 
 pub type Result<T> = core::result::Result<T, Error>;
@@ -1221,6 +1222,14 @@ impl VmCpu {
             .lock()
             .unbind_imsic_finish()
             .map_err(Error::Unbinding)
+    }
+
+    /// Injects the specified external interrupt ID into this vCPU, if allowed.
+    pub fn inject_ext_interrupt(&self, id: usize) -> Result<()> {
+        self.ext_interrupts()?
+            .lock()
+            .inject_interrupt(id)
+            .map_err(Error::InjectingInterrupt)
     }
 }
 

--- a/src/vm_interrupts.rs
+++ b/src/vm_interrupts.rs
@@ -1,0 +1,139 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use drivers::{imsic::*, CpuId};
+
+use crate::smp::PerCpu;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Error {
+    BindingImsic(ImsicError),
+    UnbindingImsic(ImsicError),
+    WrongBindStatus,
+    WrongPhysicalCpu,
+}
+
+pub type Result<T> = core::result::Result<T, Error>;
+
+// State of binding a vCPU to a physical CPU.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum BindStatus {
+    Binding(CpuId, ImsicFileId),
+    Bound(CpuId, ImsicFileId),
+    Unbinding(CpuId, ImsicFileId),
+    Unbound,
+}
+
+/// Virtual external interrupt state for a vCPU.
+pub struct VmCpuExtInterrupts {
+    bind_status: BindStatus,
+    imsic_location: ImsicLocation,
+    sw_file: SwFile,
+}
+
+impl VmCpuExtInterrupts {
+    /// Creates a new `VmCpuExtInterrupts` to track the external interrupt state of a vCPU with
+    /// `imsic_location` as the location of the vCPU's virtualized IMSIC.
+    pub fn new(imsic_location: ImsicLocation) -> Self {
+        Self {
+            bind_status: BindStatus::Unbound,
+            imsic_location,
+            sw_file: SwFile::new(),
+        }
+    }
+
+    /// Returns the location of this vCPU's virtualized IMSIC in guest physical address space.
+    pub fn imsic_location(&self) -> ImsicLocation {
+        self.imsic_location
+    }
+
+    /// Prepares to bind this vCPU to `interrupt_file` on the current physical CPU.
+    pub fn bind_imsic_prepare(&mut self, interrupt_file: ImsicFileId) -> Result<()> {
+        // The vCPU must be completely unbound to start a bind operation.
+        if self.bind_status != BindStatus::Unbound {
+            return Err(Error::WrongBindStatus);
+        }
+
+        // Initialize the guest IMSIC file we're getting bound to.
+        let imsic = Imsic::get();
+        imsic
+            .restore_guest_file_prepare(interrupt_file, &mut self.sw_file)
+            .map_err(Error::BindingImsic)?;
+
+        self.bind_status = BindStatus::Binding(PerCpu::this_cpu().cpu_id(), interrupt_file);
+        Ok(())
+    }
+
+    /// Completes the IMSIC bind operation started in `bind_imsic_prepare()`.
+    pub fn bind_imsic_finish(&mut self) -> Result<ImsicFileId> {
+        // Make sure there's a bind operation was started on this CPU.
+        let (cpu, interrupt_file) = match self.bind_status {
+            BindStatus::Binding(cpu, interrupt_file) => (cpu, interrupt_file),
+            _ => {
+                return Err(Error::WrongBindStatus);
+            }
+        };
+        if cpu != PerCpu::this_cpu().cpu_id() {
+            return Err(Error::WrongPhysicalCpu);
+        }
+
+        // Finish restoring state from the SW interrupt file.
+        let imsic = Imsic::get();
+        imsic
+            .restore_guest_file_finish(interrupt_file, &mut self.sw_file)
+            .map_err(Error::BindingImsic)?;
+        self.bind_status = BindStatus::Bound(cpu, interrupt_file);
+        Ok(interrupt_file)
+    }
+
+    /// Prepares to unbind this vCPU from its current interrupt file.
+    pub fn unbind_imsic_prepare(&mut self) -> Result<()> {
+        // We must be bound (to the current CPU) to start an unbind.
+        let (cpu, interrupt_file) = match self.bind_status {
+            BindStatus::Bound(cpu, interrupt_file) => (cpu, interrupt_file),
+            _ => {
+                return Err(Error::WrongBindStatus);
+            }
+        };
+        if cpu != PerCpu::this_cpu().cpu_id() {
+            return Err(Error::WrongPhysicalCpu);
+        }
+
+        let imsic = Imsic::get();
+        imsic
+            .save_guest_file_prepare(interrupt_file, &mut self.sw_file)
+            .map_err(Error::UnbindingImsic)?;
+        self.bind_status = BindStatus::Unbinding(cpu, interrupt_file);
+        Ok(())
+    }
+
+    /// Completes the IMSIC unbind operation started in `unbind_imsic_prepare()`.
+    pub fn unbind_imsic_finish(&mut self) -> Result<()> {
+        // We must be bound (to the current CPU) to start an unbind.
+        let (cpu, interrupt_file) = match self.bind_status {
+            BindStatus::Unbinding(cpu, interrupt_file) => (cpu, interrupt_file),
+            _ => {
+                return Err(Error::WrongBindStatus);
+            }
+        };
+        if cpu != PerCpu::this_cpu().cpu_id() {
+            return Err(Error::WrongPhysicalCpu);
+        }
+
+        let imsic = Imsic::get();
+        imsic
+            .save_guest_file_finish(interrupt_file, &mut self.sw_file)
+            .map_err(Error::UnbindingImsic)?;
+        self.bind_status = BindStatus::Unbound;
+        Ok(())
+    }
+
+    /// Returns true if this vCPU is bound to the current physical CPU.
+    pub fn is_bound_on_this_cpu(&self) -> bool {
+        match self.bind_status {
+            BindStatus::Bound(cpu_id, _) => cpu_id == PerCpu::this_cpu().cpu_id(),
+            _ => false,
+        }
+    }
+}

--- a/test-workloads/src/bin/guestvm.rs
+++ b/test-workloads/src/bin/guestvm.rs
@@ -341,6 +341,10 @@ extern "C" fn kernel_init(_hart_id: u64, boot_args: u64) {
     // Safety: WFI behavior is well-defined.
     unsafe { asm!("wfi", options(nomem, nostack)) };
 
+    // TODO: Set up and interrupt handler and enable interrupts so that we can receive injected
+    // interrupts.
+    tee_guest::allow_external_interrupt(3).expect("GuestVm - AllowExternalInterrupt failed");
+
     println!("Exiting guest");
     println!("*****************************************");
 

--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -604,6 +604,9 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
                                         }
                                     }
                                 }
+                                _ => {
+                                    continue;
+                                }
                             }
                         }
                         _ => {

--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -604,6 +604,15 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
                                         }
                                     }
                                 }
+                                AllowExternalInterrupt { id } => {
+                                    // Try to inject the allow-listed interrupt into the guest.
+                                    // If guest allowed all interrupts (-1), just pick a random
+                                    // one.
+                                    let id = u64::try_from(id).unwrap_or(7);
+                                    println!("Injecting interrupt {id} into guest");
+                                    tee_interrupt::inject_external_interrupt(vmid, 0, id)
+                                        .expect("Tellus - InjectExternalInterrupt failed");
+                                }
                                 _ => {
                                     continue;
                                 }


### PR DESCRIPTION
This series adds support for secure external interrupts by introducing the TEE-Guest calls to allow TVMs to manipulate their per-vCPU allowlist of injectable interrupts, and the TEE-Host call to actually inject the external interrupt from the host side. Guests start with injection of external interrupts disabled by default.

Patch 1 defines the new TEE calls, patches 2-4 are cleanups / prep-work to support interrupt injection, patch 5 implements the allow-listing, and patch 6 implements the interrupt injection itself. This is all (minimally) exercised in patch 7 by having GuestVm allow an external interrupt and then having Tellus inject it. While we don't yet have a trap handler in GuestVm, I've verified by manually inspecting the IMSIC CSRs that the injected interrupt was recorded.

This covers the interrupt injection support part of #91 