### PR TITLE
Fix hardcoded device

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -24,6 +24,8 @@ pub mod iommu;
 pub mod pci;
 /// Caches information about platform hardware and firmware PMU counters.
 pub mod pmu;
+/// Provide a simple platform reset driver
+pub mod reset;
 /// Provides a simple UART driver for console output.
 pub mod uart;
 

--- a/drivers/src/reset.rs
+++ b/drivers/src/reset.rs
@@ -1,0 +1,52 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use device_tree::DeviceTree;
+use page_tracking::HwMemMap;
+use riscv_pages::{DeviceMemType, PageSize, RawAddr};
+use s_mode_utils::abort::abort;
+
+/// The hardcoded base address and len.
+const RESET_BASE: u64 = 0x10_0000;
+const RESET_LEN: u64 = PageSize::Size4k as u64;
+
+/// Errors that can be returned by the RESET driver.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Error {
+    /// Failed to add an MMIO region to the system memory map.
+    AddingMmioRegion(page_tracking::MemMapError),
+}
+
+/// Holds the result of a RESET driver operation.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Driver for platform RESET.
+pub struct ResetDriver {}
+
+impl ResetDriver {
+    /// Probe for a RESET device. At this moment this device always exists and is hardcoded at 0x10_0000.
+    pub fn probe_from(_dt: &DeviceTree, mem_map: &mut HwMemMap) -> Result<()> {
+        // Safety: being hardcoded we _know_ the device is there.
+        unsafe {
+            mem_map
+                .add_mmio_region(
+                    DeviceMemType::Reset,
+                    RawAddr::supervisor(RESET_BASE),
+                    RESET_LEN,
+                )
+                .map_err(Error::AddingMmioRegion)
+        }?;
+        Ok(())
+    }
+
+    /// Powers off the machine.
+    pub fn shutdown() -> ! {
+        // Safety: on this platform, a write of 0x5555 to 0x100000 will trigger the platform to
+        // poweroff, which is defined behavior.
+        unsafe {
+            core::ptr::write_volatile(RESET_BASE as *mut u32, 0x5555);
+        }
+        abort()
+    }
+}

--- a/riscv-pages/src/memory_type.rs
+++ b/riscv-pages/src/memory_type.rs
@@ -25,6 +25,8 @@ pub enum DeviceMemType {
     PciBar,
     /// UART device.
     Uart,
+    /// Reset device.
+    Reset,
     // TODO: Add more types here.
 }
 
@@ -44,6 +46,7 @@ impl fmt::Display for DeviceMemType {
             DeviceMemType::PciConfig => write!(f, "PCI ECAM"),
             DeviceMemType::PciBar => write!(f, "PCI BAR"),
             DeviceMemType::Uart => write!(f, "UART"),
+            DeviceMemType::Reset => write!(f, "RESET"),
         }
     }
 }


### PR DESCRIPTION
Current code mapping fixed reset page at 0x10_0000 was wrong, as it did not account the reset device's PTEs.

This patch adds a super simple "ResetDriver", that adds to the memory map the device. Could be changed to a generic device for future (if any) hardcoded device. But for now it's the only "special" platform device we have, so calling it the Reset Driver seems sane.