### PR TITLE
Basic dynamic memory sharing support

### DIFF
--- a/riscv-page-tables/src/page_table.rs
+++ b/riscv-page-tables/src/page_table.rs
@@ -919,15 +919,7 @@ impl<T: PagingMode> GuestStagePageTable<T> {
         let mut inner = self.inner.lock();
         let mut pages = LockedPageList::new(self.page_tracker.clone());
         for a in addr.iter_from().take(num_pages as usize) {
-            let entry = Self::get_mapped_owned_4k_leaf(
-                &mut inner,
-                a,
-                self.page_tracker.clone(),
-                self.owner,
-                P::mem_type(),
-            )?;
-            // Unwrap ok, PFN must have been properly aligned in order to have been mapped.
-            let paddr = entry.page_addr();
+            let paddr = inner.get_mapped_4k_leaf(a)?.page_addr();
             let page = self
                 .page_tracker
                 .get_shareable_page::<P>(paddr, self.owner)

--- a/riscv-page-tables/src/page_table.rs
+++ b/riscv-page-tables/src/page_table.rs
@@ -972,6 +972,16 @@ impl<T: PagingMode> GuestStagePageTable<T> {
         Ok(())
     }
 
+    /// Returns true if the specified range is completely unpopulated, including pages that are
+    /// converted or in the process of conversion.
+    pub fn range_is_empty(&self, vaddr: PageAddr<T::MappedAddressSpace>, len: u64) -> bool {
+        let mut inner = self.inner.lock();
+        vaddr
+            .iter_from()
+            .take(PageSize::num_4k_pages(len) as usize)
+            .all(|va| matches!(inner.walk(va.into()), TableEntryType::Unused(_)))
+    }
+
     fn get_mapped_owned_4k_leaf(
         inner: &mut PageTableInner<T>,
         vaddr: PageAddr<T::MappedAddressSpace>,

--- a/sbi/src/api/tee_guest.rs
+++ b/sbi/src/api/tee_guest.rs
@@ -37,6 +37,34 @@ pub fn add_shared_memory_region(addr: u64, len: u64) -> Result<()> {
     Ok(())
 }
 
+/// Converts the specified range of address space from confidential to shared.
+///
+/// # Safety
+///
+/// This operation is destructive; the contents of memory in the range to be converted are lost.
+/// The calling VM must not access the memory in this range on any other CPUs until this call
+/// returns, at which point accesses within the range are guaranteed to be to memory shared with
+/// the host.
+pub unsafe fn share_memory(addr: u64, len: u64) -> Result<()> {
+    let msg = SbiMessage::TeeGuest(ShareMemory { addr, len });
+    ecall_send(&msg)?;
+    Ok(())
+}
+
+/// Converts the specified range of address space from shared to confidential.
+///
+/// # Safety
+///
+/// This operation is destructive; the contents of memory in the range to be converted are lost.
+/// The calling VM must not access the memory in this range on any other CPUs until this call
+/// returns, at which point accesses within the range are guaranteed to be to memory that is
+/// confidential to the calling VM.
+pub unsafe fn unshare_memory(addr: u64, len: u64) -> Result<()> {
+    let msg = SbiMessage::TeeGuest(UnshareMemory { addr, len });
+    ecall_send(&msg)?;
+    Ok(())
+}
+
 /// Allows injection of the specified external interrupt ID by the host to the calling CPU.
 pub fn allow_external_interrupt(id: u64) -> Result<()> {
     let msg = SbiMessage::TeeGuest(AllowExternalInterrupt { id: id as i64 });

--- a/sbi/src/api/tee_guest.rs
+++ b/sbi/src/api/tee_guest.rs
@@ -3,34 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::TeeGuestFunction::*;
-use crate::{ecall_send, Result, SbiMessage, TeeMemoryRegion};
+use crate::{ecall_send, Result, SbiMessage};
 
 /// Registers an emulated MMIO region in a previously-unused range of guest physical address space.
 /// Future accesses in the specified address range will trap to the host, allowing it to emulate
 /// the access.
 pub fn add_emulated_mmio_region(addr: u64, len: u64) -> Result<()> {
-    let msg = SbiMessage::TeeGuest(AddMemoryRegion {
-        region_type: TeeMemoryRegion::EmulatedMmio,
-        addr,
-        len,
-    });
-    // Safety: AddMemoryRegion does not directly access our memory. The specified range of
-    // address space must have been previously inaccessible for the call to succeed, after which
-    // accesses to that range have well-defined behavior.
-    unsafe { ecall_send(&msg) }?;
-    Ok(())
-}
-
-/// Registers a shared memory region in a previously-unused range of guest physical address space.
-/// Future accesses in the specified address range will trap to to the host, allowing it to insert
-/// pages of shared memory.
-pub fn add_shared_memory_region(addr: u64, len: u64) -> Result<()> {
-    let msg = SbiMessage::TeeGuest(AddMemoryRegion {
-        region_type: TeeMemoryRegion::Shared,
-        addr,
-        len,
-    });
-    // Safety: AddMemoryRegion does not directly access our memory. The specified range of
+    let msg = SbiMessage::TeeGuest(AddMmioRegion { addr, len });
+    // Safety: AddMmioRegion does not directly access our memory. The specified range of
     // address space must have been previously inaccessible for the call to succeed, after which
     // accesses to that range have well-defined behavior.
     unsafe { ecall_send(&msg) }?;

--- a/sbi/src/api/tee_host.rs
+++ b/sbi/src/api/tee_host.rs
@@ -4,7 +4,7 @@
 
 use crate::TeeHostFunction::*;
 use crate::{ecall_send, Error, Result, SbiMessage};
-use crate::{RegisterSetLocation, TeeMemoryRegion, TsmInfo, TsmPageType, TvmCreateParams};
+use crate::{RegisterSetLocation, TsmInfo, TsmPageType, TvmCreateParams};
 
 /// Initiates a TSM fence on this CPU.
 pub fn tsm_initiate_fence() -> Result<()> {
@@ -180,15 +180,14 @@ pub unsafe fn add_vcpu(
     Ok(())
 }
 
-/// Declares the confidential region of the guest's physical address space.
-pub fn add_confidential_memory_region(vmid: u64, guest_addr: u64, len: u64) -> Result<()> {
+/// Declares a memory region in the guest's physical address space.
+pub fn add_memory_region(vmid: u64, guest_addr: u64, len: u64) -> Result<()> {
     let msg = SbiMessage::TeeHost(TvmAddMemoryRegion {
         guest_id: vmid,
-        region_type: TeeMemoryRegion::Confidential,
         guest_addr,
         len,
     });
-    // Safety: `TvmAddConfidentialMemoryRegion` doesn't access our memory at all.
+    // Safety: `TvmAddMemoryRegion` doesn't access our memory at all.
     unsafe { ecall_send(&msg) }?;
     Ok(())
 }

--- a/sbi/src/tee_guest.rs
+++ b/sbi/src/tee_guest.rs
@@ -4,46 +4,23 @@
 
 use crate::error::*;
 use crate::function::*;
-use crate::TeeMemoryRegion;
 
 /// Functions provided by the TEE Guest extension to TVM guests.
 #[derive(Copy, Clone, Debug)]
 pub enum TeeGuestFunction {
-    /// Adds a memory region to the calling TVM at the specified range of guest physical address
-    /// space. Both `addr` and `len` must be 4kB-aligned and must not overlap with any
-    /// previously-added regions.
+    /// Marks the specified range of guest physical address space as used for emulated MMIO. Upon
+    /// return, all accesses by the TVM within the range are trapped and may be emulated by the
+    /// host.
     ///
-    /// Only `Shared` and `EmulatedMmio` regions may be added by the TVM.
+    /// Both `addr` and `len` must be 4kB-aligned, and the range must not overlap with any existing
+    /// memory regions. Returns 0 on success.
     ///
     /// a6 = 0
-    AddMemoryRegion {
-        /// a0 = type of memory region
-        region_type: TeeMemoryRegion,
-        /// a1 = start of the region
+    AddMmioRegion {
+        /// a0 = start address of the region
         addr: u64,
-        /// a2 = length of the region
+        /// a1 = length of the region
         len: u64,
-    },
-    /// Allows injection of the specified external interrupt ID into the calling TVM vCPU. Passing
-    /// an ID of -1 allows injection of all external interrupts. TVM vCPUs are started with
-    /// injection of external interrupts completely disabled by default.
-    ///
-    /// Returns an error if the specified external interrupt ID is invalid.
-    ///
-    /// a6 = 1
-    AllowExternalInterrupt {
-        /// a0 = interrupt ID
-        id: i64,
-    },
-    /// Denies injection of the specified external interrupt ID into the calling TVM vCPU. Passing
-    /// an ID of -1 denies injection of all external interrupts.
-    ///
-    /// Returns an error if the specified external interrupt ID is invalid.
-    ///
-    /// a6 = 2
-    DenyExternalInterrupt {
-        /// a0 = interrupt ID
-        id: i64,
     },
     /// Requests conversion of the specified range of guest physical address space from confidential
     /// to shared. The caller is blocked until the host has completed the invalidation and removal
@@ -53,7 +30,7 @@ pub enum TeeGuestFunction {
     /// Both `addr` and `len` must be 4kB-aligned, and the range must lie within an existing region
     /// of confidential memory. Returns 0 on success.
     ///
-    /// a6 = 3
+    /// a6 = 1
     ShareMemory {
         /// a0 = start address of the region
         addr: u64,
@@ -68,12 +45,33 @@ pub enum TeeGuestFunction {
     /// Both `addr` and `len` must be 4kB-aligned, and the range must lie within an existing region
     /// of shared memory. Returns 0 on success.
     ///
-    /// a6 = 4
+    /// a6 = 2
     UnshareMemory {
         /// a0 = start address of the region
         addr: u64,
         /// a1 = length of the region
         len: u64,
+    },
+    /// Allows injection of the specified external interrupt ID into the calling TVM vCPU. Passing
+    /// an ID of -1 allows injection of all external interrupts. TVM vCPUs are started with
+    /// injection of external interrupts completely disabled by default.
+    ///
+    /// Returns an error if the specified external interrupt ID is invalid.
+    ///
+    /// a6 = 3
+    AllowExternalInterrupt {
+        /// a0 = interrupt ID
+        id: i64,
+    },
+    /// Denies injection of the specified external interrupt ID into the calling TVM vCPU. Passing
+    /// an ID of -1 denies injection of all external interrupts.
+    ///
+    /// Returns an error if the specified external interrupt ID is invalid.
+    ///
+    /// a6 = 4
+    DenyExternalInterrupt {
+        /// a0 = interrupt ID
+        id: i64,
     },
 }
 
@@ -82,21 +80,20 @@ impl TeeGuestFunction {
     pub(crate) fn from_regs(args: &[u64]) -> Result<Self> {
         use TeeGuestFunction::*;
         match args[6] {
-            0 => Ok(AddMemoryRegion {
-                region_type: TeeMemoryRegion::from_reg(args[0])?,
-                addr: args[1],
-                len: args[2],
-            }),
-            1 => Ok(AllowExternalInterrupt { id: args[0] as i64 }),
-            2 => Ok(DenyExternalInterrupt { id: args[0] as i64 }),
-            3 => Ok(ShareMemory {
+            0 => Ok(AddMmioRegion {
                 addr: args[0],
                 len: args[1],
             }),
-            4 => Ok(UnshareMemory {
+            1 => Ok(ShareMemory {
                 addr: args[0],
                 len: args[1],
             }),
+            2 => Ok(UnshareMemory {
+                addr: args[0],
+                len: args[1],
+            }),
+            3 => Ok(AllowExternalInterrupt { id: args[0] as i64 }),
+            4 => Ok(DenyExternalInterrupt { id: args[0] as i64 }),
             _ => Err(Error::NotSupported),
         }
     }
@@ -106,51 +103,31 @@ impl SbiFunction for TeeGuestFunction {
     fn a6(&self) -> u64 {
         use TeeGuestFunction::*;
         match self {
-            AddMemoryRegion { .. } => 0,
-            AllowExternalInterrupt { .. } => 1,
-            DenyExternalInterrupt { .. } => 2,
-            ShareMemory { .. } => 3,
-            UnshareMemory { .. } => 4,
+            AddMmioRegion { .. } => 0,
+            ShareMemory { .. } => 1,
+            UnshareMemory { .. } => 2,
+            AllowExternalInterrupt { .. } => 3,
+            DenyExternalInterrupt { .. } => 4,
         }
     }
 
     fn a0(&self) -> u64 {
         use TeeGuestFunction::*;
         match self {
-            AddMemoryRegion {
-                region_type,
-                addr: _,
-                len: _,
-            } => *region_type as u64,
-            AllowExternalInterrupt { id } => *id as u64,
-            DenyExternalInterrupt { id } => *id as u64,
+            AddMmioRegion { addr, len: _ } => *addr,
             ShareMemory { addr, len: _ } => *addr,
             UnshareMemory { addr, len: _ } => *addr,
+            AllowExternalInterrupt { id } => *id as u64,
+            DenyExternalInterrupt { id } => *id as u64,
         }
     }
 
     fn a1(&self) -> u64 {
         use TeeGuestFunction::*;
         match self {
-            AddMemoryRegion {
-                region_type: _,
-                addr,
-                len: _,
-            } => *addr,
+            AddMmioRegion { addr: _, len } => *len,
             ShareMemory { addr: _, len } => *len,
             UnshareMemory { addr: _, len } => *len,
-            _ => 0,
-        }
-    }
-
-    fn a2(&self) -> u64 {
-        use TeeGuestFunction::*;
-        match self {
-            AddMemoryRegion {
-                region_type: _,
-                addr: _,
-                len,
-            } => *len,
             _ => 0,
         }
     }

--- a/sbi/src/tee_host.rs
+++ b/sbi/src/tee_host.rs
@@ -401,7 +401,7 @@ pub enum TeeHostFunction {
         guest_addr: u64,
     },
     /// Maps non-confidential shared pages in a region of shared memory previously registered by
-    /// the guest via `AddMemoryRegion` in the TEE-Guest API.
+    /// the guest via `ShareMemory` in the TEE-Guest API.
     ///
     /// a6 = 12
     TvmAddSharedPages {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2031,6 +2031,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
             } => self.add_memory_region(region_type, addr, len),
             AllowExternalInterrupt { id } => self.allow_ext_interrupt(id, active_vcpu),
             DenyExternalInterrupt { id } => self.deny_ext_interrupt(id, active_vcpu),
+            _ => Err(EcallError::Sbi(SbiError::NotSupported)),
         };
 
         // Notify the host if a TEE-Guest call succeeds.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -932,11 +932,10 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
                 .into(),
             TvmAddMemoryRegion {
                 guest_id,
-                region_type,
                 guest_addr,
                 len,
             } => self
-                .guest_add_memory_region(guest_id, region_type, guest_addr, len)
+                .guest_add_memory_region(guest_id, guest_addr, len)
                 .into(),
             TvmAddZeroPages {
                 guest_id,
@@ -1297,7 +1296,6 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
     fn guest_add_memory_region(
         &self,
         guest_id: u64,
-        region_type: TeeMemoryRegion,
         guest_addr: u64,
         len: u64,
     ) -> EcallResult<u64> {
@@ -1306,14 +1304,10 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
             .as_initializing_vm()
             .ok_or(EcallError::Sbi(SbiError::InvalidParam))?;
         let guest_addr = guest_vm.guest_addr_from_raw(guest_addr)?;
-        use TeeMemoryRegion::*;
-        match region_type {
-            Confidential => guest_vm
-                .vm_pages()
-                .add_confidential_memory_region(guest_addr, len)
-                .map_err(EcallError::from),
-            _ => Err(EcallError::Sbi(SbiError::InvalidParam)),
-        }?;
+        guest_vm
+            .vm_pages()
+            .add_confidential_memory_region(guest_addr, len)
+            .map_err(EcallError::from)?;
         Ok(0)
     }
 

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -989,12 +989,6 @@ pub type AnyVmPages<'a, T> = VmPagesRef<'a, T, VmStateAny>;
 pub type FinalizedVmPages<'a, T> = VmPagesRef<'a, T, VmStateFinalized>;
 
 impl<'a, T: GuestStagePagingMode> FinalizedVmPages<'a, T> {
-    /// Adds a shared memory region of `len` bytes starting at `page_addr` to this VM's address
-    /// space.
-    pub fn add_shared_memory_region(&self, page_addr: GuestPageAddr, len: u64) -> Result<()> {
-        self.do_add_region(page_addr, len, VmRegionType::Shared)
-    }
-
     /// Adds an emulated MMIO region of `len` bytes starting at `page_addr` to this VM's address
     /// space.
     pub fn add_mmio_region(&self, page_addr: GuestPageAddr, len: u64) -> Result<()> {

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -219,22 +219,22 @@ impl Drop for PinnedPages {
     }
 }
 
-/// Types of regions in a VM's guest physical address space.
+// Types of regions in a VM's guest physical address space.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum VmRegionType {
-    /// Memory that is private to this VM.
+enum VmRegionType {
+    // Memory that is private to this VM.
     Confidential,
-    /// Memory that is shared with the parent
+    // Memory that is shared with the parent
     Shared,
-    /// Emulated MMIO region; accesses always cause a fault that is forwarded to the VM's host.
+    // Emulated MMIO region; accesses always cause a fault that is forwarded to the VM's host.
     Mmio,
-    /// IMSIC interrupt file pages.
+    // IMSIC interrupt file pages.
     Imsic,
-    /// PCI BAR pages.
+    // PCI BAR pages.
     Pci,
 }
 
-/// A contiguous region of guest physical address space.
+// A contiguous region of guest physical address space.
 struct VmRegion {
     start: GuestPageAddr,
     end: GuestPageAddr,
@@ -244,11 +244,11 @@ struct VmRegion {
 // The maximum number of distinct memory regions we support in `VmRegionList`.
 const MAX_MEM_REGIONS: usize = 128;
 
-/// The regions of guest physical address space for a VM. Used to track which parts of the address
-/// space are designated for a particular purpose. The region list is created during VM initialization
-/// and remains static after the VM is finalized. Pages may only be inserted into a VM's address space
-/// if the mapping falls within a region of the proper type.
-pub struct VmRegionList {
+// The regions of guest physical address space for a VM. Used to track which parts of the address
+// space are designated for a particular purpose. The region list is created during VM initialization
+// and remains static after the VM is finalized. Pages may only be inserted into a VM's address space
+// if the mapping falls within a region of the proper type.
+struct VmRegionList {
     regions: Mutex<ArrayVec<VmRegion, MAX_MEM_REGIONS>>,
 }
 
@@ -260,7 +260,7 @@ impl VmRegionList {
         }
     }
 
-    /// Inserts a region at [`start`, `end`) of type `region_type`.
+    // Inserts a region at [`start`, `end`) of type `region_type`.
     fn add(
         &self,
         mut start: GuestPageAddr,
@@ -312,7 +312,7 @@ impl VmRegionList {
         Ok(())
     }
 
-    /// Returns if the range [`start`, `end`) is fully contained within a region of type `region_type`.
+    // Returns if the range [`start`, `end`) is fully contained within a region of type `region_type`.
     fn contains(
         &self,
         start: GuestPageAddr,
@@ -325,7 +325,7 @@ impl VmRegionList {
             .any(|r| r.start <= start && r.end >= end && r.region_type == region_type)
     }
 
-    /// Returns the type of the region that `addr` resides in, or `None` if it's not in any region.
+    // Returns the type of the region that `addr` resides in, or `None` if it's not in any region.
     fn find(&self, addr: GuestPhysAddr) -> Option<VmRegionType> {
         let regions = self.regions.lock();
         regions

--- a/test-workloads/src/bin/consts.rs
+++ b/test-workloads/src/bin/consts.rs
@@ -33,7 +33,9 @@
 /// | <empty>                 |
 /// |-------------------------| 0x1_0000_0000
 /// | Shared pages            |
-/// +-------------------------+ +NUM_GUEST_SHARED_PAGES
+/// |-------------------------| +NUM_GUEST_SHARED_PAGES
+/// | <empty>                 |
+/// +-------------------------+ 0x1_8000_0000
 
 pub const PAGE_SIZE_4K: u64 = 4096;
 pub const NUM_TELLUS_IMAGE_PAGES: u64 = 32;
@@ -52,6 +54,7 @@ pub const GUEST_SHARED_PAGES_START_ADDRESS: u64 = 0x1_0000_0000;
 pub const NUM_GUEST_SHARED_PAGES: u64 = 1;
 pub const GUEST_SHARED_PAGES_END_ADDRESS: u64 =
     GUEST_SHARED_PAGES_START_ADDRESS + NUM_GUEST_SHARED_PAGES * PAGE_SIZE_4K - 1;
+pub const GUEST_RAM_END_ADDRESS: u64 = 0x1_8000_0000;
 pub const GUEST_SHARE_PING: u64 = 0xBAAD_F00D;
 pub const GUEST_SHARE_PONG: u64 = 0xF00D_BAAD;
 pub const BOOT_ARG_VECTORS_ENABLED: u64 = 0x1;

--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -30,7 +30,7 @@ use s_mode_utils::{print::*, sbi_console::SbiConsole};
 use sbi::api::{base, pmu, reset, tee_host, tee_interrupt};
 use sbi::{
     PmuCounterConfigFlags, PmuCounterStartFlags, PmuCounterStopFlags, PmuEventType, PmuFirmware,
-    PmuHardware, SbiMessage, TeeMemoryRegion, EXT_PMU, EXT_TEE_HOST, EXT_TEE_INTERRUPT,
+    PmuHardware, SbiMessage, EXT_PMU, EXT_TEE_HOST, EXT_TEE_INTERRUPT,
 };
 
 // Dummy global allocator - panic if anything tries to do an allocation.
@@ -576,27 +576,11 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
                         Ok(TeeGuest(guest_func)) => {
                             use sbi::TeeGuestFunction::*;
                             match guest_func {
-                                AddMemoryRegion {
-                                    region_type,
-                                    addr,
-                                    len,
-                                } => {
-                                    use TeeMemoryRegion::*;
-                                    match region_type {
-                                        EmulatedMmio => {
-                                            mmio_region = Some(Range {
-                                                start: addr,
-                                                end: addr + len,
-                                            });
-                                        }
-                                        _ => {
-                                            println!(
-                                                "Unexpected memory region {:?} from guest",
-                                                region_type
-                                            );
-                                            break;
-                                        }
-                                    }
+                                AddMmioRegion { addr, len } => {
+                                    mmio_region = Some(Range {
+                                        start: addr,
+                                        end: addr + len,
+                                    });
                                 }
                                 ShareMemory { addr, len } => {
                                     shared_mem_region = Some(Range {

--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -483,7 +483,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     tee_host::add_confidential_memory_region(
         vmid,
         USABLE_RAM_START_ADDRESS,
-        (NUM_GUEST_DATA_PAGES + NUM_GUEST_ZERO_PAGES) * PAGE_SIZE_4K,
+        GUEST_RAM_END_ADDRESS - USABLE_RAM_START_ADDRESS,
     )
     .expect("Tellus - TvmAddConfidentialMemoryRegion failed");
 
@@ -583,12 +583,6 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
                                 } => {
                                     use TeeMemoryRegion::*;
                                     match region_type {
-                                        Shared => {
-                                            shared_mem_region = Some(Range {
-                                                start: addr,
-                                                end: addr + len,
-                                            });
-                                        }
                                         EmulatedMmio => {
                                             mmio_region = Some(Range {
                                                 start: addr,
@@ -603,6 +597,12 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
                                             break;
                                         }
                                     }
+                                }
+                                ShareMemory { addr, len } => {
+                                    shared_mem_region = Some(Range {
+                                        start: addr,
+                                        end: addr + len,
+                                    });
                                 }
                                 AllowExternalInterrupt { id } => {
                                     // Try to inject the allow-listed interrupt into the guest.

--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -480,12 +480,12 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     let donated_pages_base = next_page;
 
     // Declare the confidential region of the guest's physical address space.
-    tee_host::add_confidential_memory_region(
+    tee_host::add_memory_region(
         vmid,
         USABLE_RAM_START_ADDRESS,
         GUEST_RAM_END_ADDRESS - USABLE_RAM_START_ADDRESS,
     )
-    .expect("Tellus - TvmAddConfidentialMemoryRegion failed");
+    .expect("Tellus - TvmAddMemoryRegion failed");
 
     // Add data pages
     // Safety: The passed-in pages are unmapped and we do not access them again until they're


### PR DESCRIPTION
Add support for runtime, guest-initiated conversion between shared <-> confidential memory when the region to be converted is unpopulated.

This adds two new TEE-Guest calls -- `share_memory()` and `unshare_memory()` -- which initiate the confidential -> shared and shared -> confidential conversion, respectively. For now, this consists of updating the `VmRegionList` with the new region type and verifying that the range is unpopulated. We'll add support for handling populated regions in a follow-on PR.

Patch 1 fixes an issue that prevent sharing of already-shared pages.
Patch 2 defines the new TEE-Guest calls.
Patches 3-5 are prep work for handling the runtime shared <-> confidential conversion.
Patch 6 implements the new TEE-Guest calls.
Patch 7 updates Tellus/GuestVM to use the new calls.
Patches 8&9 remove now-obsolete TEE calls.

This should be enough to enable `swiotlb` in Linux TVM guests without restoring to pre-declared shared memory pools.

Partially addresses #153; still need to handle the already-populated case.