### PR TITLE
Zero the BSS

### DIFF
--- a/lds/guest.lds
+++ b/lds/guest.lds
@@ -36,7 +36,10 @@ SECTIONS
     } >ram AT>ram :data
 
     .bss : {
+        . = ALIGN(8);
+	PROVIDE(_bss_start = .);
         *(.sbss .sbss.*) *(.bss .bss.*)
+        . = ALIGN(8);
         PROVIDE(_bss_end = .);
     } >ram AT>ram :bss
 

--- a/lds/qemu.lds
+++ b/lds/qemu.lds
@@ -43,7 +43,10 @@ SECTIONS
     } >ram AT>ram :data
 
     .bss : {
+        . = ALIGN(8);
+	PROVIDE(_bss_start = .);
         *(.sbss .sbss.*) *(.bss .bss.*)
+        . = ALIGN(8);
         PROVIDE(_bss_end = .);
     } >ram AT>ram :bss
 

--- a/src/start.S
+++ b/src/start.S
@@ -14,18 +14,20 @@ _start:
 .option norelax
     la gp, _global_pointer
 .option pop
-    la sp, _stack_end
     csrw sstatus, zero
     csrw sie, zero
 
-    la t1, kernel_init
-    la ra, 1f
-    jr t1
-
-    j 1f
+    // Clear the BSS
+    la   a3, _bss_start
+    la   a4, _bss_end
 1:
-    wfi
-    j 1b
+    sd   zero, (a3)
+    addi a3, a3, 8
+    blt  a3, a4, 1b
+
+    la   sp, _stack_end
+    call kernel_init
+    j    wfi_loop
 
 // The entry point for secondary CPUs.
 .global _secondary_start
@@ -38,9 +40,9 @@ _secondary_start:
     csrw sstatus, zero
     csrw sie, zero
     // TP holds the address of our PerCpu struct, which is also the top of our stack.
-    mv sp, a1
-    mv tp, a1
-
-    la t1, secondary_init
-    la ra, 1b
-    jr t1
+    mv   sp, a1
+    mv   tp, a1
+    call secondary_init
+wfi_loop:
+    wfi
+    j    wfi_loop

--- a/src/trap.S
+++ b/src/trap.S
@@ -53,12 +53,9 @@ _trap_entry:
     sd   t2, ({tf_sepc})(sp)
 
     /* Now enter the rust trap handler. */
-    la   t3, handle_trap
-    la   ra, _trap_return
     move a0, sp
-    jr   t3
+    call handle_trap
 
-_trap_return:
     /* Restore state and sret. */
     ld   t0, ({tf_sstatus})(sp)
     csrw sstatus, t0

--- a/test-workloads/src/start.S
+++ b/test-workloads/src/start.S
@@ -14,18 +14,20 @@ _start:
 .option norelax
     la gp, _global_pointer
 .option pop
-    la sp, _stack_end
     csrw sstatus, zero
     csrw sie, zero
 
-    la t1, kernel_init
-    la ra, 1f
-    jr t1
-
-    j 1f
+    // Clear the BSS
+    la   a3, _bss_start
+    la   a4, _bss_end
 1:
-    wfi
-    j 1b
+    sd   zero, (a3)
+    addi a3, a3, 8
+    blt  a3, a4, 1b
+
+    la   sp, _stack_end
+    call kernel_init
+    j    wfi_loop
 
 // The entry point for secondary CPUs.
 .global _secondary_start
@@ -40,7 +42,7 @@ _secondary_start:
     // TP holds the address of our PerCpu struct, which is also the top of our stack.
     mv sp, a1
     mv tp, a1
-
-    la t1, secondary_init
-    la ra, 1b
-    jr t1
+    call secondary_init
+wfi_loop:
+    wfi
+    j    wfi_loop


### PR DESCRIPTION
Turns out we weren't doing this. Whoops.

Not an issue currently since we're running under QEMU and only OpenSBI is running before us, but it's still the right thing to do.

Patch 1 is trivial fix to the trap handler, patches 2&3 handle the BSS zeroing.