### PR TITLE
lds: Rename _global_pointer to __global_pointer$ as required by linker.

### DIFF
--- a/lds/guest.lds
+++ b/lds/guest.lds
@@ -24,15 +24,17 @@ SECTIONS
         *(.text.init) *(.text .text.*)
     } >ram AT>ram :text
 
-    PROVIDE(_global_pointer = .);
-
     .rodata : {
         *(.rodata .rodata.*)
     } >ram AT>ram :text
 
     .data : {
         . = ALIGN(4096);
-        *(.sdata .sdata.*) *(.data .data.*)
+        *(.data .data.*)
+
+        . = ALIGN(8);
+        PROVIDE(__global_pointer$ = . + 0x800);
+        *(.sdata .sdata.*)
     } >ram AT>ram :data
 
     .bss : {

--- a/lds/qemu.lds
+++ b/lds/qemu.lds
@@ -24,22 +24,24 @@ SECTIONS
         *(.text.init) *(.text .text.*)
     } >ram AT>ram :text
 
-    PROVIDE(_global_pointer = .);
-
     .rodata : {
         *(.rodata .rodata.*)
     } >ram AT>ram :text
 
     .extable : {
         . = ALIGN(8);
-	PROVIDE(_extable_start = .);
-	KEEP(*(.extable))
-	PROVIDE(_extable_end = .);
+        PROVIDE(_extable_start = .);
+        KEEP(*(.extable))
+        PROVIDE(_extable_end = .);
     } >ram AT>ram :text
 
     .data : {
         . = ALIGN(4096);
-        *(.sdata .sdata.*) *(.data .data.*)
+        *(.data .data.*)
+
+        . = ALIGN(8);
+        PROVIDE(__global_pointer$ = . + 0x800);
+        *(.sdata .sdata.*)
     } >ram AT>ram :data
 
     .bss : {

--- a/src/start.S
+++ b/src/start.S
@@ -12,7 +12,7 @@ _start:
 
 .option push
 .option norelax
-    la gp, _global_pointer
+    la gp, __global_pointer$
 .option pop
     la sp, _stack_end
     csrw sstatus, zero
@@ -33,7 +33,7 @@ _secondary_start:
 
 .option push
 .option norelax
-    la gp, _global_pointer
+    la gp, __global_pointer$
 .option pop
     csrw sstatus, zero
     csrw sie, zero

--- a/test-workloads/src/start.S
+++ b/test-workloads/src/start.S
@@ -12,7 +12,7 @@ _start:
 
 .option push
 .option norelax
-    la gp, _global_pointer
+    la gp, __global_pointer$
 .option pop
     la sp, _stack_end
     csrw sstatus, zero
@@ -33,7 +33,7 @@ _secondary_start:
 
 .option push
 .option norelax
-    la gp, _global_pointer
+    la gp, __global_pointer$
 .option pop
     csrw sstatus, zero
     csrw sie, zero


### PR DESCRIPTION
The linker assumes that if this symbol is defined, then the gp register contains that value, which it can then use to relax accesses to global symbols within that 12-bit range. The name of the symbol needs to be exactly __global_pointer$. [1]

Given in riscv we have 12bit signed offsets, the gp is usually placed at 2048 (0x800) bytes offset into the desired section.

Most of the other projects point gp in the sdata section so moving our global_pointer to .sdata section as well. I haven't done any performance tests to check for any improvements, this just to follow what others have done. [2] [3]

References:
 [1] https://www.sifive.com/blog/all-aboard-part-3-linker-relaxation-in-riscv-toolchain
 [2] https://github.com/torvalds/linux/blob/01f856ae6d0ca5ad0505b79bf2d22d7ca439b2a1/arch/riscv/kernel/vmlinux.lds.S#L121
 [3] https://github.com/zephyrproject-rtos/zephyr/blob/a5ea4664c9b625f740ad62f0e2fcd53eaed00791/include/zephyr/arch/riscv/common/linker.ld#L275

Signed-off-by: Rajnesh Kanwal <rkanwal@rivosinc.com>