### PR TITLE
Add VCPU IMSIC migration support.

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -253,7 +253,7 @@ sequenceDiagram
         S->>S: Add pages to guest's PT page pool
     end
     loop For each confidential memory region
-        H->>S: TvmAddConfidentialMemoryRegion
+        H->>S: TvmAddMemoryRegion
         S->>S: Mark region in guest address space as confidential
         H->>S: TvmAddMeasuredPages
         S->>S: Copy, measure, assign, and map pages into guest VM

--- a/drivers/src/imsic/geometry.rs
+++ b/drivers/src/imsic/geometry.rs
@@ -27,7 +27,7 @@ impl ImsicGroupId {
 pub struct ImsicHartId(u64);
 
 impl ImsicHartId {
-    /// Creates a new `ImsicGroupId` from `id`.
+    /// Creates a new `ImsicHartId` from `id`.
     pub fn new(id: u64) -> Self {
         Self(id)
     }

--- a/drivers/src/imsic/sw_file.rs
+++ b/drivers/src/imsic/sw_file.rs
@@ -35,7 +35,7 @@ impl SwFile {
     /// Creates an empty `SwFile`.
     pub fn new() -> Self {
         Self {
-            entries: [SwFileEntry::default(); 32],
+            entries: [SwFileEntry::default(); SW_FILE_ENTRIES],
             eidelivery: 0,
             eithreshold: 0,
         }

--- a/drivers/src/iommu/device_directory.rs
+++ b/drivers/src/iommu/device_directory.rs
@@ -137,7 +137,7 @@ impl DeviceContext {
         const HGATP_MODE_SHIFT: u64 = 60;
         self.iohgatp = pt.get_root_address().pfn().bits()
             | ((gscid.bits() as u64) << GSCID_SHIFT)
-            | (T::HGATP_VALUE << HGATP_MODE_SHIFT);
+            | (T::HGATP_MODE << HGATP_MODE_SHIFT);
 
         // Ensure the writes to the other context fields are visible before we mark the context
         // as valid.

--- a/riscv-page-tables/src/page_table.rs
+++ b/riscv-page-tables/src/page_table.rs
@@ -473,15 +473,15 @@ pub trait PagingMode {
 /// A page table for a S or U mode. It's enabled by storing its root address in `satp`.
 /// Examples include `Sv39`, `Sv48`, or `Sv57`
 pub trait FirstStagePagingMode: PagingMode<MappedAddressSpace = SupervisorVirt> {
-    /// `SATP_VALUE` must be set to the paging mode stored in register satp.
-    const SATP_VALUE: u64;
+    /// `SATP_MODE` must be set to the paging mode stored in register satp.
+    const SATP_MODE: u64;
 }
 
 /// A page table for a VM. It's enabled by storing its root address in `hgatp`.
 /// Examples include `Sv39x4`, `Sv48x4`, or `Sv57x4`
 pub trait GuestStagePagingMode: PagingMode<MappedAddressSpace = GuestPhys> {
-    /// `HGATP_VALUE` must be set to the paging mode stored in register hgatp.
-    const HGATP_VALUE: u64;
+    /// `HGATP_MODE` must be set to the paging mode stored in register hgatp.
+    const HGATP_MODE: u64;
 }
 
 /// The internal state of a paging hierarchy.

--- a/riscv-page-tables/src/sv48.rs
+++ b/riscv-page-tables/src/sv48.rs
@@ -59,7 +59,7 @@ impl PageTableLevel for Sv48Level {
 pub enum Sv48 {}
 
 impl FirstStagePagingMode for Sv48 {
-    const SATP_VALUE: u64 = 9;
+    const SATP_MODE: u64 = 9;
 }
 
 impl PagingMode for Sv48 {

--- a/riscv-page-tables/src/sv48x4.rs
+++ b/riscv-page-tables/src/sv48x4.rs
@@ -74,7 +74,7 @@ impl PageTableLevel for Sv48x4Level {
 pub enum Sv48x4 {}
 
 impl GuestStagePagingMode for Sv48x4 {
-    const HGATP_VALUE: u64 = 9;
+    const HGATP_MODE: u64 = 9;
 }
 
 impl PagingMode for Sv48x4 {

--- a/riscv-regs/src/csrs/defs.rs
+++ b/riscv-regs/src/csrs/defs.rs
@@ -207,7 +207,7 @@ impl SatpHelpers for LocalRegisterCopy<u64, satp::Register> {
     fn set_from<T: FirstStagePagingMode>(&mut self, pt: &FirstStagePageTable<T>, asid: u64) {
         self.modify(satp::asid.val(asid));
         self.modify(satp::ppn.val(Pfn::from(pt.get_root_address()).bits()));
-        self.modify(satp::mode.val(T::SATP_VALUE));
+        self.modify(satp::mode.val(T::SATP_MODE));
     }
 }
 
@@ -429,7 +429,7 @@ impl HgatpHelpers for LocalRegisterCopy<u64, hgatp::Register> {
     fn set_from<T: GuestStagePagingMode>(&mut self, pt: &GuestStagePageTable<T>, vmid: u64) {
         self.modify(hgatp::vmid.val(vmid));
         self.modify(hgatp::ppn.val(Pfn::from(pt.get_root_address()).bits()));
-        self.modify(hgatp::mode.val(T::HGATP_VALUE));
+        self.modify(hgatp::mode.val(T::HGATP_MODE));
     }
 }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -232,6 +232,7 @@ type AttestationSha384 = AttestationManager<sha2::Sha384>;
 pub struct Vm<T: GuestStagePagingMode> {
     vcpus: VmCpus,
     vm_pages: VmPages<T>,
+    // Only used by Host VM to track guest VMs.
     guests: Option<Guests<T>>,
     attestation_mgr: AttestationSha384,
 }
@@ -1954,7 +1955,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
             .as_finalized_vm()
             .ok_or(EcallError::Sbi(SbiError::InvalidParam))?;
 
-        // Make sure we're in the proper to state to unbind the vCPU before we go unmapping
+        // Make sure we're in the proper state to unbind the vCPU before we go unmapping
         // the page.
         let guest_addr = guest_vm.get_vcpu_imsic_addr(vcpu_id)?;
         guest_vm.unbind_vcpu_begin(vcpu_id)?;

--- a/src/vm_interrupts.rs
+++ b/src/vm_interrupts.rs
@@ -79,6 +79,8 @@ impl AllowList {
 /// Virtual external interrupt state for a vCPU.
 pub struct VmCpuExtInterrupts {
     bind_status: BindStatus,
+    // This is the virtual location where we want the guest VCPU to see the interrupt file.
+    // Physical location information is part of the bind_status in form of CpuId and ImsicFileId.
     imsic_location: ImsicLocation,
     sw_file: SwFile,
     allowed_ids: AllowList,

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -661,7 +661,7 @@ impl<'a, T: GuestStagePagingMode> ActiveVmPages<'a, T> {
         let mut hgatp = LocalRegisterCopy::<u64, hgatp::Register>::new(0);
         hgatp.modify(hgatp::vmid.val(vmid.vmid()));
         hgatp.modify(hgatp::ppn.val(Pfn::from(vm_pages.root_address()).bits()));
-        hgatp.modify(hgatp::mode.val(T::HGATP_VALUE));
+        hgatp.modify(hgatp::mode.val(T::HGATP_MODE));
         CSR.hgatp.set(hgatp.get());
 
         let tlb_version = vm_pages.inner.tlb_tracker.get_version();


### PR DESCRIPTION
Adds support to rebind a VCPU to a different PCPU without MRIF support. This only supports GIF to GIF migration.

The main idea is to update the IMSIC mappings in guest stage tables and IOMMU to point to new guest interrupt file. This allow new file to capture interrupt while the migration is in process. Given is the overall workflow:

> TvmCpuRebindImsicBegin: Sets up new interrupt file mapping and begins removal of previous one.
> 
> TvmInitiateFence: The host must complete a TLB invalidation sequence to make sure the old mappings are invalidated and new mappings are used.
> 
> TvmCpuRebindImsicClone: Must run on the old PCPU. This clones the old guest interrupt file internally to transfer it to new guest interrupt file. This also checks for TLB invalidation and frees the old guest interrupt file for future use.
> 
> TvmCpuRebindImsicEnd: Copies over the saved guest interrupt file state into the new interrupt file and marks the VCPU state again to Bound.

I must admit I don't have the pages and memory management abstraction fully figured out in my head nice and clean. I feel like there can be better ways of doing the page remapping work. Feel free to point out any problems. Also, new to rust but I have tried my best to not do any silly mistakes. Just 15 days ago, rust looked like gibberish and now I am doing the same gibberish, although not of that quality.

Marking this PR as draft as this is just to gather initial thoughts and there is some cleanup to do in the existing code as well.
- Remove the iommu msi page table related code as without MRIF, there is no point of msi page table.
- Update a couple of TH-API comments. 
- Add (per-CPU!) bitmap/state to keep track of used and unused guest interrupt files to avoid host trying to assign same file to multiple VCPUs.