### PR TITLE
Run umode stub

### DIFF
--- a/riscv-elf/src/lib.rs
+++ b/riscv-elf/src/lib.rs
@@ -241,6 +241,7 @@ impl<'elf> ElfSegment<'elf> {
 
 /// A structure that checks and prepares and ELF for loading into memory.
 pub struct ElfMap<'elf> {
+    entry: u64,
     segments: ArrayVec<ElfSegment<'elf>, ELF_SEGMENTS_MAX>,
 }
 
@@ -323,7 +324,15 @@ impl<'elf> ElfMap<'elf> {
             let segment = ElfSegment::new(data, vaddr, size, flags)?;
             segments.push(segment);
         }
-        Ok(Self { segments })
+        Ok(Self {
+            entry: header.e_entry,
+            segments,
+        })
+    }
+
+    /// Return the entry of this executable.
+    pub fn entry(&self) -> u64 {
+        self.entry
     }
 
     /// Return an iterator containings loadable segments of this ELF file.

--- a/src/hyp_map.rs
+++ b/src/hyp_map.rs
@@ -232,7 +232,7 @@ pub struct HypMap {
 
 impl HypMap {
     // Create a new hypervisor map from a hardware memory mem map and a umode ELF.
-    pub fn new(mem_map: HwMemMap, umode_elf: ElfMap<'static>) -> Result<HypMap, Error> {
+    pub fn new(mem_map: HwMemMap, umode_elf: &ElfMap<'static>) -> Result<HypMap, Error> {
         // All shared mappings come from the HW Memory Map.
         let shared_regions = mem_map
             .regions()

--- a/src/main.rs
+++ b/src/main.rs
@@ -449,8 +449,8 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
         - mem_map.regions().next().unwrap().base().bits();
 
     // Parse the user-mode ELF containing the user-mode task.
-    let user_elf = include_bytes!("../target/riscv64gc-unknown-none-elf/release/umode");
-    let user_map = ElfMap::new(user_elf).expect("Cannot load user-mode ELF");
+    let umode_bytes = include_bytes!("../target/riscv64gc-unknown-none-elf/release/umode");
+    let umode_elf = ElfMap::new(umode_bytes).expect("Cannot load user-mode ELF");
 
     println!("HW memory map:");
     for (i, r) in mem_map.regions().enumerate() {
@@ -463,8 +463,8 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
         );
     }
 
-    println!("USER memory map:");
-    for (i, s) in user_map.segments().enumerate() {
+    println!("umode memory map:");
+    for (i, s) in umode_elf.segments().enumerate() {
         println!(
             "[{:02}] region: 0x{:016x} -> 0x{:016x}, {}",
             i,
@@ -474,8 +474,8 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
         );
     }
 
-    // Create the hypervisor mapping starting from the hardware memory map.
-    let hyp_map = HypMap::new(mem_map, user_map);
+    // Create the hypervisor mapping from the hardware memory map and the U-mode ELF.
+    let hyp_map = HypMap::new(mem_map, umode_elf);
 
     // The hypervisor mapping is complete. Can setup paging structures now.
     setup_hyp_paging(hyp_map, &mut hyp_mem);

--- a/src/main.rs
+++ b/src/main.rs
@@ -475,7 +475,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     }
 
     // Create the hypervisor mapping from the hardware memory map and the U-mode ELF.
-    let hyp_map = HypMap::new(mem_map, umode_elf);
+    let hyp_map = HypMap::new(mem_map, umode_elf).expect("Cannot create Hypervisor map.");
 
     // The hypervisor mapping is complete. Can setup paging structures now.
     setup_hyp_paging(hyp_map, &mut hyp_mem);

--- a/src/trap.rs
+++ b/src/trap.rs
@@ -205,13 +205,6 @@ extern "C" fn handle_trap(tf_ptr: *mut TrapFrame) {
         tf.gprs.reg(T0)
     );
     println!(
-        "S9: 0x{:08x}, S10: 0x{:08x}, S11: 0x{:08x}, T0: 0x{:08x}",
-        tf.gprs.reg(S9),
-        tf.gprs.reg(S10),
-        tf.gprs.reg(S11),
-        tf.gprs.reg(T0)
-    );
-    println!(
         "T1: 0x{:08x}, T2: 0x{:08x}, T3: 0x{:08x}, T4: 0x{:08x}",
         tf.gprs.reg(T1),
         tf.gprs.reg(T2),

--- a/src/umode.S
+++ b/src/umode.S
@@ -1,0 +1,170 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Enter U-mode using `UmodeCpuArchState` in `a0`.
+.section .text.init
+.global _run_umode
+_run_umode:
+    /* Save hypervisor state */
+
+    /* Save Host GPRs (except T0-T6 and a0, which is the U-mode state and stashed in sscratch) */
+    sd   ra, ({hyp_ra})(a0)
+    sd   gp, ({hyp_gp})(a0)
+    sd   tp, ({hyp_tp})(a0)
+    sd   s0, ({hyp_s0})(a0)
+    sd   s1, ({hyp_s1})(a0)
+    sd   a1, ({hyp_a1})(a0)
+    sd   a2, ({hyp_a2})(a0)
+    sd   a3, ({hyp_a3})(a0)
+    sd   a4, ({hyp_a4})(a0)
+    sd   a5, ({hyp_a5})(a0)
+    sd   a6, ({hyp_a6})(a0)
+    sd   a7, ({hyp_a7})(a0)
+    sd   s2, ({hyp_s2})(a0)
+    sd   s3, ({hyp_s3})(a0)
+    sd   s4, ({hyp_s4})(a0)
+    sd   s5, ({hyp_s5})(a0)
+    sd   s6, ({hyp_s6})(a0)
+    sd   s7, ({hyp_s7})(a0)
+    sd   s8, ({hyp_s8})(a0)
+    sd   s9, ({hyp_s9})(a0)
+    sd   s10, ({hyp_s10})(a0)
+    sd   s11, ({hyp_s11})(a0)
+    sd   sp, ({hyp_sp})(a0)
+
+    /* Swap in U-mode CSRs. */
+    ld    t1, ({umode_sepc})(a0)
+    csrw  sepc, t1
+
+    /* Swap in sstatus. */
+    ld    t1, ({umode_sstatus})(a0)
+    csrrw t1, sstatus, t1
+    sd    t1, ({hyp_sstatus})(a0)
+
+    /* Set stvec so that hypervisor resumes after the sret when U-mode exits. */
+    la    t1, _umode_exit
+    csrrw t1, stvec, t1
+    sd    t1, ({hyp_stvec})(a0)
+
+    /* Save sscratch and replace with pointer to the U-mode state. */
+    csrrw t1, sscratch, a0
+    sd    t1, ({hyp_sscratch})(a0)
+
+    /* Restore the gprs from the U-mode state */
+    ld   ra, ({umode_ra})(a0)
+    ld   gp, ({umode_gp})(a0)
+    ld   tp, ({umode_tp})(a0)
+    ld   s0, ({umode_s0})(a0)
+    ld   s1, ({umode_s1})(a0)
+    ld   a1, ({umode_a1})(a0)
+    ld   a2, ({umode_a2})(a0)
+    ld   a3, ({umode_a3})(a0)
+    ld   a4, ({umode_a4})(a0)
+    ld   a5, ({umode_a5})(a0)
+    ld   a6, ({umode_a6})(a0)
+    ld   a7, ({umode_a7})(a0)
+    ld   s2, ({umode_s2})(a0)
+    ld   s3, ({umode_s3})(a0)
+    ld   s4, ({umode_s4})(a0)
+    ld   s5, ({umode_s5})(a0)
+    ld   s6, ({umode_s6})(a0)
+    ld   s7, ({umode_s7})(a0)
+    ld   s8, ({umode_s8})(a0)
+    ld   s9, ({umode_s9})(a0)
+    ld   s10, ({umode_s10})(a0)
+    ld   s11, ({umode_s11})(a0)
+    ld   t0, ({umode_t0})(a0)
+    ld   t1, ({umode_t1})(a0)
+    ld   t2, ({umode_t2})(a0)
+    ld   t3, ({umode_t3})(a0)
+    ld   t4, ({umode_t4})(a0)
+    ld   t5, ({umode_t5})(a0)
+    ld   t6, ({umode_t6})(a0)
+    ld   sp, ({umode_sp})(a0)
+    ld   a0, ({umode_a0})(a0)
+
+    sret
+
+.align 2
+_umode_exit:
+    /* Pull U-mode state out of sscratch, swapping with a0 */
+    csrrw a0, sscratch, a0
+
+    /* Save U-mode GPRs. */
+    sd   ra, ({umode_ra})(a0)
+    sd   gp, ({umode_gp})(a0)
+    sd   tp, ({umode_tp})(a0)
+    sd   s0, ({umode_s0})(a0)
+    sd   s1, ({umode_s1})(a0)
+    sd   a1, ({umode_a1})(a0)
+    sd   a2, ({umode_a2})(a0)
+    sd   a3, ({umode_a3})(a0)
+    sd   a4, ({umode_a4})(a0)
+    sd   a5, ({umode_a5})(a0)
+    sd   a6, ({umode_a6})(a0)
+    sd   a7, ({umode_a7})(a0)
+    sd   s2, ({umode_s2})(a0)
+    sd   s3, ({umode_s3})(a0)
+    sd   s4, ({umode_s4})(a0)
+    sd   s5, ({umode_s5})(a0)
+    sd   s6, ({umode_s6})(a0)
+    sd   s7, ({umode_s7})(a0)
+    sd   s8, ({umode_s8})(a0)
+    sd   s9, ({umode_s9})(a0)
+    sd   s10, ({umode_s10})(a0)
+    sd   s11, ({umode_s11})(a0)
+    sd   t0, ({umode_t0})(a0)
+    sd   t1, ({umode_t1})(a0)
+    sd   t2, ({umode_t2})(a0)
+    sd   t3, ({umode_t3})(a0)
+    sd   t4, ({umode_t4})(a0)
+    sd   t5, ({umode_t5})(a0)
+    sd   t6, ({umode_t6})(a0)
+    sd   sp, ({umode_sp})(a0)
+
+    /* Save U-mode a0 after recovering from sscratch. */
+    csrr  t0, sscratch
+    sd    t0, ({umode_a0})(a0)
+
+    /* Swap in host CSRs. */
+    ld    t1, ({hyp_stvec})(a0)
+    csrw  stvec, t1
+
+    ld    t1, ({hyp_sstatus})(a0)
+    csrrw t1, sstatus, t1
+    sd    t1, ({umode_sstatus})(a0)
+
+    ld    t1, ({hyp_sscratch})(a0)
+    csrw  sscratch, t1
+
+    /* Save U-mode EPC. */
+    csrr  t1, sepc
+    sd    t1, ({umode_sepc})(a0)
+
+    /* Restore hypervisor GPRs. */
+    ld   ra, ({hyp_ra})(a0)
+    ld   gp, ({hyp_gp})(a0)
+    ld   tp, ({hyp_tp})(a0)
+    ld   s0, ({hyp_s0})(a0)
+    ld   s1, ({hyp_s1})(a0)
+    ld   a1, ({hyp_a1})(a0)
+    ld   a2, ({hyp_a2})(a0)
+    ld   a3, ({hyp_a3})(a0)
+    ld   a4, ({hyp_a4})(a0)
+    ld   a5, ({hyp_a5})(a0)
+    ld   a6, ({hyp_a6})(a0)
+    ld   a7, ({hyp_a7})(a0)
+    ld   s2, ({hyp_s2})(a0)
+    ld   s3, ({hyp_s3})(a0)
+    ld   s4, ({hyp_s4})(a0)
+    ld   s5, ({hyp_s5})(a0)
+    ld   s6, ({hyp_s6})(a0)
+    ld   s7, ({hyp_s7})(a0)
+    ld   s8, ({hyp_s8})(a0)
+    ld   s9, ({hyp_s9})(a0)
+    ld   s10, ({hyp_s10})(a0)
+    ld   s11, ({hyp_s11})(a0)
+    ld   sp, ({hyp_sp})(a0)
+
+    ret

--- a/src/umode.rs
+++ b/src/umode.rs
@@ -1,0 +1,108 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::smp::PerCpu;
+
+use core::cell::{RefCell, RefMut};
+use riscv_elf::ElfMap;
+use riscv_regs::GeneralPurposeRegisters;
+use spin::Once;
+
+/// Host GPR and which must be saved/restored when entering/exiting U-mode.
+#[derive(Default)]
+#[repr(C)]
+struct HostCpuRegs {
+    gprs: GeneralPurposeRegisters,
+    sstatus: u64,
+    stvec: u64,
+    sscratch: u64,
+}
+
+/// Umode GPR and CSR state which must be saved/restored when exiting/entering U-mode.
+#[derive(Default)]
+#[repr(C)]
+struct UmodeCpuRegs {
+    gprs: GeneralPurposeRegisters,
+    sepc: u64,
+    sstatus: u64,
+}
+
+/// CSRs written on an exit from virtualization that are used by the host to determine the cause of
+/// the trap.
+#[derive(Default)]
+#[repr(C)]
+struct TrapRegs {
+    scause: u64,
+    stval: u64,
+}
+
+/// CPU register state that must be saved or restored when entering/exiting U-mode.
+#[derive(Default)]
+#[repr(C)]
+struct UmodeCpuArchState {
+    hyp_regs: HostCpuRegs,
+    umode_regs: UmodeCpuRegs,
+    trap_csrs: TrapRegs,
+}
+
+/// Errors returned by U-mode runs.
+#[derive(Debug)]
+pub enum Error {
+    /// Task already active.
+    TaskBusy,
+}
+
+// Entry for umode task.
+static UMODE_ENTRY: Once<u64> = Once::new();
+
+/// Represents a U-mode state with its running context.
+pub struct UmodeTask {
+    arch: RefCell<UmodeCpuArchState>,
+}
+
+impl UmodeTask {
+    /// Initialize U-mode tasks. Must be called once bofore `setup_this_cpu()`.
+    pub fn init(umode_elf: ElfMap) {
+        UMODE_ENTRY.call_once(|| umode_elf.entry());
+        // Consumes the ElfMap.
+    }
+
+    /// Initialize a new U-mode task. Must be called once on each physical CPU.
+    pub fn setup_this_cpu() {
+        let mut arch = UmodeCpuArchState::default();
+        // sstatus set to 0 (by default) is actually okay.
+        // Unwrap okay: this is called after `Self::init()`.
+        arch.umode_regs.sepc = *UMODE_ENTRY.get().unwrap();
+        let task = UmodeTask {
+            arch: RefCell::new(arch),
+        };
+        // Install umode in the current cpu.
+        PerCpu::this_cpu().set_umode_task(task);
+    }
+
+    /// Return this CPU's task. Must be call after `Self::setup_this_cpu()`.
+    pub fn get() -> &'static UmodeTask {
+        PerCpu::this_cpu().umode_task()
+    }
+
+    /// Activate this umode in order to run it.
+    pub fn activate(&self) -> Result<ActiveUmodeTask, Error> {
+        let arch = self.arch.try_borrow_mut().map_err(|_| Error::TaskBusy)?;
+        Ok(ActiveUmodeTask { arch })
+    }
+}
+
+/// Represents a U-mode that is running or runnable. Not at initial state.
+pub struct ActiveUmodeTask<'act> {
+    arch: RefMut<'act, UmodeCpuArchState>,
+}
+
+impl<'act> ActiveUmodeTask<'act> {
+    /// Run `umode` until completion or error.
+    pub fn run(&mut self) -> Result<(), Error> {
+        // Dummy write.
+        self.arch.trap_csrs.stval = 0;
+        Ok(())
+    }
+}

--- a/src/umode.rs
+++ b/src/umode.rs
@@ -4,9 +4,15 @@
 
 use crate::smp::PerCpu;
 
+use core::arch::global_asm;
 use core::cell::{RefCell, RefMut};
+use core::fmt;
+use core::mem::size_of;
+use memoffset::offset_of;
 use riscv_elf::ElfMap;
-use riscv_regs::GeneralPurposeRegisters;
+use riscv_regs::Exception::UserEnvCall;
+use riscv_regs::{GeneralPurposeRegisters, GprIndex, Readable, Trap, CSR};
+use s_mode_utils::print::*;
 use spin::Once;
 
 /// Host GPR and which must be saved/restored when entering/exiting U-mode.
@@ -46,9 +52,185 @@ struct UmodeCpuArchState {
     trap_csrs: TrapRegs,
 }
 
+impl fmt::Display for UmodeCpuArchState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let uregs = &self.umode_regs;
+        writeln!(
+            f,
+            "SEPC: 0x{:016x}, SSTATUS: 0x{:016x}",
+            uregs.sepc, uregs.sstatus,
+        )?;
+        writeln!(
+            f,
+            "SCAUSE: 0x{:016x}, STVAL: 0x{:016x}",
+            self.trap_csrs.scause, self.trap_csrs.stval,
+        )?;
+        use GprIndex::*;
+        writeln!(
+            f,
+            "RA:  0x{:016x}, GP:  0x{:016x}, TP:  0x{:016x}, S0:  0x{:016x}",
+            uregs.gprs.reg(RA),
+            uregs.gprs.reg(GP),
+            uregs.gprs.reg(TP),
+            uregs.gprs.reg(S0)
+        )?;
+        writeln!(
+            f,
+            "S1:  0x{:016x}, A0:  0x{:016x}, A1:  0x{:016x}, A2:  0x{:016x}",
+            uregs.gprs.reg(S1),
+            uregs.gprs.reg(A0),
+            uregs.gprs.reg(A1),
+            uregs.gprs.reg(A2)
+        )?;
+        writeln!(
+            f,
+            "A3:  0x{:016x}, A4:  0x{:016x}, A5:  0x{:016x}, A6:  0x{:016x}",
+            uregs.gprs.reg(A3),
+            uregs.gprs.reg(A4),
+            uregs.gprs.reg(A5),
+            uregs.gprs.reg(A6)
+        )?;
+        writeln!(
+            f,
+            "A7:  0x{:016x}, S2:  0x{:016x}, S3:  0x{:016x}, S4:  0x{:016x}",
+            uregs.gprs.reg(A7),
+            uregs.gprs.reg(S2),
+            uregs.gprs.reg(S3),
+            uregs.gprs.reg(S4)
+        )?;
+        writeln!(
+            f,
+            "S5:  0x{:016x}, S6:  0x{:016x}, S7:  0x{:016x}, S8:  0x{:016x}",
+            uregs.gprs.reg(S5),
+            uregs.gprs.reg(S6),
+            uregs.gprs.reg(S7),
+            uregs.gprs.reg(S8)
+        )?;
+        writeln!(
+            f,
+            "S9:  0x{:016x}, S10: 0x{:016x}, S11: 0x{:016x}, T0:  0x{:016x}",
+            uregs.gprs.reg(S9),
+            uregs.gprs.reg(S10),
+            uregs.gprs.reg(S11),
+            uregs.gprs.reg(T0)
+        )?;
+        writeln!(
+            f,
+            "T1:  0x{:016x}, T2:  0x{:016x}, T3:  0x{:016x}, T4:  0x{:016x}",
+            uregs.gprs.reg(T1),
+            uregs.gprs.reg(T2),
+            uregs.gprs.reg(T3),
+            uregs.gprs.reg(T4)
+        )?;
+        writeln!(
+            f,
+            "T5:  0x{:016x}, T6:  0x{:016x}, SP:  0x{:016x}",
+            uregs.gprs.reg(T5),
+            uregs.gprs.reg(T6),
+            uregs.gprs.reg(SP)
+        )
+    }
+}
+
+extern "C" {
+    // umode context switch. Defined in umode.S
+    fn _run_umode(g: *mut UmodeCpuArchState);
+}
+
+#[allow(dead_code)]
+const fn hyp_gpr_offset(index: GprIndex) -> usize {
+    offset_of!(UmodeCpuArchState, hyp_regs)
+        + offset_of!(HostCpuRegs, gprs)
+        + (index as usize) * size_of::<u64>()
+}
+
+#[allow(dead_code)]
+const fn umode_gpr_offset(index: GprIndex) -> usize {
+    offset_of!(UmodeCpuArchState, umode_regs)
+        + offset_of!(UmodeCpuRegs, gprs)
+        + (index as usize) * size_of::<u64>()
+}
+
+macro_rules! hyp_csr_offset {
+    ($reg:tt) => {
+        offset_of!(UmodeCpuArchState, hyp_regs) + offset_of!(HostCpuRegs, $reg)
+    };
+}
+
+macro_rules! umode_csr_offset {
+    ($reg:tt) => {
+        offset_of!(UmodeCpuArchState, umode_regs) + offset_of!(UmodeCpuRegs, $reg)
+    };
+}
+
+global_asm!(
+    include_str!("umode.S"),
+    hyp_ra = const hyp_gpr_offset(GprIndex::RA),
+    hyp_gp = const hyp_gpr_offset(GprIndex::GP),
+    hyp_tp = const hyp_gpr_offset(GprIndex::TP),
+    hyp_s0 = const hyp_gpr_offset(GprIndex::S0),
+    hyp_s1 = const hyp_gpr_offset(GprIndex::S1),
+    hyp_a1 = const hyp_gpr_offset(GprIndex::A1),
+    hyp_a2 = const hyp_gpr_offset(GprIndex::A2),
+    hyp_a3 = const hyp_gpr_offset(GprIndex::A3),
+    hyp_a4 = const hyp_gpr_offset(GprIndex::A4),
+    hyp_a5 = const hyp_gpr_offset(GprIndex::A5),
+    hyp_a6 = const hyp_gpr_offset(GprIndex::A6),
+    hyp_a7 = const hyp_gpr_offset(GprIndex::A7),
+    hyp_s2 = const hyp_gpr_offset(GprIndex::S2),
+    hyp_s3 = const hyp_gpr_offset(GprIndex::S3),
+    hyp_s4 = const hyp_gpr_offset(GprIndex::S4),
+    hyp_s5 = const hyp_gpr_offset(GprIndex::S5),
+    hyp_s6 = const hyp_gpr_offset(GprIndex::S6),
+    hyp_s7 = const hyp_gpr_offset(GprIndex::S7),
+    hyp_s8 = const hyp_gpr_offset(GprIndex::S8),
+    hyp_s9 = const hyp_gpr_offset(GprIndex::S9),
+    hyp_s10 = const hyp_gpr_offset(GprIndex::S10),
+    hyp_s11 = const hyp_gpr_offset(GprIndex::S11),
+    hyp_sp = const hyp_gpr_offset(GprIndex::SP),
+    hyp_sstatus = const hyp_csr_offset!(sstatus),
+    hyp_stvec = const hyp_csr_offset!(stvec),
+    hyp_sscratch = const hyp_csr_offset!(sscratch),
+    umode_ra = const umode_gpr_offset(GprIndex::RA),
+    umode_gp = const umode_gpr_offset(GprIndex::GP),
+    umode_tp = const umode_gpr_offset(GprIndex::TP),
+    umode_s0 = const umode_gpr_offset(GprIndex::S0),
+    umode_s1 = const umode_gpr_offset(GprIndex::S1),
+    umode_a0 = const umode_gpr_offset(GprIndex::A0),
+    umode_a1 = const umode_gpr_offset(GprIndex::A1),
+    umode_a2 = const umode_gpr_offset(GprIndex::A2),
+    umode_a3 = const umode_gpr_offset(GprIndex::A3),
+    umode_a4 = const umode_gpr_offset(GprIndex::A4),
+    umode_a5 = const umode_gpr_offset(GprIndex::A5),
+    umode_a6 = const umode_gpr_offset(GprIndex::A6),
+    umode_a7 = const umode_gpr_offset(GprIndex::A7),
+    umode_s2 = const umode_gpr_offset(GprIndex::S2),
+    umode_s3 = const umode_gpr_offset(GprIndex::S3),
+    umode_s4 = const umode_gpr_offset(GprIndex::S4),
+    umode_s5 = const umode_gpr_offset(GprIndex::S5),
+    umode_s6 = const umode_gpr_offset(GprIndex::S6),
+    umode_s7 = const umode_gpr_offset(GprIndex::S7),
+    umode_s8 = const umode_gpr_offset(GprIndex::S8),
+    umode_s9 = const umode_gpr_offset(GprIndex::S9),
+    umode_s10 = const umode_gpr_offset(GprIndex::S10),
+    umode_s11 = const umode_gpr_offset(GprIndex::S11),
+    umode_t0 = const umode_gpr_offset(GprIndex::T0),
+    umode_t1 = const umode_gpr_offset(GprIndex::T1),
+    umode_t2 = const umode_gpr_offset(GprIndex::T2),
+    umode_t3 = const umode_gpr_offset(GprIndex::T3),
+    umode_t4 = const umode_gpr_offset(GprIndex::T4),
+    umode_t5 = const umode_gpr_offset(GprIndex::T5),
+    umode_t6 = const umode_gpr_offset(GprIndex::T6),
+    umode_sp = const umode_gpr_offset(GprIndex::SP),
+    umode_sepc = const umode_csr_offset!(sepc),
+    umode_sstatus = const umode_csr_offset!(sstatus),
+);
+
 /// Errors returned by U-mode runs.
 #[derive(Debug)]
 pub enum Error {
+    /// Received an unexpected trap while running Umode.
+    UnexpectedTrap,
     /// Task already active.
     TaskBusy,
 }
@@ -101,8 +283,29 @@ pub struct ActiveUmodeTask<'act> {
 impl<'act> ActiveUmodeTask<'act> {
     /// Run `umode` until completion or error.
     pub fn run(&mut self) -> Result<(), Error> {
-        // Dummy write.
-        self.arch.trap_csrs.stval = 0;
-        Ok(())
+        self.run_to_exit();
+        match Trap::from_scause(self.arch.trap_csrs.scause).unwrap() {
+            Trap::Exception(UserEnvCall) => {
+                // Exit on ecall.
+                println!("U-mode ecall!");
+                println!("{}", self.arch);
+                Ok(())
+            }
+            _ => {
+                println!("{}", self.arch);
+                Err(Error::UnexpectedTrap)
+            }
+        }
+    }
+
+    /// Run until it exits
+    fn run_to_exit(&mut self) {
+        unsafe {
+            // Safe to run umode code as it only touches memory assigned to it through umode mappings.
+            _run_umode(&mut *self.arch as *mut UmodeCpuArchState);
+        }
+        // Save off the trap information.
+        self.arch.trap_csrs.scause = CSR.scause.get();
+        self.arch.trap_csrs.stval = CSR.stval.get();
     }
 }


### PR DESCRIPTION
This PR introduces ability for Salus to run user mode code.

This PR is focused on the hypervisor side.

The first patch fixes a silly bug in printing registers on an unexpected salus trap. The second patch is a preparation step.

The third patch adds ability to reset the umode at the initial state, by saving the physical addresses of that particular page table of the writable VA mappings. This avoids using slow implementations of userva accesses .

The fourth patch creates the basic infrastructure for umode life time in salus.

The fifth adds some basic assembler and run the stub until the first ecall.