### PR TITLE
Indent device tree when printing.

### DIFF
--- a/device-tree/src/device_tree.rs
+++ b/device-tree/src/device_tree.rs
@@ -330,16 +330,30 @@ impl DeviceTreeNode {
         self.children.retain(|&i| i != child);
     }
 
-    fn fmt_in(&self, tree: &DeviceTree, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
-        // TODO: Use identation to make this prettier.
+    fn fmt_indent(f: &mut fmt::Formatter, indent: usize) -> result::Result<(), fmt::Error> {
+        for _ in 0..indent {
+            write!(f, "  ")?;
+        }
+        Ok(())
+    }
+
+    fn fmt_in(
+        &self,
+        tree: &DeviceTree,
+        f: &mut fmt::Formatter,
+        indent: usize,
+    ) -> result::Result<(), fmt::Error> {
+        Self::fmt_indent(f, indent)?;
         writeln!(f, "{} {{", self.name())?;
         for p in self.props() {
+            Self::fmt_indent(f, indent + 1)?;
             writeln!(f, "{p}")?;
         }
         for &n in self.children() {
             let node = tree.get_node(n).unwrap();
-            node.fmt_in(tree, f)?;
+            node.fmt_in(tree, f, indent + 1)?;
         }
+        Self::fmt_indent(f, indent)?;
         writeln!(f, "}}")
     }
 }
@@ -551,7 +565,7 @@ impl fmt::Display for DeviceTree {
             Some(r) => {
                 let node = self.get_node(r).unwrap();
                 write!(f, "\\")?;
-                node.fmt_in(self, f)
+                node.fmt_in(self, f, 0)
             }
             None => write!(f, "empty"),
         }


### PR DESCRIPTION
Small patch to allow the Display implementation of the device tree to print elements indented by depth.

I think this makes the process of booting salus incredibly more aesthetically pleasing. :-)

Changes DT print to from this:
```Host DT: \ {
#address-cells = 0x00000002;
#size-cells = 0x00000002;
compatible = "riscv-virtio";
model = "riscv-virtio,qemu";
chosen {
}
memory@80000000 {
device_type = "memory";
reg = 0x00000000 0x80000000 0x00000000 0x76260000;
}
cpus {
#address-cells = 0x00000001;
#size-cells = 0x00000000;
timebase-frequency = 0x00989680;
cpu@0 {
device_type = "cpu";
compatible = "riscv";
reg = 0x00000000;
mmu-type = "riscv,sv48";
riscv,isa = "rv64imafdch_zicsr_zifencei_zihintpause_zba_zbb_zbc_zbs_smaia_ssaia_sscofpmf_sstc";
status = "okay";
interrupt-controller {
#interrupt-cells = 0x00000001;
interrupt-controller;
phandle = 0x0000000a;
compatible = "riscv,cpu-intc";
}
}
cpu@1 {
device_type = "cpu";
compatible = "riscv";
reg = 0x00000001;
mmu-type = "riscv,sv48";
riscv,isa = "rv64imafdch_zicsr_zifencei_zihintpause_zba_zbb_zbc_zbs_smaia_ssaia_sscofpmf_sstc";
status = "okay";
interrupt-controller {
#interrupt-cells = 0x00000001;
interrupt-controller;
phandle = 0x00000008;
compatible = "riscv,cpu-intc";
}
}
cpu@2 {
device_type = "cpu";
compatible = "riscv";
reg = 0x00000002;
mmu-type = "riscv,sv48";
riscv,isa = "rv64imafdch_zicsr_zifencei_zihintpause_zba_zbb_zbc_zbs_smaia_ssaia_sscofpmf_sstc";
status = "okay";
interrupt-controller {
#interrupt-cells = 0x00000001;
interrupt-controller;
phandle = 0x00000006;
compatible = "riscv,cpu-intc";
}
}
cpu@3 {
device_type = "cpu";
compatible = "riscv";
reg = 0x00000003;
mmu-type = "riscv,sv48";
riscv,isa = "rv64imafdch_zicsr_zifencei_zihintpause_zba_zbb_zbc_zbs_smaia_ssaia_sscofpmf_sstc";
status = "okay";
interrupt-controller {
#interrupt-cells = 0x00000001;
interrupt-controller;
phandle = 0x00000004;
compatible = "riscv,cpu-intc";
}
}
cpu@4 {
device_type = "cpu";
compatible = "riscv";
reg = 0x00000004;
mmu-type = "riscv,sv48";
riscv,isa = "rv64imafdch_zicsr_zifencei_zihintpause_zba_zbb_zbc_zbs_smaia_ssaia_sscofpmf_sstc";
status = "okay";
interrupt-controller {
#interrupt-cells = 0x00000001;
interrupt-controller;
phandle = 0x00000002;
compatible = "riscv,cpu-intc";
}
}
}
soc {
compatible = "simple-bus";
#address-cells = 0x00000002;
#size-cells = 0x00000002;
ranges;
imsics@28000000 {
compatible = "riscv,imsics";
phandle = 0x0000000c;
msi-controller;
interrupt-controller;
#interrupt-cells = 0x00000000;
riscv,guest-index-bits = 0x00000003;
riscv,hart-index-bits = 0x00000003;
riscv,ipi-id = 0x00000001;
riscv,num-ids = 0x000000ff;
reg = 0x00000000 0x28000000 0x00000000 0x00028000;
interrupts-extended = 0x0000000a 0x00000009 0x00000008 0x00000009 0x00000006 0x00000009 0x00000004 0x00000009 0x00000002 0x00000009;
}
pci@30000000 {
compatible = "pci-host-ecam-generic";
reg = 0x00000000 0x30000000 0x00000000 0x10000000;
ranges = 0x01000000 0x00000000 0x00000000 0x00000000 0x03000000 0x00000000 0x00010000 0x02000000 0x00000000 0x40000000 0x00000000 0x40000000 0x00000000 0x40000000 0x03000000 0x00000001 0x00000000 0x00000001 0x00000000 0x00000000 0x80000000;
device_type = "pci";
dma-coherent;
linux,pci-domain = 0x00000000;
bus-range = 0x00000000 0x000000ff;
msi-parent = 0x0000000c;
#size-cells = 0x00000002;
#address-cells = 0x00000003;
}
}
}
```

to this:

```
Host DT: \ {
  #address-cells = 0x00000002;
  #size-cells = 0x00000002;
  compatible = "riscv-virtio";
  model = "riscv-virtio,qemu";
  chosen {
  }
  memory@80000000 {
    device_type = "memory";
    reg = 0x00000000 0x80000000 0x00000000 0x76260000;
  }
  cpus {
    #address-cells = 0x00000001;
    #size-cells = 0x00000000;
    timebase-frequency = 0x00989680;
    cpu@0 {
      device_type = "cpu";
      compatible = "riscv";
      reg = 0x00000000;
      mmu-type = "riscv,sv48";
      riscv,isa = "rv64imafdch_zicsr_zifencei_zihintpause_zba_zbb_zbc_zbs_smaia_ssaia_sscofpmf_sstc";
      status = "okay";
      interrupt-controller {
        #interrupt-cells = 0x00000001;
        interrupt-controller;
        phandle = 0x0000000a;
        compatible = "riscv,cpu-intc";
      }
    }
    cpu@1 {
      device_type = "cpu";
      compatible = "riscv";
      reg = 0x00000001;
      mmu-type = "riscv,sv48";
      riscv,isa = "rv64imafdch_zicsr_zifencei_zihintpause_zba_zbb_zbc_zbs_smaia_ssaia_sscofpmf_sstc";
      status = "okay";
      interrupt-controller {
        #interrupt-cells = 0x00000001;
        interrupt-controller;
        phandle = 0x00000008;
        compatible = "riscv,cpu-intc";
      }
    }
    cpu@2 {
      device_type = "cpu";
      compatible = "riscv";
      reg = 0x00000002;
      mmu-type = "riscv,sv48";
      riscv,isa = "rv64imafdch_zicsr_zifencei_zihintpause_zba_zbb_zbc_zbs_smaia_ssaia_sscofpmf_sstc";
      status = "okay";
      interrupt-controller {
        #interrupt-cells = 0x00000001;
        interrupt-controller;
        phandle = 0x00000006;
        compatible = "riscv,cpu-intc";
      }
    }
    cpu@3 {
      device_type = "cpu";
      compatible = "riscv";
      reg = 0x00000003;
      mmu-type = "riscv,sv48";
      riscv,isa = "rv64imafdch_zicsr_zifencei_zihintpause_zba_zbb_zbc_zbs_smaia_ssaia_sscofpmf_sstc";
      status = "okay";
      interrupt-controller {
        #interrupt-cells = 0x00000001;
        interrupt-controller;
        phandle = 0x00000004;
        compatible = "riscv,cpu-intc";
      }
    }
    cpu@4 {
      device_type = "cpu";
      compatible = "riscv";
      reg = 0x00000004;
      mmu-type = "riscv,sv48";
      riscv,isa = "rv64imafdch_zicsr_zifencei_zihintpause_zba_zbb_zbc_zbs_smaia_ssaia_sscofpmf_sstc";
      status = "okay";
      interrupt-controller {
        #interrupt-cells = 0x00000001;
        interrupt-controller;
        phandle = 0x00000002;
        compatible = "riscv,cpu-intc";
      }
    }
  }
  soc {
    compatible = "simple-bus";
    #address-cells = 0x00000002;
    #size-cells = 0x00000002;
    ranges;
    imsics@28000000 {
      compatible = "riscv,imsics";
      phandle = 0x0000000c;
      msi-controller;
      interrupt-controller;
      #interrupt-cells = 0x00000000;
      riscv,guest-index-bits = 0x00000003;
      riscv,hart-index-bits = 0x00000003;
      riscv,ipi-id = 0x00000001;
      riscv,num-ids = 0x000000ff;
      reg = 0x00000000 0x28000000 0x00000000 0x00028000;
      interrupts-extended = 0x0000000a 0x00000009 0x00000008 0x00000009 0x00000006 0x00000009 0x00000004 0x00000009 0x00000002 0x00000009;
    }
    pci@30000000 {
      compatible = "pci-host-ecam-generic";
      reg = 0x00000000 0x30000000 0x00000000 0x10000000;
      ranges = 0x01000000 0x00000000 0x00000000 0x00000000 0x03000000 0x00000000 0x00010000 0x02000000 0x00000000 0x40000000 0x00000000 0x40000000 0x00000000 0x40000000 0x03000000 0x00000001 0x00000000 0x00000001 0x00000000 0x00000000 0x80000000;
      device_type = "pci";
      dma-coherent;
      linux,pci-domain = 0x00000000;
      bus-range = 0x00000000 0x000000ff;
      msi-parent = 0x0000000c;
      #size-cells = 0x00000002;
      #address-cells = 0x00000003;
    }
  }
}
```