### PR TITLE
Use NACL extension for registering shmem area

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,7 @@ name = "sbi"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
+ "assertions",
  "flagset",
 ]
 

--- a/sbi/Cargo.toml
+++ b/sbi/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 arrayvec = { version = "0.7.2", default-features = false }
+assertions = { path = "../assertions" }
 flagset = "0.4.3"
 
 [lib]

--- a/sbi/src/api/mod.rs
+++ b/sbi/src/api/mod.rs
@@ -11,6 +11,9 @@ pub mod reset;
 /// Host interfaces for hart state management.
 pub mod state;
 
+/// Host interfaces for nested virtualization acceleration.
+pub mod nacl;
+
 /// Host interfaces for confidential computing.
 pub mod tee_host;
 

--- a/sbi/src/api/nacl.rs
+++ b/sbi/src/api/nacl.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::NaclFunction::*;
+use crate::NaclShmem;
+use crate::{ecall_send, Result, SbiMessage};
+
+const PFN_SHIFT: u64 = 12;
+
+/// Registers the nested hypervisor <-> host hypervisor shared memory area for the calling CPU.
+/// `shmem_ptr` must be page-aligned and refer to a sufficient number of accessible, contiguous
+/// pages to hold a `NaclShmem` struct. The pages must remain accessible until the shared-memory area
+/// is unregistered by calling `unregister_shmem()`.
+///
+/// # Safety
+///
+/// The caller must own the pages referenced by `shmem_ptr`, for the number of pages sufficient to
+/// hold the `NaclShmem` structure. Since memory within the shared-memory communication area may be
+/// read or written by the host hypervisor at any time, the caller must treat the memory as volatile
+/// until it is unregistered.
+pub unsafe fn register_shmem(shmem_ptr: *mut NaclShmem) -> Result<()> {
+    let msg = SbiMessage::Nacl(SetShmem {
+        shmem_pfn: (shmem_ptr as u64) >> PFN_SHIFT,
+    });
+    ecall_send(&msg)?;
+    Ok(())
+}
+
+/// Unregisters the nested hypervisor <-> host hypervisor  shared memory area for the calling CPU.
+pub fn unregister_shmem() -> Result<()> {
+    let msg = SbiMessage::Nacl(SetShmem {
+        shmem_pfn: u64::MAX,
+    });
+    // Safety: Doesn't access host memory.
+    unsafe { ecall_send(&msg) }?;
+    Ok(())
+}

--- a/sbi/src/consts.rs
+++ b/sbi/src/consts.rs
@@ -12,6 +12,7 @@ pub const EXT_PMU: u64 = 0x504D55;
 pub const EXT_RESET: u64 = 0x53525354;
 pub const EXT_DBCN: u64 = 0x4442434E; // DBCN
 pub const EXT_ATTESTATION: u64 = 0x41545354; // ATST
+pub const EXT_NACL: u64 = 0x4E41434C; // NACL
 pub const EXT_TEE_HOST: u64 = 0x54454548; // TEEH
 pub const EXT_TEE_INTERRUPT: u64 = 0x54454549; // TEEI
 pub const EXT_TEE_GUEST: u64 = 0x54454547; // TEEG

--- a/sbi/src/nacl.rs
+++ b/sbi/src/nacl.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::*;
+use crate::function::*;
+
+/// Number of bytes in the `NaclShmem` scratch area.
+pub const NACL_SCRATCH_BYTES: usize = 2048;
+
+/// Layout of the shared-memory area registered with `SetShmem`.
+pub struct NaclShmem {
+    /// Scratch space. The layout of this scratch space is defined by the particular function being
+    /// invoked.
+    ///
+    /// For the `TvmCpuRun` function in the TEE-Host extension, the layout of this scratch space
+    /// matches the `TsmShmemScratch` struct.
+    pub scratch: [u64; NACL_SCRATCH_BYTES / 8],
+    _reserved: [u64; 240],
+    /// Bitmap indicating which CSRs in `csrs` the host wishes to sync.
+    ///
+    /// Currently unused in the TEE-related extensions and will not be read or written by the TSM.
+    pub dirty_bitmap: [u64; 16],
+    /// Hypervisor and virtual-supervisor CSRs. The 12-bit CSR number is transformed into a 10-bit
+    /// index by extracting bits `{csr[11:10], csr[8:0]}` since `csr[9:8]` is always 2'b10 for HS
+    /// and VS CSRs.
+    ///
+    /// These CSRs may be updated by `TvmCpuRun` in the TEE-Host extension. See the documentation
+    /// of `TvmCpuRun` for more detials.
+    pub csrs: [u64; 1024],
+}
+
+impl NaclShmem {
+    /// Returns the index in `csrs` of the HS or VS CSR at `csr_num`.
+    pub fn csr_index(csr_num: u16) -> usize {
+        (((csr_num & 0xc00) >> 2) | (csr_num & 0xff)) as usize
+    }
+}
+
+impl Default for NaclShmem {
+    fn default() -> Self {
+        Self {
+            scratch: [0; 256],
+            _reserved: [0; 240],
+            dirty_bitmap: [0; 16],
+            csrs: [0; 1024],
+        }
+    }
+}
+
+/// Functions provided by the Nested Virtualization Acceleration (NACL) extension.
+#[derive(Copy, Clone, Debug)]
+pub enum NaclFunction {
+    /// Registers the nested hypervisor <-> host hypervisor shared memory area for the calling CPU.
+    /// `shmem_pfn` is the base PFN of where the `NaclShmem` struct will be placed in the caller's
+    /// physical address space. The entire range of memory occupied by the `NaclShmem` struct must
+    /// remain accessible to the caller until the `NaclShmem` strucutre is unregistered by calling
+    /// this function with `shmem_pfn` set to -1. In particular this means that, in the presence of
+    /// the TEE-Host extension, the memory occupied by the `NaclShmem` structure is "pinned" in
+    /// the non-confidential state and cannot be converted.
+    ///
+    /// a6 = 0
+    SetShmem {
+        /// a0 = PFN of shared memory area
+        shmem_pfn: u64,
+    },
+    // There are other functions in the proposed NACL extension, but we ignore them as they aren't
+    // relevant to the TEE extensions. Note that this violates SBI policy, but since both the TEE and
+    // NACL extensions are in active development, we let it go for now.
+}
+
+impl NaclFunction {
+    /// Attempts to parse `Self` from the passed in `a0-a7`.
+    pub(crate) fn from_regs(args: &[u64]) -> Result<Self> {
+        use NaclFunction::*;
+        match args[6] {
+            0 => Ok(SetShmem { shmem_pfn: args[0] }),
+            _ => Err(Error::NotSupported),
+        }
+    }
+}
+
+impl SbiFunction for NaclFunction {
+    fn a6(&self) -> u64 {
+        use NaclFunction::*;
+        match self {
+            SetShmem { .. } => 0,
+        }
+    }
+
+    fn a0(&self) -> u64 {
+        use NaclFunction::*;
+        match self {
+            SetShmem { shmem_pfn } => *shmem_pfn,
+        }
+    }
+}

--- a/sbi/src/sbi.rs
+++ b/sbi/src/sbi.rs
@@ -21,6 +21,9 @@ pub use attestation::*;
 // The Base SBI extension
 mod base;
 pub use base::*;
+// The Nested Virtualization Acceleration (NACL) SBI extension
+mod nacl;
+pub use nacl::*;
 // The reset SBI extension
 mod reset;
 pub use reset::*;
@@ -115,6 +118,8 @@ pub enum SbiMessage {
     Reset(ResetFunction),
     /// Handles output to the console for debug.
     DebugConsole(DebugConsoleFunction),
+    /// Provides functions for accelerating nested virtualization.
+    Nacl(NaclFunction),
     /// Provides capabilities for starting confidential virtual machines.
     TeeHost(TeeHostFunction),
     /// Provides interrupt virtualization for confidential virtual machines.
@@ -138,6 +143,7 @@ impl SbiMessage {
             EXT_HART_STATE => StateFunction::from_regs(args).map(SbiMessage::HartState),
             EXT_RESET => ResetFunction::from_regs(args).map(SbiMessage::Reset),
             EXT_DBCN => DebugConsoleFunction::from_regs(args).map(SbiMessage::DebugConsole),
+            EXT_NACL => NaclFunction::from_regs(args).map(SbiMessage::Nacl),
             EXT_TEE_HOST => TeeHostFunction::from_regs(args).map(SbiMessage::TeeHost),
             EXT_TEE_INTERRUPT => {
                 TeeInterruptFunction::from_regs(args).map(SbiMessage::TeeInterrupt)
@@ -158,6 +164,7 @@ impl SbiMessage {
             HartState(_) => EXT_HART_STATE,
             Reset(_) => EXT_RESET,
             DebugConsole(_) => EXT_DBCN,
+            Nacl(_) => EXT_NACL,
             TeeHost(_) => EXT_TEE_HOST,
             TeeInterrupt(_) => EXT_TEE_INTERRUPT,
             TeeGuest(_) => EXT_TEE_GUEST,
@@ -177,6 +184,7 @@ impl SbiMessage {
             HartState(f) => f.a6(),
             Reset(f) => f.a6(),
             DebugConsole(f) => f.a6(),
+            Nacl(f) => f.a6(),
             TeeHost(f) => f.a6(),
             TeeInterrupt(f) => f.a6(),
             TeeGuest(f) => f.a6(),
@@ -194,6 +202,7 @@ impl SbiMessage {
             HartState(f) => f.a5(),
             Reset(f) => f.a5(),
             DebugConsole(f) => f.a5(),
+            Nacl(f) => f.a5(),
             TeeHost(f) => f.a5(),
             TeeInterrupt(f) => f.a5(),
             TeeGuest(f) => f.a5(),
@@ -211,6 +220,7 @@ impl SbiMessage {
             HartState(f) => f.a4(),
             Reset(f) => f.a4(),
             DebugConsole(f) => f.a4(),
+            Nacl(f) => f.a4(),
             TeeHost(f) => f.a4(),
             TeeInterrupt(f) => f.a4(),
             TeeGuest(f) => f.a4(),
@@ -228,6 +238,7 @@ impl SbiMessage {
             HartState(f) => f.a3(),
             Reset(f) => f.a3(),
             DebugConsole(f) => f.a3(),
+            Nacl(f) => f.a3(),
             TeeHost(f) => f.a3(),
             TeeInterrupt(f) => f.a3(),
             TeeGuest(f) => f.a3(),
@@ -245,6 +256,7 @@ impl SbiMessage {
             HartState(f) => f.a2(),
             Reset(f) => f.a2(),
             DebugConsole(f) => f.a2(),
+            Nacl(f) => f.a2(),
             TeeHost(f) => f.a2(),
             TeeInterrupt(f) => f.a2(),
             TeeGuest(f) => f.a2(),
@@ -262,6 +274,7 @@ impl SbiMessage {
             HartState(f) => f.a1(),
             Reset(f) => f.a1(),
             DebugConsole(f) => f.a1(),
+            Nacl(f) => f.a1(),
             TeeHost(f) => f.a1(),
             TeeInterrupt(f) => f.a1(),
             TeeGuest(f) => f.a1(),
@@ -279,6 +292,7 @@ impl SbiMessage {
             Reset(f) => f.a0(),
             DebugConsole(f) => f.a0(),
             HartState(f) => f.a0(),
+            Nacl(f) => f.a0(),
             TeeHost(f) => f.a0(),
             TeeInterrupt(f) => f.a0(),
             TeeGuest(f) => f.a0(),

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -299,9 +299,9 @@ global_asm!(
     sstatus_vs_enable = const sstatus::vs::Initial.value,
 );
 
-// Wrapper for a `TsmShmemArea` struct pinned in host shared memory.
+// Wrapper for a `NaclShmem` struct pinned in host shared memory.
 struct PinnedTsmShmemArea {
-    ptr: NonNull<sbi::TsmShmemArea>,
+    ptr: NonNull<sbi::NaclShmem>,
     // Optional since we might be sharing with the hypervisor in the host VM case.
     _pin: Option<PinnedPages>,
 }
@@ -310,10 +310,10 @@ impl PinnedTsmShmemArea {
     // Creates a new `PinnedTsmShmemArea` from a set of pinned shared pages.
     fn new(pages: PinnedPages) -> Result<Self> {
         // Make sure the pin actually covers the size of the structure.
-        if pages.range().length_bytes() < size_of::<sbi::TsmShmemArea>() as u64 {
+        if pages.range().length_bytes() < size_of::<sbi::NaclShmem>() as u64 {
             return Err(Error::InsufficientSharedStatePages);
         }
-        let ptr = pages.range().base().bits() as *mut sbi::TsmShmemArea;
+        let ptr = pages.range().base().bits() as *mut sbi::NaclShmem;
         Ok(Self {
             ptr: NonNull::new(ptr).ok_or(Error::InvalidSharedStatePtr)?,
             _pin: Some(pages),


### PR DESCRIPTION
We're going to use the same shared memory interface as the proposed NACL extension, so to avoid defining the same function in the TEE-Host extension, use the NACL extension for (un)registering the shared memory area. The layout of the scratch area in the NACL shared memory structure (NaclShmem) will still be defined by the TEE-Host extension.

This removes the TsmSetShmem call, and defines just enough of the NACL extension to register shared memory. We don't care about the rest of the NACL extension currently, so leave it out for now.

Signed-off-by: Andrew Bresticker <abrestic@rivosinc.com>