### PR TITLE
Report guest TVM's VSIE to host

### DIFF
--- a/sbi/src/tee_host.rs
+++ b/sbi/src/tee_host.rs
@@ -316,7 +316,7 @@ pub enum TeeHostFunction {
     ///     instruction is a load, the TSM will read from the register in `guest_gprs` corresponding
     ///     to the `rd` register in the instruction and use it to complete the load the next time the
     ///     TVM vCPU is run.
-    ///   - VSTIMECMP is always written by the TSM upon return from `TvmCpuRun`.
+    ///   - VSTIMECMP and VSIE are always written by the TSM upon return from `TvmCpuRun`.
     ///   - A0-A7 will be written in `guest_gprs` with the ECALL arguments on ECALLs made by the
     ///     TVM vCPU.
     ///

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -784,6 +784,7 @@ impl<'vcpu, 'pages, 'host, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, '
     pub fn exit(mut self, cause: VmExitCause) {
         self.host_context
             .set_csr(CSR_VSTIMECMP, CSR.vstimecmp.get());
+        self.host_context.set_csr(CSR_VSIE, CSR.vsie.get());
 
         use VmExitCause::*;
         match cause {


### PR DESCRIPTION
The host can use the guest's VSIE.SEIE to determine if it needs to set the corresponding bit for the guest in HGEIE.