### PR TITLE
Forward debug console to host

### DIFF
--- a/src/host_vm.rs
+++ b/src/host_vm.rs
@@ -431,6 +431,9 @@ impl HostVmRunner {
                                 // Can't do anything about errors right now.
                                 let _ = self.handle_put_string(&vm, addr, len);
                             }
+                            Ok(PutChar(c)) => {
+                                print!("{}", c as u8 as char);
+                            }
                             _ => {
                                 println!("Unhandled ECALL from host");
                                 return ControlFlow::Break(());

--- a/src/host_vm.rs
+++ b/src/host_vm.rs
@@ -15,7 +15,7 @@ use riscv_regs::{
     CSR_HTINST, CSR_HTVAL, CSR_SCAUSE, CSR_STVAL,
 };
 use s_mode_utils::print::*;
-use sbi::{self, SbiMessage};
+use sbi::{self, DebugConsoleFunction, SbiMessage, StateFunction};
 
 use crate::guest_tracking::{GuestVm, Guests, Result as GuestTrackingResult};
 use crate::smp;
@@ -421,11 +421,15 @@ impl HostVmRunner {
                                 println!("Host VM requested shutdown");
                                 return ControlFlow::Break(());
                             }
-                            Ok(HartState(sbi::StateFunction::HartStart { hart_id, .. })) => {
+                            Ok(HartState(StateFunction::HartStart { hart_id, .. })) => {
                                 smp::send_ipi(CpuId::new(hart_id as usize));
                             }
-                            Ok(HartState(sbi::StateFunction::HartStop)) => {
+                            Ok(HartState(StateFunction::HartStop)) => {
                                 return ControlFlow::Continue(())
+                            }
+                            Ok(DebugConsole(DebugConsoleFunction::PutString { len, addr })) => {
+                                // Can't do anything about errors right now.
+                                let _ = self.handle_put_string(&vm, addr, len);
                             }
                             _ => {
                                 println!("Unhandled ECALL from host");
@@ -495,6 +499,48 @@ impl HostVmRunner {
         }
 
         Ok(())
+    }
+
+    fn handle_put_string<T: GuestStagePagingMode>(
+        &mut self,
+        vm: &FinalizedVm<T>,
+        addr: u64,
+        len: u64,
+    ) -> core::result::Result<u64, u64> {
+        // Pin the pages that we'll be printing from. We assume that the buffer is physically
+        // contiguous, which should be the case since that's how we set up the host VM's address
+        // space.
+        let page_addr = GuestPageAddr::with_round_down(
+            GuestPhysAddr::guest(addr, vm.page_owner_id()),
+            PageSize::Size4k,
+        );
+        let offset = addr - page_addr.bits();
+        let num_pages = PageSize::num_4k_pages(offset + len);
+        let pinned = vm
+            .vm_pages()
+            .pin_shared_pages(page_addr, num_pages)
+            .map_err(|_| 0u64)?;
+
+        // Print the bytes in chunks. We copy to a temporary buffer as the bytes could be modified
+        // concurrently by the VM on another CPU.
+        let mut copied = 0;
+        let mut hyp_addr = pinned.range().base().bits() + offset;
+        while copied != len {
+            let mut buf = [0u8; 256];
+            let to_copy = core::cmp::min(buf.len(), (len - copied) as usize);
+            for c in buf.iter_mut() {
+                // Safety: We've confirmed that the address is within a region of accessible memory
+                // and cannot be remapped as long as we hold the pin. `u8`s are always aligned and
+                // properly initialized.
+                *c = unsafe { core::ptr::read_volatile(hyp_addr as *const u8) };
+                hyp_addr += 1;
+            }
+            let s = core::str::from_utf8(&buf[..to_copy]).map_err(|_| copied)?;
+            print!("{s}");
+            copied += to_copy as u64;
+        }
+
+        Ok(len)
     }
 }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -714,9 +714,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
                 EcallAction::Break(VmExitCause::FatalEcall(msg), SbiReturn::success(0))
             }
             SbiMessage::Base(base_func) => EcallAction::Continue(self.handle_base_msg(base_func)),
-            SbiMessage::DebugConsole(debug_con_func) => {
-                self.handle_debug_console(debug_con_func, active_vcpu.active_pages())
-            }
+            SbiMessage::DebugConsole(debug_con_func) => self.handle_debug_console(debug_con_func),
             SbiMessage::HartState(hsm_func) => self.handle_hart_state_msg(hsm_func),
             SbiMessage::Nacl(nacl_func) => self.handle_nacl_msg(nacl_func, active_vcpu),
             SbiMessage::TeeHost(host_func) => self.handle_tee_host_msg(host_func, active_vcpu),
@@ -890,49 +888,13 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
         SbiReturn::success(ret)
     }
 
-    // Handles the printing of characters from VM memory.
-    // Copies the characters to a bounce buffer, parses them as UTF-8, and sends them on to the
-    // console.
-    // On success or error, returns the number of bytes written.
-    fn debug_console_print(
-        &self,
-        mut len: u64,
-        addr: u64,
-        active_pages: &ActiveVmPages<T>,
-    ) -> core::result::Result<u64, u64> {
-        let mut chunk = [0u8; 256];
-        let mut curr_addr = addr;
-        while len > 0 {
-            let count = core::cmp::min(len as usize, chunk.len());
-            active_pages
-                .copy_from_guest(
-                    &mut chunk[0..count],
-                    RawAddr::guest(curr_addr, self.page_owner_id()),
-                )
-                .map_err(|_| curr_addr - addr)?;
-            let s = core::str::from_utf8(&chunk[0..count]).map_err(|_| curr_addr - addr)?;
-            print!("{s}");
-            curr_addr += count as u64;
-            len -= count as u64;
-        }
-        Ok(len)
-    }
-
-    fn handle_debug_console(
-        &self,
-        debug_con_func: DebugConsoleFunction,
-        active_pages: &ActiveVmPages<T>,
-    ) -> EcallAction {
+    fn handle_debug_console(&self, debug_con_func: DebugConsoleFunction) -> EcallAction {
         match debug_con_func {
-            DebugConsoleFunction::PutString { len, addr } => {
-                EcallAction::Continue(match self.debug_console_print(len, addr, active_pages) {
-                    Ok(n) => SbiReturn::success(n),
-                    Err(n) => SbiReturn {
-                        error_code: sbi::SBI_ERR_INVALID_ADDRESS,
-                        return_value: n,
-                    },
-                })
-            }
+            // TODO: Let the host set the return value and forward it to the guest.
+            DebugConsoleFunction::PutString { len, addr: _ } => EcallAction::Break(
+                VmExitCause::ResumableEcall(SbiMessage::DebugConsole(debug_con_func)),
+                SbiReturn::success(len),
+            ),
         }
     }
 

--- a/test-workloads/src/bin/consts.rs
+++ b/test-workloads/src/bin/consts.rs
@@ -34,6 +34,8 @@
 /// |-------------------------| 0x1_0000_0000
 /// | Shared pages            |
 /// |-------------------------| +NUM_GUEST_SHARED_PAGES
+/// | Shared console buffer   |
+/// |-------------------------| +4kB
 /// | <empty>                 |
 /// +-------------------------+ 0x1_8000_0000
 
@@ -52,8 +54,8 @@ pub const GUEST_ZERO_PAGES_END_ADDRESS: u64 =
     GUEST_ZERO_PAGES_START_ADDRESS + NUM_GUEST_ZERO_PAGES * PAGE_SIZE_4K - 1;
 pub const GUEST_SHARED_PAGES_START_ADDRESS: u64 = 0x1_0000_0000;
 pub const NUM_GUEST_SHARED_PAGES: u64 = 1;
-pub const GUEST_SHARED_PAGES_END_ADDRESS: u64 =
-    GUEST_SHARED_PAGES_START_ADDRESS + NUM_GUEST_SHARED_PAGES * PAGE_SIZE_4K - 1;
+pub const GUEST_DBCN_ADDRESS: u64 =
+    GUEST_SHARED_PAGES_START_ADDRESS + NUM_GUEST_SHARED_PAGES * PAGE_SIZE_4K;
 pub const GUEST_RAM_END_ADDRESS: u64 = 0x1_8000_0000;
 pub const GUEST_SHARE_PING: u64 = 0xBAAD_F00D;
 pub const GUEST_SHARE_PONG: u64 = 0xF00D_BAAD;

--- a/test-workloads/src/bin/guestvm.rs
+++ b/test-workloads/src/bin/guestvm.rs
@@ -355,10 +355,15 @@ fn test_interrupts() {
     }
 }
 
+// TODO: Put console buffer in shared memory.
+static mut CONSOLE_BUFFER: [u8; 256] = [0; 256];
+
 #[no_mangle]
 #[allow(clippy::zero_ptr)]
 extern "C" fn kernel_init(_hart_id: u64, boot_args: u64) {
-    SbiConsole::set_as_console();
+    // Safety: We're giving SbiConsole exclusive ownership of CONSOLE_BUFFER and will not touch it
+    // for the remainder of this program.
+    unsafe { SbiConsole::set_as_console(&mut CONSOLE_BUFFER) };
 
     println!("*****************************************");
     println!("Hello world from Tellus guest            ");

--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -643,6 +643,9 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
                                 len,
                             );
                         }
+                        Ok(PutChar(c)) => {
+                            print!("{}", c as u8 as char);
+                        }
                         _ => {
                             println!("Unexpected ECALL from guest");
                             break;


### PR DESCRIPTION
Forward debug console ECALLs (DBCN and legacy `put_char`) to a VM's host instead of handling console output directly within Salus. For guest TVMs, this means that that buffer to be printed must reside in memory shared with the host VM.

- Patches 1&2 prepare for console forwarding by putting the DBCN buffer in shared memory.
- Patches 3&4 forward the DBCN and `put_char` calls to the host, respectively.
- Patch 5 forwards the return value from the host back to the guest for these ECALLs.

Looking for opinions on the forwarding of ECALL return values. Currently I'm just using A0/A1 from the shared memory area, which means the host will have to know which ECALLs for which it's expected to provide a return value. Other options I considered are: setting a flag (in shared memory?) that indicates to the host that it needs to provide a return value, or having a separate `sbi_return` struct in the shared memory area where the host puts the return value (with sentinel values to indicate whether or not the TSM is expecting to find something there).

Fixes #146 