### PR TITLE
VmCpu: Don't allow setting Zero GPR.

### DIFF
--- a/riscv-regs/src/regs.rs
+++ b/riscv-regs/src/regs.rs
@@ -101,6 +101,10 @@ impl GeneralPurposeRegisters {
 
     /// Sets the value of the given register.
     pub fn set_reg(&mut self, reg_index: GprIndex, val: u64) {
+        if reg_index == GprIndex::Zero {
+            return;
+        }
+
         self.0[reg_index as usize] = val;
     }
 


### PR DESCRIPTION
It's possible that Zero GPR be used as destination register for some instructions. For example the assembler pseudoinstruction to write a CSR, CSRW csr, rs1, is encoded as CSRRW x0, csr, rs1. While emulating a csr we can end up updating the x0 gpr. This gets problematic when emulating the CSRR instruction as it is encoded as CSRRS rd, csr, x0. Here we will end up setting bits in csr from x0 written from last CSRW emulation giving us undefined behavior.

Signed-off-by: Rajnesh Kanwal <rkanwal@rivosinc.com>