### PR TITLE
riscv-page-tables: move test next to code tested.

### DIFF
--- a/riscv-page-tables/src/lib.rs
+++ b/riscv-page-tables/src/lib.rs
@@ -30,6 +30,11 @@
 
 extern crate alloc;
 
+// Include std when running unit tests.
+#[cfg(test)]
+#[macro_use]
+extern crate std;
+
 mod page_table;
 /// Provides access to the fields of a riscv PTE.
 mod pte;
@@ -37,6 +42,9 @@ mod pte;
 mod sv48;
 /// Interfaces to build and manage sv48x4 page tables for VMs.
 pub mod sv48x4;
+/// Priovides stubs for test harnesses.
+#[cfg(test)]
+mod test_stubs;
 /// Provides low-level TLB management functions such as fencing.
 pub mod tlb;
 
@@ -49,169 +57,3 @@ pub use page_table::{
 pub use pte::{PteFieldBits, PteLeafPerms};
 pub use sv48::Sv48;
 pub use sv48x4::Sv48x4;
-
-#[cfg(test)]
-#[macro_use]
-extern crate std;
-
-#[cfg(test)]
-mod tests {
-    use alloc::vec::Vec;
-    use page_tracking::*;
-    use riscv_pages::*;
-    use std::{mem, slice};
-
-    use super::page_table::*;
-    use super::sv48::Sv48;
-    use super::sv48x4::Sv48x4;
-    use super::*;
-
-    struct StubState {
-        root_pages: SequentialPages<InternalClean>,
-        pte_pages: SequentialPages<InternalClean>,
-        page_tracker: PageTracker,
-        host_pages: PageList<Page<ConvertedClean>>,
-    }
-
-    fn stub_sys_memory() -> StubState {
-        const ONE_MEG: usize = 1024 * 1024;
-        const MEM_ALIGN: usize = 2 * ONE_MEG;
-        const MEM_SIZE: usize = 256 * ONE_MEG;
-        let backing_mem = vec![0u8; MEM_SIZE + MEM_ALIGN];
-        let aligned_pointer = unsafe {
-            // Not safe - just a test
-            backing_mem
-                .as_ptr()
-                .add(backing_mem.as_ptr().align_offset(MEM_ALIGN))
-        };
-        let start_pa = RawAddr::supervisor(aligned_pointer as u64);
-        let mut hw_map = unsafe {
-            // Not safe - just a test
-            HwMemMapBuilder::new(Sv48x4::TOP_LEVEL_ALIGN)
-                .add_memory_region(start_pa, MEM_SIZE.try_into().unwrap())
-                .unwrap()
-                .build()
-        };
-        let mut hyp_mem = HypPageAlloc::new(&mut hw_map);
-        let root_pages =
-            hyp_mem.take_pages_for_host_state_with_alignment(4, Sv48x4::TOP_LEVEL_ALIGN);
-        let pte_pages = hyp_mem.take_pages_for_host_state(3);
-        let (page_tracker, host_pages) = PageTracker::from(hyp_mem, Sv48x4::TOP_LEVEL_ALIGN);
-        // Leak the backing ram so it doesn't get freed
-        std::mem::forget(backing_mem);
-        StubState {
-            root_pages,
-            pte_pages,
-            page_tracker,
-            host_pages,
-        }
-    }
-
-    #[test]
-    fn ownership_root_pages() {
-        let state = stub_sys_memory();
-
-        let page_tracker = state.page_tracker;
-        let id = page_tracker.add_active_guest().unwrap();
-
-        // Should fail as root_pages owner is not set.
-        assert!(
-            GuestStagePageTable::<Sv48x4>::new(state.root_pages, id, page_tracker.clone()).is_err()
-        );
-    }
-
-    #[test]
-    fn map_and_unmap_sv48x4() {
-        let state = stub_sys_memory();
-
-        let page_tracker = state.page_tracker;
-        let mut host_pages = state.host_pages;
-        let id = PageOwnerId::host();
-        let guest_page_table: GuestStagePageTable<Sv48x4> =
-            GuestStagePageTable::new(state.root_pages, id, page_tracker.clone())
-                .expect("creating sv48x4");
-
-        let pages_to_map = [host_pages.next().unwrap(), host_pages.next().unwrap()];
-        let page_addrs: Vec<SupervisorPageAddr> = pages_to_map.iter().map(|p| p.addr()).collect();
-        let mut pte_pages = state.pte_pages.into_iter();
-        let gpa_base = PageAddr::new(RawAddr::guest(0x8000_0000, PageOwnerId::host())).unwrap();
-        let mapper = guest_page_table
-            .map_range(gpa_base, PageSize::Size4k, 2, &mut || pte_pages.next())
-            .unwrap();
-        for (page, gpa) in pages_to_map.into_iter().zip(gpa_base.iter_from()) {
-            // Write to the page so that we can test if it's retained later.
-            unsafe {
-                // Not safe - just a test
-                let slice = slice::from_raw_parts_mut(
-                    page.addr().bits() as *mut u64,
-                    page.size() as usize / mem::size_of::<u64>(),
-                );
-                slice[0] = 0xdeadbeef;
-            }
-            let mappable = page_tracker.assign_page_for_mapping(page, id).unwrap();
-            assert!(mapper.map_page(gpa, mappable).is_ok());
-        }
-        let version = TlbVersion::new();
-        let invalidated = guest_page_table
-            .invalidate_range(gpa_base, 2 * PageSize::Size4k as u64, |addr| {
-                page_tracker.is_mapped_page(addr, id, MemType::Ram)
-            })
-            .unwrap();
-        for paddr in invalidated {
-            // Safety: Not safe - just a test
-            let page: Page<Invalidated> = unsafe { Page::new(paddr) };
-            page_tracker.convert_page(page, version).unwrap();
-        }
-        let version = version.increment();
-        let converted = guest_page_table
-            .get_invalidated_pages(gpa_base, 2 * PageSize::Size4k as u64, |addr| {
-                page_tracker.is_converted_page(addr, id, MemType::Ram, version)
-            })
-            .unwrap();
-        let mut locked_pages = LockedPageList::new(page_tracker.clone());
-        for paddr in converted {
-            let page = page_tracker
-                .get_converted_page::<Page<ConvertedDirty>>(paddr, id, version)
-                .unwrap();
-            locked_pages.push(page).unwrap();
-        }
-        let dirty_page = locked_pages.next().unwrap();
-        assert_eq!(dirty_page.addr(), page_addrs[0]);
-        assert_eq!(dirty_page.get_u64(0).unwrap(), 0xdeadbeef);
-        page_tracker.unlock_page(dirty_page).unwrap();
-        let clean_page = locked_pages.next().unwrap().clean();
-        assert_eq!(clean_page.addr(), page_addrs[1]);
-        assert_eq!(clean_page.get_u64(0).unwrap(), 0);
-        page_tracker.unlock_page(clean_page).unwrap();
-    }
-
-    #[test]
-    fn map_and_unmap_sv48() {
-        let state = stub_sys_memory();
-
-        let mut host_pages = state.host_pages;
-        let hyp_page_table: FirstStagePageTable<Sv48> =
-            FirstStagePageTable::new(state.root_pages.into_iter().next().unwrap())
-                .expect("creating sv48");
-
-        let pages_to_map = [host_pages.next().unwrap(), host_pages.next().unwrap()];
-        let mut pte_pages = state.pte_pages.into_iter();
-        let gpa_base = PageAddr::new(RawAddr::supervisor_virt(0x8000_0000)).unwrap();
-        let pte_fields = PteFieldBits::leaf_with_perms(PteLeafPerms::RW);
-        let mapper = hyp_page_table
-            .map_range(gpa_base, PageSize::Size4k, 2, &mut || pte_pages.next())
-            .unwrap();
-        for (page, gpa) in pages_to_map.into_iter().zip(gpa_base.iter_from()) {
-            // Write to the page so that we can test if it's retained later.
-            unsafe {
-                // Not safe - just a test
-                let slice = slice::from_raw_parts_mut(
-                    page.addr().bits() as *mut u64,
-                    page.size() as usize / mem::size_of::<u64>(),
-                );
-                slice[0] = 0xdeadbeef;
-                assert!(mapper.map_addr(gpa, page.addr(), pte_fields).is_ok());
-            }
-        }
-    }
-}

--- a/riscv-page-tables/src/test_stubs.rs
+++ b/riscv-page-tables/src/test_stubs.rs
@@ -1,0 +1,46 @@
+use page_tracking::*;
+use riscv_pages::*;
+
+use super::page_table::*;
+use super::sv48x4::Sv48x4;
+use super::*;
+
+pub struct StubState {
+    pub root_pages: SequentialPages<InternalClean>,
+    pub pte_pages: SequentialPages<InternalClean>,
+    pub page_tracker: PageTracker,
+    pub host_pages: PageList<Page<ConvertedClean>>,
+}
+
+pub fn stub_sys_memory() -> StubState {
+    const ONE_MEG: usize = 1024 * 1024;
+    const MEM_ALIGN: usize = 2 * ONE_MEG;
+    const MEM_SIZE: usize = 256 * ONE_MEG;
+    let backing_mem = vec![0u8; MEM_SIZE + MEM_ALIGN];
+    let aligned_pointer = unsafe {
+        // Not safe - just a test
+        backing_mem
+            .as_ptr()
+            .add(backing_mem.as_ptr().align_offset(MEM_ALIGN))
+    };
+    let start_pa = RawAddr::supervisor(aligned_pointer as u64);
+    let mut hw_map = unsafe {
+        // Not safe - just a test
+        HwMemMapBuilder::new(Sv48x4::TOP_LEVEL_ALIGN)
+            .add_memory_region(start_pa, MEM_SIZE.try_into().unwrap())
+            .unwrap()
+            .build()
+    };
+    let mut hyp_mem = HypPageAlloc::new(&mut hw_map);
+    let root_pages = hyp_mem.take_pages_for_host_state_with_alignment(4, Sv48x4::TOP_LEVEL_ALIGN);
+    let pte_pages = hyp_mem.take_pages_for_host_state(3);
+    let (page_tracker, host_pages) = PageTracker::from(hyp_mem, Sv48x4::TOP_LEVEL_ALIGN);
+    // Leak the backing ram so it doesn't get freed
+    std::mem::forget(backing_mem);
+    StubState {
+        root_pages,
+        pte_pages,
+        page_tracker,
+        host_pages,
+    }
+}


### PR DESCRIPTION
Pull the shared test code to its own file so it can be used from multiple places. The shared code was the only reason the tests for the page table modules were bundled in lib.rs instead of local to where the page tables are implemented.

Signed-off-by: Dylan Reid <dgreid@chromium.org>