### PR TITLE
Salus: Map guest memory in U-mode

### DIFF
--- a/riscv-page-tables/src/lib.rs
+++ b/riscv-page-tables/src/lib.rs
@@ -51,8 +51,8 @@ pub mod tlb;
 pub use page_table::Error as PageTableError;
 pub use page_table::Result as PageTableResult;
 pub use page_table::{
-    FirstStagePageTable, FirstStagePagingMode, GuestStageMapper, GuestStagePageTable,
-    GuestStagePagingMode, PagingMode,
+    FirstStageMapper, FirstStagePageTable, FirstStagePagingMode, GuestStageMapper,
+    GuestStagePageTable, GuestStagePagingMode, PagingMode,
 };
 pub use pte::{PteFieldBits, PteLeafPerms};
 pub use sv48::Sv48;

--- a/src/umode.rs
+++ b/src/umode.rs
@@ -10,8 +10,7 @@ use core::mem::size_of;
 use core::ops::ControlFlow;
 use memoffset::offset_of;
 use riscv_elf::ElfMap;
-use riscv_regs::Exception::UserEnvCall;
-use riscv_regs::{GeneralPurposeRegisters, GprIndex, Readable, Trap, CSR};
+use riscv_regs::{Exception::UserEnvCall, GeneralPurposeRegisters, GprIndex, Readable, Trap, CSR};
 use s_mode_utils::print::*;
 use spin::Once;
 use u_mode_api::{Error as UmodeApiError, HypCall, TryIntoRegisters, UmodeRequest};
@@ -227,7 +226,7 @@ global_asm!(
     umode_sstatus = const umode_csr_offset!(sstatus),
 );
 
-/// Errors returned by U-mode runs.
+/// Errors returned by U-mode operations.
 #[derive(Debug)]
 pub enum Error {
     /// Received an unexpected trap while running Umode.
@@ -349,6 +348,7 @@ impl UmodeTask {
                     ControlFlow::Break(res) => break res,
                 },
                 _ => {
+                    println!("Unexpected U-mode Trap:");
                     println!("{}", self.arch);
                     break Err(Error::UnexpectedTrap);
                 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -13,13 +13,16 @@ use riscv_page_tables::{GuestStagePageTable, GuestStagePagingMode};
 use riscv_pages::*;
 use riscv_regs::{DecodedInstruction, Exception, GprIndex, Instruction, Interrupt, Trap};
 use s_mode_utils::print::*;
-use sbi_rs::{Error as SbiError, *};
+use sbi_rs::{salus::*, Error as SbiError, *};
 
 use crate::guest_tracking::{GuestStateGuard, GuestVm, Guests};
+use crate::hyp_map::UmodeSlotId;
+use crate::umode::UmodeTask;
 use crate::vm_cpu::{ActiveVmCpu, VmCpu, VmCpuParent, VmCpuStatus, VmCpuTrap, VmCpus, VM_CPUS_MAX};
 use crate::vm_pages::Error as VmPagesError;
 use crate::vm_pages::{
-    ActiveVmPages, AnyVmPages, InstructionFetchError, PageFaultType, VmPages, VmPagesRef,
+    ActiveVmPages, AnyVmPages, GuestUmodeMapping, InstructionFetchError, PageFaultType, VmPages,
+    VmPagesRef,
 };
 
 #[derive(Debug)]
@@ -724,7 +727,21 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
                 self.handle_attestation_msg(attestation_func, active_vcpu.active_pages())
             }
             SbiMessage::Pmu(pmu_func) => self.handle_pmu_msg(pmu_func, active_vcpu).into(),
-            SbiMessage::Vendor(_) => EcallAction::Unhandled,
+            SbiMessage::Vendor(regs) => self.handle_vendor_msg(&regs, active_vcpu).into(),
+        }
+    }
+
+    fn handle_vendor_msg(
+        &self,
+        regs: &[u64],
+        active_vcpu: &mut ActiveVmCpu<T>,
+    ) -> EcallResult<u64> {
+        let vendor_msg = SalusSbiMessage::from_regs(regs)
+            .map_err(|_| EcallError::Sbi(SbiError::NotSupported))?;
+        match vendor_msg {
+            SalusSbiMessage::SalusTest(test_function) => {
+                self.handle_salus_test(test_function, active_vcpu.active_pages())
+            }
         }
     }
 
@@ -1477,6 +1494,54 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
             .vm_pages()
             .initiate_fence()
             .map_err(EcallError::from)?;
+        Ok(0)
+    }
+
+    fn handle_salus_test(
+        &self,
+        test_func: SalusTestFunction,
+        _active_pages: &ActiveVmPages<T>,
+    ) -> EcallResult<u64> {
+        use SalusTestFunction::*;
+        match test_func {
+            MemCopy(args) => self.guest_test_memcopy(args.to, args.from, args.len),
+        }
+    }
+
+    fn map_guest_range_in_umode_slot(
+        &self,
+        slot: UmodeSlotId,
+        addr: u64,
+        len: u64,
+        writable: bool,
+    ) -> EcallResult<(u64, GuestUmodeMapping)> {
+        let base = PageSize::Size4k.round_down(addr);
+        let end = addr
+            .checked_add(len)
+            .ok_or(EcallError::Sbi(SbiError::InvalidParam))?;
+        let umode_mapping = self
+            .vm_pages()
+            .map_in_umode_slot(
+                slot,
+                self.guest_addr_from_raw(base)?,
+                PageSize::num_4k_pages(end - base),
+                writable,
+            )
+            .map_err(EcallError::from)?;
+        let vaddr = umode_mapping.vaddr().bits() + (addr - base);
+        Ok((vaddr, umode_mapping))
+    }
+
+    fn guest_test_memcopy(&self, to: u64, from: u64, len: u64) -> EcallResult<u64> {
+        let (from_vaddr, _from_mapping) =
+            self.map_guest_range_in_umode_slot(UmodeSlotId::A, from, len, false)?;
+        let (to_vaddr, _to_mapping) =
+            self.map_guest_range_in_umode_slot(UmodeSlotId::B, to, len, true)?;
+        // Both ranges are mapped for at least `len` bytes, `to_vaddr` is user-writable and
+        // `from_vaddr` user-readable.
+        let request = u_mode_api::UmodeRequest::memcopy(to_vaddr, from_vaddr, len)
+            .ok_or(EcallError::Sbi(SbiError::InvalidParam))?;
+        UmodeTask::send_req(request).map_err(|_| EcallError::Sbi(SbiError::Failed))?;
         Ok(0)
     }
 

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -419,7 +419,7 @@ impl VmCpuArchState {
 }
 
 // Sets the status on dropping depending on the state of next_status.
-// Used by ActiveVmCpu sto set the Vcpu's state on de-activation.
+// Used by ActiveVmCpu to set the Vcpu's state on de-activation.
 struct StatusSet<'vcpu> {
     vcpu: &'vcpu VmCpu,
     next_status: VmCpuStatus,

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -1695,7 +1695,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVmPages<'a, T> {
 
     /// Pins `count` physically-contiguous pages starting at `page_addr` as shared pages, returning
     /// a `PinnedPages` structure that will release the pin when dropped. Used to share memory
-    /// between a VM on the hypervisor.
+    /// between a VM and the hypervisor.
     pub fn pin_shared_pages(&self, page_addr: GuestPageAddr, count: u64) -> Result<PinnedPages> {
         if count == 0 {
             return Err(Error::EmptyPageRange);

--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -31,7 +31,7 @@ use riscv_regs::{
 use s_mode_utils::abort::abort;
 use s_mode_utils::ecall::ecall_send;
 use s_mode_utils::{print::*, sbi_console::SbiConsole};
-use sbi_rs::api::{base, nacl, pmu, reset, state, tee_host, tee_interrupt};
+use sbi_rs::api::{base, nacl, pmu, reset, salus, state, tee_host, tee_interrupt};
 use sbi_rs::{
     Error as SbiError, PmuCounterConfigFlags, PmuCounterStartFlags, PmuCounterStopFlags,
     PmuEventType, PmuFirmware, PmuHardware, SbiMessage, SbiReturn, EXT_PMU, EXT_TEE_HOST,
@@ -982,6 +982,22 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     }
     exercise_pmu_functionality();
     nacl::unregister_shmem().expect("SetShmem failed");
+
+    // Check memcpy to see if u-mode tasks in tellus are functional
+    let src_bytes = [0x55u8; 1024];
+    let mut dst_bytes = [0xaau8; 1024];
+    // Safety: using mut ref for dst_bytes and borrowing src_bytes - safe as this is the only
+    // owner of the local data.
+    unsafe {
+        salus::test_memcpy(
+            dst_bytes.as_mut_ptr(),
+            src_bytes.as_ptr(),
+            dst_bytes.len() as u64,
+        )
+        .expect("memcpy failed");
+    }
+    assert_eq!(dst_bytes, src_bytes);
+
     println!("Tellus - All OK");
     poweroff();
 }

--- a/u-mode/src/main.rs
+++ b/u-mode/src/main.rs
@@ -19,7 +19,7 @@ extern "C" fn task_main(cpuid: u64) -> ! {
         // Return result and wait for next operation.
         let req = hyp_nextop(res);
         res = match req {
-            Ok(req) => match req.op() {
+            Ok(req) => match req.op {
                 UmodeOp::Nop => Ok(()),
                 UmodeOp::Hello => {
                     println!("----------------------------");

--- a/u-mode/src/main.rs
+++ b/u-mode/src/main.rs
@@ -8,7 +8,21 @@
 extern crate libuser;
 
 use libuser::*;
-use u_mode_api::UmodeOp;
+use u_mode_api::{Error as UmodeApiError, UmodeOp, UmodeRequest};
+
+fn op_memcopy(req: &UmodeRequest) -> Result<(), UmodeApiError> {
+    let in_addr = req.in_addr.ok_or(UmodeApiError::InvalidArgument)?;
+    // Safety: we trust the hypervisor to have mapped at `req.in_addr` `req.in_len` bytes for reading.
+    let input = unsafe { &*core::ptr::slice_from_raw_parts(in_addr as *const u8, req.in_len) };
+    let out_addr = req.out_addr.ok_or(UmodeApiError::InvalidArgument)?;
+    // Safety: we trust the hypervisor to have mapped at `req.out_addr` `req.out_len` bytes valid
+    // for reading and writing.
+    let output =
+        unsafe { &mut *core::ptr::slice_from_raw_parts_mut(out_addr as *mut u8, req.out_len) };
+    let len = core::cmp::min(input.len(), output.len());
+    output[0..len].copy_from_slice(&input[0..len]);
+    Ok(())
+}
 
 #[no_mangle]
 extern "C" fn task_main(cpuid: u64) -> ! {
@@ -34,6 +48,7 @@ extern "C" fn task_main(cpuid: u64) -> ! {
                     println!("----------------------------");
                     Ok(())
                 }
+                UmodeOp::MemCopy => op_memcopy(&req),
             },
             Err(err) => Err(err),
         };


### PR DESCRIPTION
Implement a full end-to-end test of usage of u-mode from guest by using a memcopy operation to copy guest code from u-mode. Stresses all parts of the U-mode feature.

First two patches are clean up.
Third patch implement ability to unmap mapped pages in the hypervisor page table.
Fourth patch add ability to map guest pages in u-mode slot. To avoid implementing a VA allocator, but still be flexible on what to map, a special U-mode VA area is divided in equal size slots.
The rest of the PR uses these changes to implement a end-to-end memcopy (test function)

Note: sbi-rs is updated to last main to include vendor extensions.