### PR TITLE
U-mode: reset to initial state on unrecoverable error.

### DIFF
--- a/riscv-page-tables/src/pte.rs
+++ b/riscv-page-tables/src/pte.rs
@@ -164,7 +164,7 @@ impl Pte {
 }
 
 /// The status bits that define PTE state.
-#[derive(Default, Copy, Clone)]
+#[derive(Default, Copy, Clone, PartialEq)]
 pub struct PteFieldBits {
     bits: u64,
 }


### PR DESCRIPTION
The first patch allows to retrieve HypMap information at run time.

The second patch implement reset in umode. When the error is unrecoverable (Panic or UnhandledTrap), the hypervisor will:

1. restore the U-mode memory for the local CPU at initial state.
2. restore the U-mode architectural state for the local CPU at initial state.
3. run the newly reset umode until it initializes itself.

If we can't reset U-mode the hypervisor will fail an unwrap(). Because we won't be able to run U-mode again and just retrying would be just pointless.