### PR TITLE
CI: Github action to save objdump to the cache for later use

### DIFF
--- a/.github/workflows/objdump-to-cache.yml
+++ b/.github/workflows/objdump-to-cache.yml
@@ -1,0 +1,30 @@
+###
+# This action exist to put objcopy
+# into a cache for use in other actions
+###
+
+name: objdump to cache
+
+on:
+  workflow_dispatch
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Update modules
+      run: sudo apt update
+    - name: Install toolchain
+      run: sudo apt install binutils-riscv64-unknown-elf
+    - name: stash objcopy
+      run: cp /usr/bin/riscv64-unknown-elf-objcopy .
+    - name: Cache Objcopy
+      uses: actions/cache@v3
+      with:
+        key: objcopy
+        path: ./riscv64-unknown-elf-objcopy


### PR DESCRIPTION
This is needed for the next step, which runs qemu as past of the checkin tests. This prevents flakiness from failing due to network issues. 