### PR TITLE
Update SBI main.

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -724,6 +724,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
                 self.handle_attestation_msg(attestation_func, active_vcpu.active_pages())
             }
             SbiMessage::Pmu(pmu_func) => self.handle_pmu_msg(pmu_func, active_vcpu).into(),
+            SbiMessage::Vendor(_) => EcallAction::Unhandled,
         }
     }
 


### PR DESCRIPTION
SBI-rs has been updated with two PRs.

1. Vendor PR
2. nacl shared mem fix.

Originally I put the Vendor PR update in the umode mem mapping patch, but this would effectively block updating to new SBI-rs patches until that PR is merged.

Unblock this by updating it now, returning Unhandled on Vendor() in salus.