### PR TITLE
Vm: Deny TEEG ABI calls from host.

### DIFF
--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -1217,6 +1217,13 @@ impl<'vcpu, 'pages, 'host, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, '
 
         self.active_pages = Some(active_pages);
     }
+
+    pub fn is_host_vcpu(&self) -> bool {
+        match self.host_context {
+            VmCpuParent::HostVm(_) => false,
+            VmCpuParent::Tsm(_) => true,
+        }
+    }
 }
 
 impl<T: GuestStagePagingMode> VmCpuExitReporting for ActiveVmCpu<'_, '_, '_, T> {


### PR DESCRIPTION
Given TEEG ABI calls are not supported for host, return error for these calls and also report EXT_TEE_GUEST to be not supported.

As of now if host does a TEEG call it leads to unhandled ecall and then system shutdown. This change also avoid this by returning unsupported ecall error to host.

Signed-off-by: Rajnesh Kanwal <rkanwal@rivosinc.com>