### PR TITLE
tellus: Add panic! for unexpected guest state

### DIFF
--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -1009,7 +1009,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
                 }
             }
         } else {
-            println!("Guest VM terminated with unexpected cause 0x{:x}", scause,);
+            panic!("Guest VM terminated with unexpected cause 0x{:x}", scause);
         }
     }
 
@@ -1031,7 +1031,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     // to guard against the compiler's no-aliasing assumptions.
     let guest_written_value = unsafe { core::ptr::read_volatile(shared_page_base as *mut u64) };
     if guest_written_value != GUEST_SHARE_PONG {
-        println!("Tellus - unexpected value from guest shared page: 0x{guest_written_value:x}");
+        panic!("Tellus - unexpected value from guest shared page: 0x{guest_written_value:x}");
     }
     // Check that we can reclaim previously-converted pages and that they have been cleared.
     reclaim_pages(


### PR DESCRIPTION
Presently, tellus prints a message if it detects unexpected guest conditions (like termination from illegal instruction, unexpected values in shared memory, etc.). This can be misleading because it's easy to miss these messages while testing. This is a trivial change that replaces some println!() with panic!().