### PR TITLE
Introduce U-mode buffer.

### DIFF
--- a/riscv-pages/src/page.rs
+++ b/riscv-pages/src/page.rs
@@ -40,7 +40,7 @@ impl PageSize {
     }
 
     /// Checks if the given quantity is aligned to this page size.
-    pub fn is_aligned(&self, val: u64) -> bool {
+    pub const fn is_aligned(&self, val: u64) -> bool {
         (val & (*self as u64 - 1)) == 0
     }
 

--- a/src/umode.rs
+++ b/src/umode.rs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::hyp_map::UmodeBuffer;
 use crate::smp::PerCpu;
 
 use core::arch::global_asm;
+use core::cell::RefMut;
 use core::fmt;
 use core::mem::size_of;
 use core::ops::ControlFlow;
@@ -262,7 +264,12 @@ impl UmodeTask {
         Ok(())
     }
 
-    pub fn reset(&mut self) -> Result<(), Error> {
+    /// Return the U-mode buffer for this task.
+    pub fn umode_buffer_mut() -> RefMut<'static, UmodeBuffer> {
+        PerCpu::this_cpu().page_table().umode_buffer_mut()
+    }
+
+    fn reset(&mut self) -> Result<(), Error> {
         // Initialize umode CPU state to run at ELF entry.
         let mut arch = UmodeCpuArchState::default();
         // Unwrap okay: this is called after `Self::init()`.

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::hyp_map::UmodeSlotId;
 use arrayvec::ArrayVec;
 use attestation::AttestationManager;
 use core::arch::global_asm;
@@ -21,7 +20,7 @@ use riscv_regs::{
 };
 use spin::{Mutex, Once, RwLock, RwLockReadGuard};
 
-use crate::hyp_map::Error as HypMapError;
+use crate::hyp_map::{Error as HypMapError, HypMap, UmodeSlotId};
 use crate::smp::PerCpu;
 use crate::vm::{VmStateAny, VmStateFinalized, VmStateInitializing};
 use crate::vm_id::VmId;
@@ -267,7 +266,7 @@ impl GuestUmodeMapping {
 
     /// Returns the start of the mapping (i.e., the address of the mapped U-mode slot).
     pub fn vaddr(&self) -> PageAddr<SupervisorVirt> {
-        PerCpu::this_cpu().page_table().umode_slot_va(self.slot)
+        HypMap::umode_slot_va(self.slot)
     }
 }
 

--- a/u-mode-api/src/lib.rs
+++ b/u-mode-api/src/lib.rs
@@ -123,9 +123,9 @@ impl IntoRegisters for Result<(), Error> {
 pub enum UmodeOp {
     /// Do nothing.
     Nop = 1,
-    /// Say hello.
-    Hello = 2,
-    /// Copy memory from input to output.
+    /// (Test) Print data passed in input.
+    PrintString = 2,
+    /// (Test) Copy memory from input to output.
     MemCopy = 3,
 }
 
@@ -135,7 +135,7 @@ impl TryFrom<u64> for UmodeOp {
     fn try_from(reg: u64) -> Result<UmodeOp, Error> {
         match reg {
             1 => Ok(UmodeOp::Nop),
-            2 => Ok(UmodeOp::Hello),
+            2 => Ok(UmodeOp::PrintString),
             3 => Ok(UmodeOp::MemCopy),
             _ => Err(Error::RequestNotSupported),
         }
@@ -169,12 +169,12 @@ impl UmodeRequest {
         }
     }
 
-    /// Hello World.
-    pub fn hello() -> UmodeRequest {
+    /// Print String
+    pub fn print_string(addr: u64, len: u64) -> UmodeRequest {
         UmodeRequest {
-            op: UmodeOp::Hello,
-            in_addr: None,
-            in_len: 0,
+            op: UmodeOp::PrintString,
+            in_addr: Some(addr),
+            in_len: len as usize,
             out_addr: None,
             out_len: 0,
         }


### PR DESCRIPTION
U-mode buffer is the mechanism used to pass hypervisor data to
U-mode. While guest pages are mapped directly into U-mode, hypervisor
pages should not be mapped.

A U-mode buffer is a small set of contiguous physical pages where
hypervisor data shared with U-mode are copied. It is mapped read-only
in U-mode.

There is single U-mode buffer per CPU. A U-mode buffer cannot be
mapped in multiple CPUs at the same time.

This PR says goodbye to cowsay, and rather test the buffer with a message sent from hypervisor to U-mode.