### PR TITLE
Run cargo clippy and fix libuser and umode runs for it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ run_buildroot_debug: salus_debug
 
 .PHONY: lint
 lint:
-	cargo clippy -- -D warnings  -Wmissing-docs
+	cargo clippy --workspace --exclude test_workloads -- -D warnings  -Wmissing-docs
 
 .PHONY: format
 format:

--- a/libuser/src/hypcalls.rs
+++ b/libuser/src/hypcalls.rs
@@ -54,6 +54,8 @@ pub fn hyp_panic() -> ! {
     }
 }
 
+/// Complete current operation (sending a Result to the hypervisor)
+/// and request the next operation to execute.
 pub fn hyp_nextop(result: Result<(), UmodeApiError>) -> Result<UmodeRequest, UmodeApiError> {
     let mut regs = [0u64; 8];
     let hypc = HypCall::NextOp(result);

--- a/libuser/src/lib.rs
+++ b/libuser/src/lib.rs
@@ -4,6 +4,12 @@
 
 #![no_std]
 
+//! # Salus U-mode support library.
+//!
+//! This library implements basic functions used to create a `no_std`
+//! environment for salus U-mode, and helper functions to issue
+//! `ecall` to salus.
+
 mod hypcalls;
 
 pub use crate::hypcalls::*;
@@ -25,12 +31,13 @@ impl core::fmt::Write for UserWriter {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         for c in s.chars() {
             // Ignore errors for putchar.
-            let _ = hyp_putchar(c);
+            hyp_putchar(c);
         }
         Ok(())
     }
 }
 
+/// `print` macro using calls to salus.
 #[macro_export]
 macro_rules! print {
     ($($args:tt)*) => {
@@ -42,6 +49,7 @@ macro_rules! print {
     };
 }
 
+/// `println` macro using calls to salus.
 #[macro_export]
 macro_rules! println {
     ($($args:tt)*) => {

--- a/u-mode/src/main.rs
+++ b/u-mode/src/main.rs
@@ -5,6 +5,16 @@
 #![no_std]
 #![no_main]
 
+//! # Salus U-mode binary.
+//!
+//! This is Salus U-mode code. It is used to offload functionalities
+//! of the hypervisor in user mode. There's a copy of this task in
+//! each CPU.
+//!
+//! The task it's based on a request loop. This task can be reset at
+//! any time by the hypervisor, so it shouldn't hold non-recoverable
+//! state.
+
 extern crate libuser;
 
 use libuser::*;


### PR DESCRIPTION
@stillson noticed that with the bazel build libuser would fail the cargo clippy. U-mode also had some comment failures.

Fix them and also instruct make lint run checks for umode and libuser.

test_workloads is excluded as it fails.