### PR TITLE
U-mode: share data between hypervisor and u-mode.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,6 +787,7 @@ checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
 name = "umode"
 version = "0.1.0"
 dependencies = [
+ "data_model",
  "libuser",
  "u_mode_api",
 ]

--- a/libuser/src/start.S
+++ b/libuser/src/start.S
@@ -17,6 +17,8 @@ _start:
     la sp, _stack_end
 
     // a0 contains cpu id
+    // a1 contains the U-mode mapped area address
+    // a2 contains the U-mode mapped area size
     call task_main
 
     // ecall to panic

--- a/riscv-pages/src/page.rs
+++ b/riscv-pages/src/page.rs
@@ -40,7 +40,7 @@ impl PageSize {
     }
 
     /// Checks if the given quantity is aligned to this page size.
-    pub fn is_aligned(&self, val: u64) -> bool {
+    pub const fn is_aligned(&self, val: u64) -> bool {
         (val & (*self as u64 - 1)) == 0
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -495,10 +495,8 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     UmodeTask::init(umode_elf);
     // Setup U-mode task for this CPU.
     UmodeTask::setup_this_cpu().expect("Could not setup umode");
-    // Simple test: do a NOP request to the U-mode task.
-    UmodeTask::send_req(u_mode_api::UmodeRequest::nop()).unwrap();
-    UmodeTask::send_req(u_mode_api::UmodeRequest::hello()).unwrap();
-    UmodeTask::send_req(u_mode_api::UmodeRequest::nop()).unwrap();
+    // Do a NOP request to the U-mode task to check it's functional in this CPU.
+    UmodeTask::send_req(u_mode_api::UmodeRequest::nop()).expect("U-mode not executing NOP");
 
     // Now load the host VM.
     let host = HostVmLoader::new(
@@ -543,8 +541,8 @@ extern "C" fn secondary_init(_hart_id: u64) {
 
     // Setup U-mode task for this CPU.
     UmodeTask::setup_this_cpu().expect("Could not setup umode");
-    // Simple test: run U-mode until the first `ecall`.
-    UmodeTask::send_req(u_mode_api::UmodeRequest::nop()).unwrap();
+    // Do a NOP request to the U-mode task to check it's functional in this CPU.
+    UmodeTask::send_req(u_mode_api::UmodeRequest::nop()).expect("U-mode not executing NOP");
 
     HOST_VM.wait().run(me.cpu_id().raw() as u64);
     poweroff();

--- a/src/main.rs
+++ b/src/main.rs
@@ -498,6 +498,16 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     // Do a NOP request to the U-mode task to check it's functional in this CPU.
     UmodeTask::send_req(u_mode_api::UmodeRequest::nop()).expect("U-mode not executing NOP");
 
+    {
+        // Temporary test: share a string with U-mode and have U-mode print it back.
+        let msg1: [u8; 17] = "Hello from U-mode".as_bytes().try_into().unwrap();
+        UmodeTask::send_req_with_shared_data(
+            u_mode_api::UmodeRequest::print_string(msg1.len()),
+            msg1,
+        )
+        .unwrap();
+    }
+
     // Now load the host VM.
     let host = HostVmLoader::new(
         hyp_dt,

--- a/src/umode.rs
+++ b/src/umode.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::hyp_map::{UMODE_SHARED_SIZE, UMODE_SHARED_START};
 use crate::smp::PerCpu;
 
 use core::arch::global_asm;
@@ -271,6 +272,14 @@ impl UmodeTask {
         arch.umode_regs
             .gprs
             .set_reg(GprIndex::A0, PerCpu::this_cpu().cpu_id().raw() as u64);
+        // Set U-mode Shared Area address as a1.
+        arch.umode_regs
+            .gprs
+            .set_reg(GprIndex::A1, UMODE_SHARED_START);
+        // Set U-mode Shared Area size as a2.
+        arch.umode_regs
+            .gprs
+            .set_reg(GprIndex::A2, UMODE_SHARED_SIZE);
         // sstatus set to 0 (by default) is actually okay.
         self.arch = arch;
         // Run task until it initializes itself and calls HypCall::NextOp().

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::hyp_map::UmodeSlotId;
 use arrayvec::ArrayVec;
 use attestation::AttestationManager;
 use core::arch::global_asm;
@@ -21,7 +20,7 @@ use riscv_regs::{
 };
 use spin::{Mutex, Once, RwLock, RwLockReadGuard};
 
-use crate::hyp_map::Error as HypMapError;
+use crate::hyp_map::{Error as HypMapError, HypMap, UmodeSlotId};
 use crate::smp::PerCpu;
 use crate::vm::{VmStateAny, VmStateFinalized, VmStateInitializing};
 use crate::vm_id::VmId;
@@ -267,7 +266,7 @@ impl GuestUmodeMapping {
 
     /// Returns the start of the mapping (i.e., the address of the mapped U-mode slot).
     pub fn vaddr(&self) -> PageAddr<SupervisorVirt> {
-        PerCpu::this_cpu().page_table().umode_slot_va(self.slot)
+        HypMap::umode_slot_va(self.slot)
     }
 }
 

--- a/u-mode-api/src/lib.rs
+++ b/u-mode-api/src/lib.rs
@@ -122,6 +122,11 @@ impl IntoRegisters for Result<(), Error> {
 pub enum UmodeRequest {
     /// Do nothing.
     Nop,
+    /// (Test) Print string passed in shared region.
+    PrintString {
+        /// length of data in the U-mode Shared Region to be printed.
+        len: usize,
+    },
     /// (Test) Copy memory from input to output.
     MemCopy {
         /// starting address of output
@@ -140,6 +145,17 @@ impl UmodeRequest {
     /// U-mode Shared Region: not used.
     pub fn nop() -> UmodeRequest {
         UmodeRequest::Nop
+    }
+
+    /// Print String from U-mode Shared Region
+    ///
+    /// Arguments:
+    ///    len: length of data in the U-mode Shared Region to be printed.
+    ///
+    /// U-mode Shared Region:
+    ///    Contains the data to be printed at the beginning of the area.
+    pub fn print_string(len: usize) -> UmodeRequest {
+        UmodeRequest::PrintString { len }
     }
 
     /// Copy memory from input to output.
@@ -174,6 +190,7 @@ impl UmodeRequest {
 // Mappings of A0 register to U-mode operation.
 const UMOP_NOP: u64 = 0;
 const UMOP_MEMCOPY: u64 = 1;
+const UMOP_PRINTSTR: u64 = 2;
 
 impl TryIntoRegisters for UmodeRequest {
     fn try_from_registers(regs: &[u64]) -> Result<UmodeRequest, Error> {
@@ -183,6 +200,9 @@ impl TryIntoRegisters for UmodeRequest {
                 out_addr: regs[1],
                 in_addr: regs[2],
                 len: regs[3],
+            }),
+            UMOP_PRINTSTR => Ok(UmodeRequest::PrintString {
+                len: regs[1] as usize,
             }),
             _ => Err(Error::RequestNotSupported),
         }
@@ -202,6 +222,10 @@ impl TryIntoRegisters for UmodeRequest {
                 regs[1] = out_addr;
                 regs[2] = in_addr;
                 regs[3] = len;
+            }
+            UmodeRequest::PrintString { len } => {
+                regs[0] = UMOP_PRINTSTR;
+                regs[1] = len as u64;
             }
         }
     }

--- a/u-mode-api/src/lib.rs
+++ b/u-mode-api/src/lib.rs
@@ -123,8 +123,6 @@ impl IntoRegisters for Result<(), Error> {
 pub enum UmodeOp {
     /// Do nothing.
     Nop = 1,
-    /// Say hello.
-    Hello = 2,
     /// Copy memory from input to output.
     MemCopy = 3,
 }
@@ -135,7 +133,6 @@ impl TryFrom<u64> for UmodeOp {
     fn try_from(reg: u64) -> Result<UmodeOp, Error> {
         match reg {
             1 => Ok(UmodeOp::Nop),
-            2 => Ok(UmodeOp::Hello),
             3 => Ok(UmodeOp::MemCopy),
             _ => Err(Error::RequestNotSupported),
         }
@@ -162,17 +159,6 @@ impl UmodeRequest {
     pub fn nop() -> UmodeRequest {
         UmodeRequest {
             op: UmodeOp::Nop,
-            in_addr: None,
-            in_len: 0,
-            out_addr: None,
-            out_len: 0,
-        }
-    }
-
-    /// Hello World.
-    pub fn hello() -> UmodeRequest {
-        UmodeRequest {
-            op: UmodeOp::Hello,
             in_addr: None,
             in_len: 0,
             out_addr: None,

--- a/u-mode-api/src/lib.rs
+++ b/u-mode-api/src/lib.rs
@@ -16,7 +16,7 @@
 //! hypervisor for specific services or for signalling end of
 //! execution.
 //!
-//! There are two says to pass data between the two components:
+//! There are two ways to pass data between the two components:
 //! registers and memory.
 //!
 //! ## Passing Data through Registers.
@@ -117,100 +117,90 @@ impl IntoRegisters for Result<(), Error> {
 
 // UmodeRequest: calls from hypervisor to Umode requesting an operation.
 
-/// Umode operations.
-#[derive(Debug, Clone, Copy)]
-#[repr(u64)]
-pub enum UmodeOp {
-    /// Do nothing.
-    Nop = 1,
-    /// Copy memory from input to output.
-    MemCopy = 3,
-}
-
-impl TryFrom<u64> for UmodeOp {
-    type Error = Error;
-
-    fn try_from(reg: u64) -> Result<UmodeOp, Error> {
-        match reg {
-            1 => Ok(UmodeOp::Nop),
-            3 => Ok(UmodeOp::MemCopy),
-            _ => Err(Error::RequestNotSupported),
-        }
-    }
-}
-
 /// An operation requested by the hypervisor and executed by umode.
 #[derive(Debug)]
-pub struct UmodeRequest {
-    /// The operation requested.
-    pub op: UmodeOp,
-    /// Optional start of mapped area accessible as read-only.
-    pub in_addr: Option<u64>,
-    /// If in_addr is valid, length of the area acessible as read-only.
-    pub in_len: usize,
-    /// Optional start of mapped area accessible as read-write.
-    pub out_addr: Option<u64>,
-    /// If in_addr is valid, length of the area acessible as read-write.
-    pub out_len: usize,
+pub enum UmodeRequest {
+    /// Do nothing.
+    Nop,
+    /// (Test) Copy memory from input to output.
+    MemCopy {
+        /// starting address of output
+        out_addr: u64,
+        ///  starting address of input
+        in_addr: u64,
+        /// length of input and output
+        len: u64,
+    },
 }
 
 impl UmodeRequest {
     /// A Nop request: do nothing.
+    ///
+    /// Arguments: none
     pub fn nop() -> UmodeRequest {
-        UmodeRequest {
-            op: UmodeOp::Nop,
-            in_addr: None,
-            in_len: 0,
-            out_addr: None,
-            out_len: 0,
-        }
+        UmodeRequest::Nop
     }
 
     /// Copy memory from input to output.
+    ///
+    /// Arguments:
+    ///    out_addr: starting address of output
+    ///    in_addr: starting address of input
+    ///    len: length of input and output
     ///
     /// Caller must guarantee that:
     /// 1. `in_addr` must be mapped user readable for `len` bytes.
     /// 2. `out_addr` must be mapped user writable for `len` bytes.
     pub fn memcopy(out_addr: u64, in_addr: u64, len: u64) -> Option<UmodeRequest> {
-        // Check that input and output ranges do not overlap.
+        // This test call is special because the guest memory in input/output will be used directly
+        // by U-mode. Check that input and output ranges do not overlap.
         let overlap = core::cmp::max(out_addr, in_addr)
             <= core::cmp::min(out_addr + len - 1, in_addr + len - 1);
         if overlap {
             None
         } else {
-            Some(UmodeRequest {
-                op: UmodeOp::MemCopy,
-                in_addr: Some(in_addr),
-                in_len: len as usize,
-                out_addr: Some(out_addr),
-                out_len: len as usize,
+            Some(UmodeRequest::MemCopy {
+                out_addr,
+                in_addr,
+                len,
             })
         }
     }
 }
 
+// Mappings of A0 register to U-mode operation.
+const UMOP_NOP: u64 = 0;
+const UMOP_MEMCOPY: u64 = 1;
+
 impl TryIntoRegisters for UmodeRequest {
     fn try_from_registers(regs: &[u64]) -> Result<UmodeRequest, Error> {
-        let req = UmodeRequest {
-            op: UmodeOp::try_from(regs[0])?,
-            in_addr: if regs[1] == 0 { None } else { Some(regs[1]) },
-            in_len: regs[2] as usize,
-            out_addr: if regs[3] == 0 { None } else { Some(regs[3]) },
-            out_len: regs[4] as usize,
-        };
-        Ok(req)
+        match regs[0] {
+            UMOP_NOP => Ok(UmodeRequest::Nop),
+            UMOP_MEMCOPY => Ok(UmodeRequest::MemCopy {
+                out_addr: regs[1],
+                in_addr: regs[2],
+                len: regs[3],
+            }),
+            _ => Err(Error::RequestNotSupported),
+        }
     }
 
     fn to_registers(&self, regs: &mut [u64]) {
-        regs[0] = self.op as u64;
-        regs[1] = if let Some(val) = self.in_addr { val } else { 0 };
-        regs[2] = self.in_len as u64;
-        regs[3] = if let Some(val) = self.out_addr {
-            val
-        } else {
-            0
-        };
-        regs[4] = self.out_len as u64;
+        match *self {
+            UmodeRequest::Nop => {
+                regs[0] = UMOP_NOP;
+            }
+            UmodeRequest::MemCopy {
+                out_addr,
+                in_addr,
+                len,
+            } => {
+                regs[0] = UMOP_MEMCOPY;
+                regs[1] = out_addr;
+                regs[2] = in_addr;
+                regs[3] = len;
+            }
+        }
     }
 }
 

--- a/u-mode-api/src/lib.rs
+++ b/u-mode-api/src/lib.rs
@@ -137,6 +137,7 @@ impl UmodeRequest {
     /// A Nop request: do nothing.
     ///
     /// Arguments: none
+    /// U-mode Shared Region: not used.
     pub fn nop() -> UmodeRequest {
         UmodeRequest::Nop
     }
@@ -147,6 +148,8 @@ impl UmodeRequest {
     ///    out_addr: starting address of output
     ///    in_addr: starting address of input
     ///    len: length of input and output
+    ///
+    /// U-mode Shared Region: Not used.
     ///
     /// Caller must guarantee that:
     /// 1. `in_addr` must be mapped user readable for `len` bytes.

--- a/u-mode/Cargo.toml
+++ b/u-mode/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+data_model = { path = "../data-model" }
 libuser = { path = "../libuser" }
 u_mode_api = { path = "../u-mode-api" }

--- a/u-mode/src/main.rs
+++ b/u-mode/src/main.rs
@@ -45,19 +45,6 @@ extern "C" fn task_main(cpuid: u64) -> ! {
         res = match req {
             Ok(req) => match req.op {
                 UmodeOp::Nop => Ok(()),
-                UmodeOp::Hello => {
-                    println!("----------------------------");
-                    println!(" ___________________");
-                    println!("< Hello from UMODE! >");
-                    println!(" -------------------");
-                    println!("        \\   ^__^");
-                    println!("         \\  (oo)\\_______");
-                    println!("            (__)\\       )\\/\\");
-                    println!("                ||----w |");
-                    println!("                ||     ||");
-                    println!("----------------------------");
-                    Ok(())
-                }
                 UmodeOp::MemCopy => op_memcopy(&req),
             },
             Err(err) => Err(err),

--- a/u-mode/src/main.rs
+++ b/u-mode/src/main.rs
@@ -18,36 +18,51 @@
 extern crate libuser;
 
 use libuser::*;
-use u_mode_api::{Error as UmodeApiError, UmodeOp, UmodeRequest};
+use u_mode_api::{Error as UmodeApiError, UmodeRequest};
 
-fn op_memcopy(req: &UmodeRequest) -> Result<(), UmodeApiError> {
-    let in_addr = req.in_addr.ok_or(UmodeApiError::InvalidArgument)?;
-    // Safety: we trust the hypervisor to have mapped at `req.in_addr` `req.in_len` bytes for reading.
-    let input = unsafe { &*core::ptr::slice_from_raw_parts(in_addr as *const u8, req.in_len) };
-    let out_addr = req.out_addr.ok_or(UmodeApiError::InvalidArgument)?;
-    // Safety: we trust the hypervisor to have mapped at `req.out_addr` `req.out_len` bytes valid
-    // for reading and writing.
-    let output =
-        unsafe { &mut *core::ptr::slice_from_raw_parts_mut(out_addr as *mut u8, req.out_len) };
-    let len = core::cmp::min(input.len(), output.len());
-    output[0..len].copy_from_slice(&input[0..len]);
-    Ok(())
+struct UmodeTask {}
+
+impl UmodeTask {
+    // Copy memory from input to output.
+    //
+    // Arguments:
+    //    out_addr: starting address of output
+    //    in_addr: starting address of input
+    //    len: length of input and output
+    fn op_memcopy(&self, out_addr: u64, in_addr: u64, len: usize) -> Result<(), UmodeApiError> {
+        // Safety: we trust the hypervisor to have mapped at `in_addr` `len` bytes for reading.
+        let input = unsafe { &*core::ptr::slice_from_raw_parts(in_addr as *const u8, len) };
+        // Safety: we trust the hypervisor to have mapped at `out_addr` `len` bytes valid
+        // for reading and writing.
+        let output = unsafe { &mut *core::ptr::slice_from_raw_parts_mut(out_addr as *mut u8, len) };
+        output[0..len].copy_from_slice(&input[0..len]);
+        Ok(())
+    }
+
+    // Run the main loop, receiving requests from the hypervisor and executing them.
+    fn run_loop(&self) -> ! {
+        let mut res = Ok(());
+        loop {
+            // Return result and wait for next operation.
+            let req = hyp_nextop(res);
+            res = match req {
+                Ok(req) => match req {
+                    UmodeRequest::Nop => Ok(()),
+                    UmodeRequest::MemCopy {
+                        out_addr,
+                        in_addr,
+                        len,
+                    } => self.op_memcopy(out_addr, in_addr, len as usize),
+                },
+                Err(err) => Err(err),
+            };
+        }
+    }
 }
 
 #[no_mangle]
 extern "C" fn task_main(cpuid: u64) -> ! {
-    println!("umode/#{} initialized.", cpuid);
-    // Initialization done.
-    let mut res = Ok(());
-    loop {
-        // Return result and wait for next operation.
-        let req = hyp_nextop(res);
-        res = match req {
-            Ok(req) => match req.op {
-                UmodeOp::Nop => Ok(()),
-                UmodeOp::MemCopy => op_memcopy(&req),
-            },
-            Err(err) => Err(err),
-        };
-    }
+    let task = UmodeTask {};
+    println!("umode/#{}: started.", cpuid,);
+    task.run_loop();
 }


### PR DESCRIPTION
This PR is the logical continuation (and rework) of #222. What has changed is that I have worked until the certificate generation was fully working in U-mode, and made things as simple as possible in order to create a simple, but sane and future proof interface.

First five patches are a clean up:

Patch 1 & 2 remove the use of unwrap on PageAddr creation similar to what @dgreid has done for other parts of the code.
Patch 3 & 4 are cleanup over the recent U-mode patches (Goodbye cowsay).
Patch 5 is a cleanup of the API. Recently the `input` and `output` functions were removed from the API, as they were considered unsafe for salus, and this meant that the registers as passed in U-mode API calls were strictly call-dependent. The logical implication for that was that the API could be greatly simplified and made more clear. This patch implements that.

The rest of the patches introduce the Umode Shared Memory region. Equivalent to #222 U-mode buffer in mechanism, is an area of hypervisor memory that is mapped read-only on U-mode.