### PR TITLE
README: Improve accuracy of the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ The `Makefile` provides targets for running various hosts in QEMU.
 ### Prerequisites
 
 Toolchains:
-- Rust: Install [rustup](rustup.rs), then: `rustup target add riscv64gc-unknown-none-elf`
-- GCC: Install `gcc-riscv64-unknown-elf`
+- Rust: Install [rustup](https://www.rust-lang.org/tools/install), then: `rustup target add riscv64gc-unknown-none-elf`
+- GCC: Install `gcc-riscv64-unknown-elf` built from
+  [RISC-V collab](https://github.com/riscv-collab/riscv-gnu-toolchain#installation-linux)
 
 QEMU:
 - Out-of-tree patches are required; see table below.
+- Install `libslirp-dev` for QEMU to build SLIRP network stack
 - Build using QEMU [instructions](https://wiki.qemu.org/Hosts/Linux) with
   `--target-list=riscv64-softmmu`
 - Set the `QEMU=` variable to point to the compiled QEMU tree when using the


### PR DESCRIPTION
While going through the `README` steps, I came across a few road blocks that I thought would be best documented directly in there.

- Fix rustup hyperlink

- Indicate libslirp must be installed
    As a prerequisite before building QEMU, libslirp must be present
    otherwise SLIRP won't be available through the QEMU binary. It
    prevents an error from being triggered when using "-netdev user".

- Indicate how to build the cross compiler
    Provide a link to the instructions on how to build and install the
    GCC RISCV64 compiler for a Linux machine.