### PR TITLE
attestation: Port to latest rice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 [[package]]
 name = "rice"
 version = "0.1.0"
-source = "git+https://github.com/rivosinc/rice#9575afb0baa71560c648222cff8b8b0be59e5703"
+source = "git+https://github.com/rivosinc/rice#433b319d6b15bccb706ecd71150efebd1841b582"
 dependencies = [
  "arrayvec",
  "const-oid",


### PR DESCRIPTION
The latest rice crate removed its GenericArray dependency, adapt to the new prototypes.

Signed-off-by: Samuel Ortiz <sameo@rivosinc.com>