### PR TITLE
Remove warning from tellus.

### DIFF
--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -24,7 +24,7 @@ use core::arch::asm;
 use core::ops::Range;
 use device_tree::{Fdt, ImsicInfo};
 use riscv_regs::{
-    hie, hip, sie, sip, DecodedInstruction, Exception, GprIndex, Instruction, Interrupt,
+    hie, hip, sie, DecodedInstruction, Exception, GprIndex, Instruction, Interrupt,
     LocalRegisterCopy, Readable, RiscvCsrInterface, Trap, Writeable, CSR, CSR_CYCLE, CSR_HTINST,
     CSR_HTVAL,
 };


### PR DESCRIPTION
Tellus isn't checked by make lint. `sip` is not used anymore and generated a warning.

This removes it.

Signed-off-by: Gianluca Guida <gianluca@rivosinc.com>