### PR TITLE
Salus: Move certificate generation to U-mode.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,10 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 [[package]]
 name = "u_mode_api"
 version = "0.1.0"
+dependencies = [
+ "attestation",
+ "data_model",
+]
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,8 +791,15 @@ checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
 name = "umode"
 version = "0.1.0"
 dependencies = [
+ "const-oid",
  "data_model",
+ "der",
+ "ed25519",
+ "ed25519-dalek",
+ "generic-array",
  "libuser",
+ "rice",
+ "sha2 0.10.2",
  "u_mode_api",
 ]
 

--- a/attestation/src/lib.rs
+++ b/attestation/src/lib.rs
@@ -35,6 +35,9 @@ pub enum Error {
 
     /// Derived Key is too short
     DerivedKeyTooShort,
+
+    /// The DICE engined failed to retrieve the CDI ID.
+    DiceCdiId(rice::Error),
 }
 
 /// Custom attestation result.

--- a/attestation/src/lib.rs
+++ b/attestation/src/lib.rs
@@ -40,6 +40,15 @@ pub enum Error {
 /// Custom attestation result.
 pub type Result<T> = core::result::Result<T, Error>;
 
+/// Number of static measurement registers
+pub const STATIC_MSMT_REGISTERS: usize = 4;
+
+/// Number of dynamically extensible measurement registers
+pub const DYNAMIC_MSMT_REGISTERS: usize = 4;
+
+/// Total number of measurement registers
+pub const MSMT_REGISTERS: usize = STATIC_MSMT_REGISTERS + DYNAMIC_MSMT_REGISTERS;
+
 /// Our TCG PCR indexes mapping.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/attestation/src/lib.rs
+++ b/attestation/src/lib.rs
@@ -12,9 +12,6 @@ pub enum Error {
     /// The DICE engine failed to extract a CDI.
     DiceCdiExtraction(rice::Error),
 
-    /// The DICE engine Failed to generate a certificate from a CSR.
-    DiceCsrCertificate(rice::Error),
-
     /// The DICE engine failed to build a new layer.
     DiceLayerBuild(rice::Error),
 

--- a/attestation/src/manager.rs
+++ b/attestation/src/manager.rs
@@ -10,7 +10,7 @@ use ed25519_dalek::SECRET_KEY_LENGTH;
 use generic_array::GenericArray;
 use hkdf::HmacImpl;
 use rice::{
-    cdi::CdiType,
+    cdi::{CdiType, CDI_ID_LEN},
     layer::Layer,
     x509::{certificate::MAX_CERT_SIZE, extensions::dice::tcbinfo::DiceTcbInfo, request::CertReq},
 };
@@ -226,6 +226,23 @@ impl<'a, D: Digest, H: HmacImpl<D>> AttestationManager<D, H> {
             .map_err(Error::DiceRoll)?;
 
         Ok(())
+    }
+
+    /// Extract data from attestation layer for U-mode operation.
+    pub fn measurement_registers(
+        &self,
+    ) -> Result<ArrayVec<MeasurementRegisterDigest<D>, MSMT_REGISTERS>> {
+        Ok(self
+            .measurements
+            .read()
+            .iter()
+            .map(|m| m.digest.clone())
+            .collect())
+    }
+
+    /// Return the CDI ID of the attestation layer.
+    pub fn attestation_cdi_id(&self) -> Result<[u8; CDI_ID_LEN]> {
+        self.attestation_layer.cdi_id().map_err(Error::DiceCdiId)
     }
 
     /// Build a DER-formatted x.509 certificate from a CSR.

--- a/attestation/src/manager.rs
+++ b/attestation/src/manager.rs
@@ -18,11 +18,8 @@ use sbi_rs::{AttestationCapabilities, EvidenceFormat, HashAlgorithm};
 use spin::RwLock;
 
 use crate::{
-    measurement::{
-        MeasurementRegister, DYNAMIC_MSMT_REGISTERS, MSMT_REGISTERS, STATIC_MSMT_REGISTERS,
-        TVM_MSMT_REGISTERS,
-    },
-    Error, Result, TcgPcrIndex,
+    measurement::{MeasurementRegister, MeasurementRegisterDigest, TVM_MSMT_REGISTERS},
+    Error, Result, TcgPcrIndex, DYNAMIC_MSMT_REGISTERS, MSMT_REGISTERS, STATIC_MSMT_REGISTERS,
 };
 
 // TODO Get the SVN from the RoT

--- a/attestation/src/measurement.rs
+++ b/attestation/src/measurement.rs
@@ -96,6 +96,9 @@ pub const TVM_MSMT_REGISTERS: [MeasurementRegisterBuilder; MSMT_REGISTERS] = [
     msmt_dynamic_reg!(7, TcgPcrIndex::RuntimePcr3, true),
 ];
 
+/// Type of the register measured data hash.
+pub type MeasurementRegisterDigest<D> = GenericArray<u8, <D as OutputSizeUser>::OutputSize>;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MeasurementRegister<D: Digest> {
     // The DiceTcbInfo sequence index.
@@ -130,7 +133,7 @@ pub struct MeasurementRegister<D: Digest> {
     pub hash_algorithm: ObjectIdentifier,
 
     // The measured data hash.
-    pub digest: GenericArray<u8, <D as OutputSizeUser>::OutputSize>,
+    pub digest: MeasurementRegisterDigest<D>,
 }
 
 impl<D: Digest> MeasurementRegister<D> {

--- a/attestation/src/measurement.rs
+++ b/attestation/src/measurement.rs
@@ -2,20 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::MSMT_REGISTERS;
 use const_oid::ObjectIdentifier;
 use digest::{Digest, OutputSizeUser};
 use generic_array::GenericArray;
 use sbi_rs::MeasurementRegisterDescriptor;
 
 use crate::{Error, Result, TcgPcrIndex};
-
-/// Number of static measurement registers
-pub const STATIC_MSMT_REGISTERS: usize = 4;
-
-/// Number of dynamically extensible measurement registers
-pub const DYNAMIC_MSMT_REGISTERS: usize = 4;
-
-pub(crate) const MSMT_REGISTERS: usize = STATIC_MSMT_REGISTERS + DYNAMIC_MSMT_REGISTERS;
 
 pub struct MeasurementRegisterBuilder {
     // The DiceTcbInfo FWIDs list index.

--- a/lds/umode.lds
+++ b/lds/umode.lds
@@ -33,11 +33,11 @@ SECTIONS
         *(.sbss .sbss.*) *(.bss .bss.*)
     } :data
 
-    . += 4096;
+    . += 16*1024*1024;
 
     .stack ALIGN(4096) (NOLOAD) : {
     PROVIDE(_stack_start = .);
-    . += 4096;
+    . += 176*1024;
     PROVIDE(_stack_end = .);
     } :stack
 

--- a/libuser/src/hypcalls.rs
+++ b/libuser/src/hypcalls.rs
@@ -56,7 +56,7 @@ pub fn hyp_panic() -> ! {
 
 /// Complete current operation (sending a Result to the hypervisor)
 /// and request the next operation to execute.
-pub fn hyp_nextop(result: Result<(), UmodeApiError>) -> Result<UmodeRequest, UmodeApiError> {
+pub fn hyp_nextop(result: Result<u64, UmodeApiError>) -> Result<UmodeRequest, UmodeApiError> {
     let mut regs = [0u64; 8];
     let hypc = HypCall::NextOp(result);
     hypc.to_registers(&mut regs);

--- a/src/main.rs
+++ b/src/main.rs
@@ -496,17 +496,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     // Setup U-mode task for this CPU.
     UmodeTask::setup_this_cpu().expect("Could not setup umode");
     // Do a NOP request to the U-mode task to check it's functional in this CPU.
-    UmodeTask::send_req(u_mode_api::UmodeRequest::nop()).expect("U-mode not executing NOP");
-
-    {
-        // Temporary test: share a string with U-mode and have U-mode print it back.
-        let msg1: [u8; 17] = "Hello from U-mode".as_bytes().try_into().unwrap();
-        UmodeTask::send_req_with_shared_data(
-            u_mode_api::UmodeRequest::print_string(msg1.len()),
-            msg1,
-        )
-        .unwrap();
-    }
+    UmodeTask::send_req(u_mode_api::UmodeRequest::Nop).expect("U-mode not executing NOP");
 
     // Now load the host VM.
     let host = HostVmLoader::new(
@@ -552,7 +542,7 @@ extern "C" fn secondary_init(_hart_id: u64) {
     // Setup U-mode task for this CPU.
     UmodeTask::setup_this_cpu().expect("Could not setup umode");
     // Do a NOP request to the U-mode task to check it's functional in this CPU.
-    UmodeTask::send_req(u_mode_api::UmodeRequest::nop()).expect("U-mode not executing NOP");
+    UmodeTask::send_req(u_mode_api::UmodeRequest::Nop).expect("U-mode not executing NOP");
 
     HOST_VM.wait().run(me.cpu_id().raw() as u64);
     poweroff();

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -16,7 +16,7 @@ use s_mode_utils::print::*;
 use sbi_rs::{salus::*, Error as SbiError, *};
 
 use crate::guest_tracking::{GuestStateGuard, GuestVm, Guests};
-use crate::hyp_map::UmodeSlotId;
+use crate::hyp_map::{UmodeSlotId, UmodeSlotPerm};
 use crate::umode::UmodeTask;
 use crate::vm_cpu::{ActiveVmCpu, VmCpu, VmCpuParent, VmCpuStatus, VmCpuTrap, VmCpus, VM_CPUS_MAX};
 use crate::vm_pages::Error as VmPagesError;
@@ -1512,7 +1512,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
         slot: UmodeSlotId,
         addr: u64,
         len: u64,
-        writable: bool,
+        slot_perm: UmodeSlotPerm,
     ) -> EcallResult<(u64, GuestUmodeMapping)> {
         let base = PageSize::Size4k.round_down(addr);
         let end = addr
@@ -1524,7 +1524,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
                 slot,
                 self.guest_addr_from_raw(base)?,
                 PageSize::num_4k_pages(end - base),
-                writable,
+                slot_perm,
             )
             .map_err(EcallError::from)?;
         let vaddr = umode_mapping.vaddr().bits() + (addr - base);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -4,20 +4,19 @@
 
 use attestation::{AttestationManager, Error as AttestationError, TcgPcrIndex};
 use core::{mem, ops::ControlFlow, slice};
-use der::Decode;
 use drivers::{imsic::*, pmu::PmuInfo};
 use page_tracking::collections::PageBox;
 use page_tracking::{LockedPageList, PageList, PageTracker, TlbVersion};
-use rice::x509::{request::CertReq, MAX_CSR_LEN};
 use riscv_page_tables::{GuestStagePageTable, GuestStagePagingMode};
 use riscv_pages::*;
 use riscv_regs::{DecodedInstruction, Exception, GprIndex, Instruction, Interrupt, Trap};
 use s_mode_utils::print::*;
 use sbi_rs::{salus::*, Error as SbiError, *};
+use u_mode_api::Error as UmodeApiError;
 
 use crate::guest_tracking::{GuestStateGuard, GuestVm, Guests};
 use crate::hyp_map::{UmodeSlotId, UmodeSlotPerm};
-use crate::umode::UmodeTask;
+use crate::umode::{Error as UmodeError, ExecError, UmodeTask};
 use crate::vm_cpu::{ActiveVmCpu, VmCpu, VmCpuParent, VmCpuStatus, VmCpuTrap, VmCpus, VM_CPUS_MAX};
 use crate::vm_pages::Error as VmPagesError;
 use crate::vm_pages::{
@@ -186,6 +185,24 @@ impl From<AttestationError> for EcallError {
             // TODO: Map individual error types.
             // InvalidParam may not be the right value for each error.
             _ => EcallError::Sbi(SbiError::InvalidParam),
+        }
+    }
+}
+
+impl From<UmodeApiError> for EcallError {
+    fn from(error: UmodeApiError) -> EcallError {
+        match error {
+            UmodeApiError::InvalidArgument => EcallError::Sbi(SbiError::InvalidParam),
+            _ => EcallError::Sbi(SbiError::Failed),
+        }
+    }
+}
+
+impl From<UmodeError> for EcallError {
+    fn from(error: UmodeError) -> EcallError {
+        match error {
+            UmodeError::Exec(ExecError::Umode(api_error)) => api_error.into(),
+            _ => EcallError::Sbi(SbiError::Failed),
         }
     }
 }
@@ -1559,7 +1576,6 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
                     evidence_format,
                     cert_addr_out,
                     cert_size as usize,
-                    active_pages,
                 )
                 .into(),
 
@@ -1621,55 +1637,47 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
         Ok(0)
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn guest_get_evidence(
         &self,
-        cert_request_addr: u64,
-        cert_request_size: usize,
+        csr_guest_addr: u64,
+        csr_len: usize,
         _request_data_addr: u64,
         _evidence_format: u64,
-        cert_addr_out: u64,
-        cert_size: usize,
-        active_pages: &ActiveVmPages<T>,
+        certout_guest_addr: u64,
+        certout_len: usize,
     ) -> EcallResult<u64> {
-        if cert_request_size > MAX_CSR_LEN {
-            return Err(EcallError::Sbi(SbiError::InsufficientBufferCapacity));
+        // Map CSR read-only.
+        let (csr_addr, _csr_mapping) = self.map_guest_range_in_umode_slot(
+            UmodeSlotId::A,
+            csr_guest_addr,
+            csr_len as u64,
+            UmodeSlotPerm::Readonly,
+        )?;
+        // Map Output Certificate writable.
+        let (certout_addr, _certout_mapping) = self.map_guest_range_in_umode_slot(
+            UmodeSlotId::B,
+            certout_guest_addr,
+            certout_len as u64,
+            UmodeSlotPerm::Writable,
+        )?;
+        // Gather measurement registers from the attestation manager and transform it in a array.
+        let msmt_genarray = self.attestation_mgr().measurement_registers()?;
+        let zero = [0u8; u_mode_api::cert::SHA384_LEN];
+        let mut msmt_regs = [zero; attestation::MSMT_REGISTERS];
+        for (i, r) in msmt_genarray.iter().enumerate() {
+            msmt_regs[i].copy_from_slice(r.as_slice());
         }
-
-        let mut csr_bytes = [0u8; MAX_CSR_LEN];
-        let csr_gpa = RawAddr::guest(cert_request_addr, self.page_owner_id());
-        active_pages
-            .copy_from_guest(&mut csr_bytes.as_mut_slice()[..cert_request_size], csr_gpa)
-            .map_err(EcallError::from)?;
-
-        let csr = CertReq::from_der(&csr_bytes[..cert_request_size])
-            .map_err(|_| EcallError::Sbi(SbiError::InvalidParam))?;
-        println!(
-            "CSR version {:?} Signature algorithm {:?}",
-            csr.info.version, csr.algorithm.oid
-        );
-
-        csr.verify()
-            .map_err(|_| EcallError::Sbi(SbiError::InvalidParam))?;
-
-        let cert_gpa = RawAddr::guest(cert_addr_out, self.page_owner_id());
-        let cert_der_array = self
-            .attestation_mgr()
-            .csr_certificate(&csr)
-            .map_err(|_| EcallError::Sbi(SbiError::InvalidParam))?;
-        let cert_der = cert_der_array.as_slice();
-        let cert_der_len = cert_der.len();
-
-        // Check that the guest gave us enough space
-        if cert_size < cert_der_len {
-            return Err(EcallError::Sbi(SbiError::InvalidParam));
-        }
-
-        active_pages
-            .copy_to_guest(cert_gpa, cert_der)
-            .map_err(EcallError::from)?;
-
-        Ok(cert_der_len as u64)
+        // Get the CDI ID for the attestation layer.
+        let cdi_id = self.attestation_mgr().attestation_cdi_id()?;
+        let shared_data = u_mode_api::cert::GetEvidenceShared { msmt_regs, cdi_id };
+        let request = u_mode_api::UmodeRequest::GetEvidence {
+            csr_addr,
+            csr_len,
+            certout_addr,
+            certout_len,
+        };
+        // Send request to U-mode.
+        Ok(UmodeTask::send_req_with_shared_data(request, shared_data)?)
     }
 
     fn guest_extend_measurement(

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -20,7 +20,7 @@ use riscv_regs::{
 };
 use spin::{Mutex, Once, RwLock, RwLockReadGuard};
 
-use crate::hyp_map::{Error as HypMapError, HypMap, UmodeSlotId};
+use crate::hyp_map::{Error as HypMapError, HypMap, UmodeSlotId, UmodeSlotPerm};
 use crate::smp::PerCpu;
 use crate::vm::{VmStateAny, VmStateFinalized, VmStateInitializing};
 use crate::vm_id::VmId;
@@ -1811,13 +1811,13 @@ impl<'a, T: GuestStagePagingMode> FinalizedVmPages<'a, T> {
         slot: UmodeSlotId,
         page_addr: GuestPageAddr,
         count: u64,
-        writable: bool,
+        slot_perm: UmodeSlotPerm,
     ) -> Result<GuestUmodeMapping> {
         let pages = self.get_shareable_pages(page_addr, count)?;
         // TODO: Check that guest request for mapping it writable is consistent with the guest mappings.
         let mapper = PerCpu::this_cpu()
             .page_table()
-            .umode_slot_mapper(slot, count, writable)
+            .umode_slot_mapper(slot, count, slot_perm)
             .map_err(Error::HypMap)?;
         let to_page_addr = mapper.vaddr();
 

--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -30,7 +30,7 @@ use riscv_regs::{
 };
 use s_mode_utils::abort::abort;
 use s_mode_utils::{print::*, sbi_console::SbiConsole};
-use sbi_rs::api::{base, nacl, pmu, reset, salus, state, tee_host, tee_interrupt};
+use sbi_rs::api::{base, nacl, pmu, reset, state, tee_host, tee_interrupt};
 use sbi_rs::{
     ecall_send, Error as SbiError, PmuCounterConfigFlags, PmuCounterStartFlags,
     PmuCounterStopFlags, PmuEventType, PmuFirmware, PmuHardware, SbiMessage, SbiReturn, EXT_PMU,
@@ -1046,21 +1046,6 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     }
     exercise_pmu_functionality();
     nacl::unregister_shmem().expect("SetShmem failed");
-
-    // Check memcpy to see if u-mode tasks in tellus are functional
-    let src_bytes = [0x55u8; 1024];
-    let mut dst_bytes = [0xaau8; 1024];
-    // Safety: using mut ref for dst_bytes and borrowing src_bytes - safe as this is the only
-    // owner of the local data.
-    unsafe {
-        salus::test_memcpy(
-            dst_bytes.as_mut_ptr(),
-            src_bytes.as_ptr(),
-            dst_bytes.len() as u64,
-        )
-        .expect("memcpy failed");
-    }
-    assert_eq!(dst_bytes, src_bytes);
 
     println!("Tellus - All OK");
     poweroff();

--- a/u-mode-api/Cargo.toml
+++ b/u-mode-api/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+attestation = { path = "../attestation" }
+data_model = { path = "../data-model" }

--- a/u-mode-api/src/cert.rs
+++ b/u-mode-api/src/cert.rs
@@ -1,0 +1,32 @@
+// Copyright (c) 2023 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use attestation::MSMT_REGISTERS;
+use data_model::DataInit;
+
+/// CDI ID length.
+pub const CDI_ID_LEN: usize = 20;
+/// Length of a SHA384 hash.
+pub const SHA384_LEN: usize = 48;
+
+/// Compound Device Identifier (CDI) ID type.
+pub type CdiId = [u8; CDI_ID_LEN];
+/// Measurement registers for the Sha384 case.
+pub type MeasurementRegisterSha384 = [u8; SHA384_LEN];
+
+/// Structure passed with `GetEvidence` in the Umode Shared Region.
+/// Represents the status of the DICE layer needed to generate a
+/// certificate.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct GetEvidenceShared {
+    /// Measurement registers in SHA-384. In `fwid` order.
+    pub msmt_regs: [MeasurementRegisterSha384; MSMT_REGISTERS],
+    /// CDI Id.
+    pub cdi_id: CdiId,
+}
+
+// Safety: `GetEvidenceShared` is a POD struct without implicit padding and therefore can be
+// initialized from a byte array.
+unsafe impl DataInit for GetEvidenceShared {}

--- a/u-mode-api/src/lib.rs
+++ b/u-mode-api/src/lib.rs
@@ -90,23 +90,24 @@ pub trait TryIntoRegisters: Sized {
     fn to_registers(&self, regs: &mut [u64]);
 }
 
-// Result<(), Error> is passed through registers. Implement trait.
+// Result<u64, Error> is passed through registers. Implement trait.
 
 // Error code for success.
 const HYPC_SUCCESS: u64 = 0;
 
-impl IntoRegisters for Result<(), Error> {
-    fn from_registers(regs: &[u64]) -> Result<(), Error> {
+impl IntoRegisters for Result<u64, Error> {
+    fn from_registers(regs: &[u64]) -> Result<u64, Error> {
         match regs[0] {
-            HYPC_SUCCESS => Ok(()),
+            HYPC_SUCCESS => Ok(regs[1]),
             e => Err(e.into()),
         }
     }
 
     fn to_registers(&self, regs: &mut [u64]) {
         match self {
-            Ok(_) => {
+            Ok(val) => {
                 regs[0] = HYPC_SUCCESS;
+                regs[1] = *val;
             }
             Err(e) => {
                 regs[0] = *e as u64;
@@ -153,7 +154,7 @@ pub enum HypCall {
     /// Print a character for debug.
     PutChar(u8),
     /// Return result of previous request and wait for next operation.
-    NextOp(Result<(), Error>),
+    NextOp(Result<u64, Error>),
 }
 
 const HYPC_PANIC: u64 = 0;

--- a/u-mode/Cargo.toml
+++ b/u-mode/Cargo.toml
@@ -7,5 +7,12 @@ edition = "2021"
 
 [dependencies]
 data_model = { path = "../data-model" }
+der = { version = "0.6.0", features = ["derive", "flagset", "oid"] }
 libuser = { path = "../libuser" }
 u_mode_api = { path = "../u-mode-api" }
+rice = { git = "https://github.com/rivosinc/rice" }
+const-oid = { version = "0.9.0", features = ["db"] }
+sha2 = {version = "0.10", default-features = false }
+generic-array = "0.14.5"
+ed25519 = { version = "1.5.2", default-features = false, features = ["pkcs8"] }
+ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend"] }

--- a/u-mode/src/cert.rs
+++ b/u-mode/src/cert.rs
@@ -1,0 +1,104 @@
+// Copyright (c) 2023 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+extern crate libuser;
+use libuser::*;
+
+use der::Decode;
+use ed25519::Signature;
+use ed25519_dalek::Signer;
+use generic_array::GenericArray;
+use rice::x509::certificate::{Certificate, MAX_CERT_SIZE};
+use rice::x509::extensions::dice::tcbinfo::DiceTcbInfo;
+use rice::x509::request::CertReq;
+use rice::x509::MAX_CSR_LEN;
+use u_mode_api::cert::*;
+
+#[derive(Debug)]
+pub enum Error {
+    /// Input CSR buffer size too small.
+    CsrBufferTooSmall(usize, usize),
+    /// Cannot parse CSR.
+    CsrParseFailed(der::Error),
+    /// Cannot verify CSR.
+    CsrVerificationFailed(rice::Error),
+    /// Cannot add FWID extension.
+    FwidAddFailed(rice::Error),
+    /// Could not create TcbInfo Extensions.
+    TcbInfoFailed(rice::Error),
+    /// Cannot create Certificate.
+    CertificateCreationFailed(rice::Error),
+    /// Output Certificate buffer too small.
+    CertificateBufferTooSmall(usize, usize),
+}
+
+struct UmodeSigner {}
+
+impl Signer<Signature> for UmodeSigner {
+    fn try_sign(&self, _: &[u8]) -> Result<Signature, ed25519::Error> {
+        // TODO: Implement Signing of certificate.
+        Signature::from_bytes(&[0; 64])
+    }
+}
+
+pub fn get_certificate_sha384(
+    csr_input: &[u8],
+    evidence: GetEvidenceShared,
+    cert_output: &mut [u8],
+) -> Result<u64, Error> {
+    // Copy CSR from input.
+    let csr_len = csr_input.len();
+    if csr_len > MAX_CSR_LEN {
+        return Err(Error::CsrBufferTooSmall(csr_len, MAX_CSR_LEN));
+    }
+    let mut csr_bytes = [0u8; MAX_CSR_LEN];
+    csr_bytes[0..csr_len].copy_from_slice(csr_input);
+
+    let mut tcb_info_bytes = [0u8; 4096];
+    let mut tcb_info = DiceTcbInfo::new();
+    let hash_algorithm = const_oid::db::rfc5912::ID_SHA_384;
+
+    let csr = CertReq::from_der(&csr_bytes[0..csr_len]).map_err(Error::CsrParseFailed)?;
+
+    println!(
+        "U-mode CSR version {:?} Signature algorithm {:?}",
+        csr.info.version, csr.algorithm.oid
+    );
+
+    csr.verify().map_err(Error::CsrVerificationFailed)?;
+
+    for m in evidence.msmt_regs.iter() {
+        tcb_info
+            .add_fwid::<sha2::Sha384>(hash_algorithm, GenericArray::from_slice(m.as_slice()))
+            .map_err(Error::FwidAddFailed)?;
+    }
+
+    let tcb_info_extn = tcb_info
+        .to_extension(&mut tcb_info_bytes)
+        .map_err(Error::TcbInfoFailed)?;
+    let extensions: [&[u8]; 1] = [tcb_info_extn];
+
+    let mut cert_der_bytes = [0u8; MAX_CERT_SIZE];
+    let cert_der = Certificate::from_raw_parts(
+        evidence.cdi_id,
+        &evidence.cdi_id,
+        csr.info.subject.clone(),
+        csr.info.public_key,
+        Some(&extensions),
+        &UmodeSigner {},
+        &mut cert_der_bytes,
+    )
+    .map_err(Error::CertificateCreationFailed)?;
+
+    let cert_der_len = cert_der.len();
+    if cert_output.len() < cert_der_len {
+        return Err(Error::CertificateBufferTooSmall(
+            cert_output.len(),
+            cert_der_len,
+        ));
+    }
+    // Copy cert to output.
+    cert_output[0..cert_der_len].copy_from_slice(cert_der);
+    Ok(cert_der_len as u64)
+}

--- a/u-mode/src/main.rs
+++ b/u-mode/src/main.rs
@@ -28,13 +28,13 @@ struct UmodeTask {
 impl UmodeTask {
     // Run the main loop, receiving requests from the hypervisor and executing them.
     fn run_loop(&self) -> ! {
-        let mut res = Ok(());
+        let mut res = Ok(0);
         loop {
             // Return result and wait for next operation.
             let req = hyp_nextop(res);
             res = match req {
                 Ok(req) => match req {
-                    UmodeRequest::Nop => Ok(()),
+                    UmodeRequest::Nop => Ok(0),
                 },
                 Err(err) => Err(err),
             };

--- a/u-mode/src/main.rs
+++ b/u-mode/src/main.rs
@@ -21,11 +21,73 @@ use data_model::{VolatileMemory, VolatileSlice};
 use libuser::*;
 use u_mode_api::{Error as UmodeApiError, UmodeRequest};
 
+mod cert;
+
+// Dummy global allocator - panic if anything tries to do an allocation.
+struct GeneralGlobalAlloc;
+
+unsafe impl core::alloc::GlobalAlloc for GeneralGlobalAlloc {
+    unsafe fn alloc(&self, _layout: core::alloc::Layout) -> *mut u8 {
+        panic!("alloc called!");
+    }
+
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: core::alloc::Layout) {
+        panic!("dealloc called!");
+    }
+}
+
+// Global allocator linking (not usage) required by rice dependencies.
+#[global_allocator]
+static GENERAL_ALLOCATOR: GeneralGlobalAlloc = GeneralGlobalAlloc;
+
 struct UmodeTask {
     vslice: VolatileSlice<'static>,
 }
 
 impl UmodeTask {
+    // Get an attestation evidence.
+    // This function returns a serialized, DER formatted X.509 certificate.
+    // The attestation evidence is included as a certificate extension.
+    //
+    // Arguments:
+    //   csr_addr: starting address of the input Certificate Signing Request.
+    //   csr_len: size of the input Certificate Signing Request.
+    //   certout_addr: starting address of the output Certificate.
+    //   certout_len: size for the output Certificate.
+    //
+    // U-mode Shared Region: contains an instance of `GetEvidenceShared`.
+    fn op_get_evidence(
+        &self,
+        csr_addr: u64,
+        csr_len: usize,
+        certout_addr: u64,
+        certout_len: usize,
+    ) -> Result<u64, UmodeApiError> {
+        // Safety: we trust the hypervisor to have mapped at `csr_addr` `csr_len` bytes for reading.
+        let csr = unsafe { &*core::ptr::slice_from_raw_parts(csr_addr as *const u8, csr_len) };
+        // Safety: we trust the hypervisor to have mapped at `certout_addr` `certout_len` bytes valid
+        // for reading and writing.
+        let certout = unsafe {
+            &mut *core::ptr::slice_from_raw_parts_mut(certout_addr as *mut u8, certout_len)
+        };
+        let shared_data = self
+            .vslice
+            .get_ref(0)
+            .map_err(|_| UmodeApiError::Failed)?
+            .load();
+        cert::get_certificate_sha384(csr, shared_data, certout).map_err(|e| {
+            println!("get_certificate failed: {:?}", e);
+            use cert::Error::*;
+            match e {
+                CsrBufferTooSmall(_, _)
+                | CsrParseFailed(_)
+                | CsrVerificationFailed(_)
+                | CertificateBufferTooSmall(_, _) => UmodeApiError::InvalidArgument,
+                _ => UmodeApiError::Failed,
+            }
+        })
+    }
+
     // Run the main loop, receiving requests from the hypervisor and executing them.
     fn run_loop(&self) -> ! {
         let mut res = Ok(0);
@@ -35,6 +97,12 @@ impl UmodeTask {
             res = match req {
                 Ok(req) => match req {
                     UmodeRequest::Nop => Ok(0),
+                    UmodeRequest::GetEvidence {
+                        csr_addr,
+                        csr_len,
+                        certout_addr,
+                        certout_len,
+                    } => self.op_get_evidence(csr_addr, csr_len, certout_addr, certout_len),
                 },
                 Err(err) => Err(err),
             };


### PR DESCRIPTION
This PR moves the certificate generation (through the get_evidence call) in U-mode.

Some preparation:

Patch 1: as the U-mode certificate call will use both Umode guest mappings and Umode shared region, the test calls for these functions (PrintString and MemCopy) can be removed. I have left some stub implementation of the vendor extensions of salus for future use, but can be removed completely, at the cost of reimplementing it in case we have another temporary need in the future.

Patch2 allow Umode request to return a `Result<u64>` instead of a `Result<()>`, to allow returning directly values that can be mapped in `SbiReturn`.

Patch3 exposes the number of management registers to the API.


The following patches implement the call in Umode-API, U-mode and the hypervisor itself.

Last patch cleans the certificate generation code in hypervisor.

This patch is possibly still a RFC at this stage.