### PR TITLE
Basic test system to work with docker image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,7 @@ dependencies = [
  "sha2 0.10.2",
  "spin",
  "static_assertions",
+ "test_system",
  "u_mode_api",
 ]
 
@@ -724,6 +725,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_system"
+version = "0.1.0"
+
+[[package]]
 name = "test_workloads"
 version = "0.1.0"
 dependencies = [
@@ -738,6 +743,7 @@ dependencies = [
  "s_mode_utils",
  "sbi_rs",
  "spin",
+ "test_system",
 ]
 
 [[package]]
@@ -799,6 +805,7 @@ dependencies = [
  "libuser",
  "rice",
  "sha2 0.10.2",
+ "test_system",
  "u_mode_api",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ sbi_rs = { path = "./sbi-rs" }
 spin = { version = "*", default-features = false }
 sha2 = {version = "0.10", default-features = false }
 riscv_elf = { path = "./riscv-elf" }
+test_system = { path = "./test-system" }
 
 [workspace]
 

--- a/test-system/Cargo.toml
+++ b/test-system/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test_system"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/test-system/src/lib.rs
+++ b/test-system/src/lib.rs
@@ -1,0 +1,142 @@
+// Copyright (c) 2021 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+
+//! Crate for basic test system that works with the docker
+//! image ```rivos/rivos-qemu-docker```
+//!
+//! First, declare the test using test_declare,
+//! `test_declare!("test_name")`
+//! `test_declare!("test_name", hartid)`
+//!
+//! For a pass or fail use test_pass or test fail
+//! `test_pass!("test_name")`
+//! `test_pass!("test_name", hartid)`
+//! `test_fail!("test_name")`
+//! `test_fail!("test_name", hartid)`
+//!
+//! Test assert will check the boolean expression and
+//! then call test_pass or test_fail
+//! `test_assert!(boolean_expr, "test_name")`
+//! `test_assert!(boolean_expr, "test_name", hartid)`
+
+/// Simple enum for the result of a test
+pub enum TestResult {
+    /// The test returns as expected
+    Pass,
+    /// The test returns incorrectly
+    Fail,
+}
+
+/// Declare and pass a test, for tests that
+/// pass by reach a point in the code
+#[macro_export]
+macro_rules! test_declare_pass {
+    ($n:expr) => {
+        test_declare!($n);
+        test_pass!($n)
+    };
+    ($n:expr,$h:expr) => {
+        test_declare!($n, $h);
+        test_pass!($n, $h)
+    };
+}
+
+/// Declare and fail a test, for tests that
+/// fail by reach a point in the code
+#[macro_export]
+macro_rules! test_declare_fail {
+    ($n:expr) => {
+        test_declare!($n);
+        test_fail!($n)
+    };
+    ($n:expr,$h:expr) => {
+        test_declare!($n);
+        test_fail!($n)
+    };
+}
+
+/// Declare a test
+#[macro_export]
+macro_rules! test_declare {
+    ($n:expr) => {
+        println!("TEST: {}", $n)
+    };
+    ($n:expr,$h:expr) => {
+        println!("TEST: {} {}", $n, $h)
+    };
+}
+
+/// Mark a test as failing
+#[macro_export]
+macro_rules! test_pass {
+    ($n:expr) => {
+        println!("PASS: {}", $n)
+    };
+    ($n:expr, $h:expr) => {
+        println!("PASS: {} {}", $n, $h)
+    };
+}
+
+/// Mark a test as passing
+#[macro_export]
+macro_rules! test_fail {
+    ($n:expr) => {
+        println!("FAIL: {}", $n)
+    };
+    ($n:expr, $h:expr) => {
+        println!("FAIL: {} {}", $n, $h)
+    };
+}
+
+/// Mark a test as passing or failing depending on the value
+/// a boolean expression.
+#[macro_export]
+macro_rules! test_assert {
+    ($e:expr, $n:expr) => {
+        test_declare!($n);
+        if $e {
+            test_pass!($n)
+        } else {
+            test_fail!($n)
+        }
+    };
+    ($e:expr, $n:expr, $h:expr) => {
+        test_declare!($n, $h);
+        if $e {
+            test_pass!($n, $h)
+        } else {
+            test_fail!($n, $h)
+        }
+    };
+}
+
+/// Run a test in a block of code.
+/// The block returns TestResult::Pass
+/// or TestResult::Fail
+///
+///```
+/// use test_system::*;
+///
+/// test_runtest!("runtest test", {
+///     let a = 7;
+///     if a - 6 == 1 {
+///         TestResult::Pass
+///     } else {
+///         TestResult::Fail
+///     }
+/// });
+/// ```
+#[macro_export]
+macro_rules! test_runtest {
+    ($n:expr, $b:block) => {
+        test_declare!($n);
+        let res: TestResult = $b;
+        match res {
+            TestResult::Pass => test_pass!($n),
+            TestResult::Fail => test_fail!($n),
+        }
+    };
+}

--- a/test-workloads/Cargo.toml
+++ b/test-workloads/Cargo.toml
@@ -20,6 +20,7 @@ s_mode_utils = { path = "../s-mode-utils" }
 sbi_rs = { path = "../sbi-rs" }
 spin = { version = "*", default-features = false }
 riscv_regs = { path = "../riscv-regs" }
+test_system = { path = "../test-system" }
 
 [dependencies.fdt-rs]
 git = "https://github.com/rivosinc/fdt-rs"

--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -35,6 +35,7 @@ use sbi_rs::{
     EXT_TEE_HOST, EXT_TEE_INTERRUPT,
 };
 use spin::{Mutex, Once};
+use test_system::*;
 use test_workloads::consts::*;
 
 // The secondary CPU entry point, defined in start.S. Calls secondary_init below.
@@ -462,6 +463,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     // for the remainder of this program.
     unsafe { SbiConsole::set_as_console(&mut CONSOLE_BUFFER) };
     println!("Tellus: Booting the test VM");
+    test_declare_pass!("booting tellus", hart_id);
 
     // Safe because we trust the host to boot with a valid fdt_addr pass in register a1.
     let fdt = match unsafe { Fdt::new_from_raw_pointer(fdt_addr as *const u8) } {

--- a/u-mode/Cargo.toml
+++ b/u-mode/Cargo.toml
@@ -20,3 +20,4 @@ sha2 = {version = "0.10", default-features = false }
 generic-array = "0.14.5"
 ed25519 = { version = "1.5.2", default-features = false, features = ["pkcs8"] }
 ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend"] }
+test_system = { path = "../test-system"}

--- a/u-mode/src/main.rs
+++ b/u-mode/src/main.rs
@@ -19,6 +19,7 @@ extern crate libuser;
 
 use data_model::{VolatileMemory, VolatileSlice};
 use libuser::*;
+use test_system::*;
 use u_mode_api::{Error as UmodeApiError, UmodeRequest};
 
 mod cert;
@@ -121,5 +122,6 @@ extern "C" fn task_main(cpuid: u64, shared_addr: u64, shared_size: u64) -> ! {
         "umode/#{}: U-mode Shared Region: {:016x} - {} bytes",
         cpuid, shared_addr, shared_size
     );
+    test_declare_pass!("umode start", cpuid);
     task.run_loop()
 }


### PR DESCRIPTION

This creates a basic system for working with the docker image rivos/rivos-qemu-docker which is what we use for acceptance testing with github actions.

Macros added to declare test pass and fail which will be detected when run under the overwatch.py program on the docker image.

The idea is that this can be easily extended to other parts of the system which can println!