### PR TITLE
Salus: allow call-specific hypercalls in U-mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -496,7 +496,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     // Setup U-mode task for this CPU.
     UmodeTask::setup_this_cpu().expect("Could not setup umode");
     // Do a NOP request to the U-mode task to check it's functional in this CPU.
-    UmodeTask::send_req(u_mode_api::UmodeRequest::Nop).expect("U-mode not executing NOP");
+    UmodeTask::execute_nop().expect("U-mode not executing NOP");
 
     // Now load the host VM.
     let host = HostVmLoader::new(
@@ -542,7 +542,7 @@ extern "C" fn secondary_init(_hart_id: u64) {
     // Setup U-mode task for this CPU.
     UmodeTask::setup_this_cpu().expect("Could not setup umode");
     // Do a NOP request to the U-mode task to check it's functional in this CPU.
-    UmodeTask::send_req(u_mode_api::UmodeRequest::Nop).expect("U-mode not executing NOP");
+    UmodeTask::execute_nop().expect("U-mode not executing NOP");
 
     HOST_VM.wait().run(me.cpu_id().raw() as u64);
     poweroff();

--- a/src/umode.rs
+++ b/src/umode.rs
@@ -300,7 +300,18 @@ impl UmodeTask {
         Ok(())
     }
 
-    fn execute_request<T: DataInit>(
+    /// Execute a NOP request.
+    pub fn execute_nop() -> Result<(), Error> {
+        Self::execute_request::<u8>(UmodeRequest::Nop, None)?;
+        Ok(())
+    }
+
+    /// Enter U-mode task and execute a request.
+    ///
+    /// # Arguments:
+    ///
+    /// `shared_data`: if present, the structure will be copied to the U-mode shared region.
+    pub fn execute_request<T: DataInit>(
         req: UmodeRequest,
         shared_data: Option<T>,
     ) -> Result<u64, Error> {
@@ -326,19 +337,6 @@ impl UmodeTask {
         }
         let res = ret.map_err(Error::Exec)?;
         res.map_err(Error::Request)
-    }
-
-    /// Send a request and execute U-mode until an error is returned.
-    pub fn send_req(req: UmodeRequest) -> Result<u64, Error> {
-        Self::execute_request::<u8>(req, None)
-    }
-
-    /// Same as `send_req` but share `shared_data` in U-mode shared area while executing this request.
-    pub fn send_req_with_shared_data<T: DataInit>(
-        req: UmodeRequest,
-        shared_data: T,
-    ) -> Result<u64, Error> {
-        Self::execute_request(req, Some(shared_data))
     }
 
     fn handle_ecall(&mut self) -> ControlFlow<Result<OpResult, ExecError>> {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -201,7 +201,7 @@ impl From<UmodeApiError> for EcallError {
 impl From<UmodeError> for EcallError {
     fn from(error: UmodeError) -> EcallError {
         match error {
-            UmodeError::Exec(ExecError::Umode(api_error)) => api_error.into(),
+            UmodeError::Request(api_error) => api_error.into(),
             _ => EcallError::Sbi(SbiError::Failed),
         }
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1677,7 +1677,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
             certout_len,
         };
         // Send request to U-mode.
-        Ok(UmodeTask::send_req_with_shared_data(request, shared_data)?)
+        Ok(UmodeTask::execute_request(request, Some(shared_data))?)
     }
 
     fn guest_extend_measurement(

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1677,7 +1677,11 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
             certout_len,
         };
         // Send request to U-mode.
-        Ok(UmodeTask::execute_request(request, Some(shared_data))?)
+        Ok(UmodeTask::execute_request(
+            request,
+            Some(shared_data),
+            &UmodeTask::only_std_hypcalls,
+        )?)
     }
 
     fn guest_extend_measurement(

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1680,7 +1680,18 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
         Ok(UmodeTask::execute_request(
             request,
             Some(shared_data),
-            &UmodeTask::only_std_hypcalls,
+            &|hypc| match hypc {
+                u_mode_api::HypCall::ExtSign {
+                    msg_addr: _,
+                    msg_size: _,
+                    sign_addr: _,
+                    sign_size: _,
+                } => {
+                    println!("Signing!");
+                    Ok(())
+                }
+                _ => Err(ExecError::UnhandledHypCall(hypc)),
+            },
         )?)
     }
 

--- a/u-mode-api/src/lib.rs
+++ b/u-mode-api/src/lib.rs
@@ -182,10 +182,11 @@ impl TryIntoRegisters for UmodeRequest {
 
 // HypCall: calls from umode to hypervisor.
 
-/// Result returned from Umode Op execution.
+/// Result returned from Umode Request execution (U-mode -> Hypervisor)
 pub type OpResult = Result<u64, Error>;
 
 /// Calls from umode to the hypervisors.
+#[derive(Debug)]
 pub enum HypCall {
     /// Panic and exit immediately.
     Panic,

--- a/u-mode-api/src/lib.rs
+++ b/u-mode-api/src/lib.rs
@@ -182,6 +182,9 @@ impl TryIntoRegisters for UmodeRequest {
 
 // HypCall: calls from umode to hypervisor.
 
+/// Result returned from Umode Op execution.
+pub type OpResult = Result<u64, Error>;
+
 /// Calls from umode to the hypervisors.
 pub enum HypCall {
     /// Panic and exit immediately.
@@ -189,7 +192,7 @@ pub enum HypCall {
     /// Print a character for debug.
     PutChar(u8),
     /// Return result of previous request and wait for next operation.
-    NextOp(Result<u64, Error>),
+    NextOp(OpResult),
 }
 
 const HYPC_PANIC: u64 = 0;

--- a/u-mode/src/cert.rs
+++ b/u-mode/src/cert.rs
@@ -36,9 +36,10 @@ pub enum Error {
 struct UmodeSigner {}
 
 impl Signer<Signature> for UmodeSigner {
-    fn try_sign(&self, _: &[u8]) -> Result<Signature, ed25519::Error> {
-        // TODO: Implement Signing of certificate.
-        Signature::from_bytes(&[0; 64])
+    fn try_sign(&self, msg: &[u8]) -> Result<Signature, ed25519::Error> {
+        let mut signature_bytes = [0; 64];
+        hyp_sign(msg, &mut signature_bytes);
+        Signature::from_bytes(&signature_bytes)
     }
 }
 


### PR DESCRIPTION
In preparation for modifying Attestation Manager to sign certificates, this change implements a stub hypervisor sign ecall for u-mode, that is accessible only during a guest request to get an evidence certificate.

Patch1: Fixes and makes error handling in U-mode requests a bit saner: task.run() will return an ExecError in case U-mode execution failed unexpectedly, and in the non error case will return the result of the operation (which is a Result<u64, UmodeApiError>). This helps simplify things and allows for an easier following of which error code we're handling.

