### PR TITLE
Add hgatp emulation.

### DIFF
--- a/src/smp.rs
+++ b/src/smp.rs
@@ -60,6 +60,8 @@ impl PerCpu {
             .unwrap();
         PER_CPU_BASE.call_once(|| pcpu_base);
 
+        VmIdTracker::init();
+
         // Now initialize each PerCpu structure.
         for i in 0..cpu_info.num_cpus() {
             let cpu_id = CpuId::new(i);

--- a/src/vm_id.rs
+++ b/src/vm_id.rs
@@ -44,6 +44,12 @@ fn get_vmid_bits() -> u64 {
     vmid_bits
 }
 
+/// Returns the VMID length.
+pub fn get_vmid_len() -> u64 {
+    // Unwrap okay: this is called after `VmIdTracker::init()`
+    *VMIDLEN.get().unwrap()
+}
+
 impl VmIdTracker {
     pub fn init() {
         VMIDLEN.call_once(get_vmid_bits);
@@ -64,8 +70,7 @@ impl VmIdTracker {
 
     /// Assigns a VMID, rolling over and flushing the TLB if necessary.
     pub fn next_vmid(&mut self) -> VmId {
-        // Unwrap okay: this is called after `init()`
-        let vmid_bits = *VMIDLEN.get().unwrap();
+        let vmid_bits = get_vmid_len();
         if self.next_vmid == 0 {
             // We rolled over. Bump the version and flush everything since we're now potentially
             // reusing old VMIDs.


### PR DESCRIPTION
We need bare minimum hgatp emulation to allow the host to detect the VMIDLEN and the paging mode supported. All the writes are basically ignored and not conveyed to hardware csr.

Related change in Host: https://github.com/rajnesh-kanwal/linux/commit/85245a9bc1f390dc8de3e1ef50a7f54e0224610a