### PR TITLE
ci: Allow manual triggering of build/test workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,7 +36,7 @@ jobs:
     - uses: actions/cache/restore@v3
       with:
         path: ./riscv64-unknown-elf-objcopy
-        key: objcopy       
+        key: objcopy
     - name: Build
       run: make salus
     - name: Build tellus


### PR DESCRIPTION
To help us debug the failures in https://github.com/rivosinc/salus/actions/runs/4190690805/jobs/7264351267 that we've been unable to reproduce locally.