### PR TITLE
VmInterrupts: Allow interrupt injection to new file while rebinding

### DIFF
--- a/src/vm_interrupts.rs
+++ b/src/vm_interrupts.rs
@@ -25,6 +25,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 enum BindStatus {
     Binding(CpuId, ImsicFileId),
     Bound(CpuId, ImsicFileId),
+    // Rebinding has old CpuId and old ImsicFileId first and new ones later.
     Rebinding(CpuId, ImsicFileId, CpuId, ImsicFileId),
     Cloned(CpuId, ImsicFileId),
     Unbinding(CpuId, ImsicFileId),
@@ -308,7 +309,7 @@ impl VmCpuExtInterrupts {
             return Err(Error::DeniedInterruptId(id));
         }
         match self.bind_status {
-            BindStatus::Bound(cpu_id, file) => {
+            BindStatus::Bound(cpu_id, file) | BindStatus::Rebinding(_, _, cpu_id, file) => {
                 // Unwrap ok: CPU ID and file must be valid if a vCPU is bound to it.
                 Imsic::get().send_ipi_raw(cpu_id, file, id as u32).unwrap();
             }


### PR DESCRIPTION
When VCPU is not bound we sent those interrupts to swfile to be later copied to hw-interrupt file for injection.
When rebinding, the `rebind_imsic_begin()` sets the state to Rebinding but swfile is not set up for use as it's supposed to be setup on the previous PCPU which is done by `rebind_imsic_clone()`.

Given sw_file is used only between `rebind_imsic_clone()` and `rebind_imsic_finish()` it's possible that we miss interrupts between `rebind_imsic_begin()` and `rebind_imsic_clone()`.

Given we have the new interrupt file wired up, we can send interrupts directly to the new interrupt file in the Rebinding state and after transitioning to Cloned state, we are safe to use swfile.

Signed-off-by: Rajnesh Kanwal <rkanwal@rivosinc.com>
Reported-by: Atish Patra <atishp@rivosinc.com>