### PR TITLE
VmCpu: Fix rd and rs2 encoding for load and store instructions.

### DIFF
--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -738,9 +738,9 @@ impl<'vcpu, 'pages, 'host, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, '
         };
         // Set rd (for loads) or rs2 (for stores) to A0.
         let htinst = if mmio_op.opcode().is_load() {
-            htinst_base | ((GprIndex::A0 as u32) << 20)
-        } else {
             htinst_base | ((GprIndex::A0 as u32) << 7)
+        } else {
+            htinst_base | ((GprIndex::A0 as u32) << 20)
         };
         htinst as u64
     }


### PR DESCRIPTION
For load instruction, rd is encoded in bits 7:11 and for store instruction, rs2 is encoded in bits 20:24.