### PR TITLE
Implement certificate signing in Umode.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -154,6 +154,7 @@ rust_binary(
         "@rice-index//:generic-array",
         "@rice-index//:hkdf",
         "@rice-index//:sha2",
+        "@rice-index//:signature",
         "@salus-index//:arrayvec",
         "@salus-index//:memoffset",
         "@salus-index//:static_assertions",

--- a/attestation/src/lib.rs
+++ b/attestation/src/lib.rs
@@ -12,8 +12,8 @@ pub enum Error {
     /// The DICE engine failed to extract a CDI.
     DiceCdiExtraction(rice::Error),
 
-    /// The DICE engine failed to build a new layer.
-    DiceLayerBuild(rice::Error),
+    /// The DICE engine failed to build a CDI structure.
+    DiceCdiBuild(rice::Error),
 
     /// The DICE engine failed to build the next layer CDI and certificates.
     DiceRoll(rice::Error),

--- a/bazel-locks/Cargo.Bazel.lock
+++ b/bazel-locks/Cargo.Bazel.lock
@@ -169,6 +169,7 @@ dependencies = [
  "riscv-decode",
  "seq-macro",
  "sha2 0.10.6",
+ "signature",
  "spin",
  "spki",
  "static_assertions",

--- a/bazel-locks/cargo-bazel-lock.json
+++ b/bazel-locks/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "da8d99e5d4302ff8454ff4bfe3c97853f1da5432858ef0c6a20f8ae71c5f15c7",
+  "checksum": "10d6462d0159208144ee581d02488f938eaa92eddef86966eaa1b9f5f3e033db",
   "crates": {
     "arrayvec 0.7.2": {
       "name": "arrayvec",
@@ -772,6 +772,10 @@
             {
               "id": "sha2 0.10.6",
               "target": "sha2"
+            },
+            {
+              "id": "signature 1.6.4",
+              "target": "signature"
             },
             {
               "id": "spin 0.9.5",

--- a/deps.bzl
+++ b/deps.bzl
@@ -66,6 +66,7 @@ def salus_dependencies():
             "riscv-decode": crate.spec(
                 version = "0.2",
             ),
+            "signature": crate.spec(version = "1.6.4", default_features = False),
             "spin": crate.spec(
                 version = "0.9",
                 default_features = False,

--- a/libuser/src/hypcalls.rs
+++ b/libuser/src/hypcalls.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::arch::asm;
-use u_mode_api::{Error as UmodeApiError, HypCall, TryIntoRegisters, UmodeRequest};
+use u_mode_api::{CdiOp, CdiSel, Error as UmodeApiError, HypCall, TryIntoRegisters, UmodeRequest};
 
 /// Send an ecall to the hypervisor.
 ///
@@ -66,4 +66,43 @@ pub fn hyp_nextop(result: Result<u64, UmodeApiError>) -> Result<UmodeRequest, Um
     }
     // In case there's an error on decoding the request, return it to caller.
     UmodeRequest::try_from_registers(&regs)
+}
+
+/// Get the ID of the CDI selected by `cdi_sel`.
+pub fn hyp_cdi_id(cdi_sel: CdiSel, id: &mut [u8]) {
+    let mut regs = [0u64; 8];
+    let hypc = HypCall::Cdi {
+        cdi_sel,
+        cdi_op: CdiOp::Id {
+            idout_addr: id.as_ptr() as u64,
+            idout_len: id.len() as u64,
+        },
+    };
+    hypc.to_registers(&mut regs);
+    // Safety: we trust the hypervisor to write at `idout_addr` for `idout_len` bytes. This range is
+    // entirely contained in `id`, of which we have a mutable reference.
+    unsafe {
+        ecall(&mut regs);
+    }
+}
+
+/// Sign a message with the secret key of the CDI selected by `cdi_sel`.
+pub fn hyp_cdi_sign(cdi_sel: CdiSel, msg: &[u8], signature: &mut [u8]) {
+    let mut regs = [0u64; 8];
+    let hypc = HypCall::Cdi {
+        cdi_sel,
+        cdi_op: CdiOp::Sign {
+            msg_addr: msg.as_ptr() as u64,
+            msg_len: msg.len() as u64,
+            signout_addr: signature.as_ptr() as u64,
+            signout_len: signature.len() as u64,
+        },
+    };
+    hypc.to_registers(&mut regs);
+    // Safety: we trust the hypervisor to write at `sign_addr` for `sign_len` bytes. This range is
+    // entirely contained in `signature`, of which we have a mutable reference. We also trust the
+    // hypervisor to read from `msg_addr` for `msg_len` bytes, which is entirely contained in `msg`.
+    unsafe {
+        ecall(&mut regs);
+    }
 }

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -5,3 +5,4 @@
 use core::arch::global_asm;
 
 global_asm!(include_str!("start.S"));
+global_asm!(include_str!("mem_extable.S"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -542,8 +542,7 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
     // Setup U-mode task for this CPU.
     UmodeTask::setup_this_cpu().expect("Could not setup umode");
     // Do a NOP request to the U-mode task to check it's functional in this CPU.
-    UmodeTask::send_req(u_mode_api::UmodeRequest::Nop).expect("U-mode not executing NOP");
-    test_declare_pass!("successful return from u-mode");
+    UmodeTask::nop().expect("U-mode not executing NOP");
 
     // Now load the host VM.
     let host = HostVmLoader::new(
@@ -595,7 +594,7 @@ extern "C" fn secondary_init(hart_id: u64) {
     // Setup U-mode task for this CPU.
     UmodeTask::setup_this_cpu().expect("Could not setup umode");
     // Do a NOP request to the U-mode task to check it's functional in this CPU.
-    UmodeTask::send_req(u_mode_api::UmodeRequest::Nop).expect("U-mode not executing NOP");
+    UmodeTask::nop().expect("U-mode not executing NOP");
 
     HOST_VM.wait().run(me.cpu_id().raw() as u64);
     poweroff();

--- a/src/mem_extable.S
+++ b/src/mem_extable.S
@@ -52,11 +52,6 @@ _copy_from_guest:
     addi  t2, t2, 1
     j     1b
 
-.align 2
-_ret_from_copy:
-    mv    a0, t2
-    ret
-
 // Fetch an instruction from guest memory using HLVX. Only supports 2 or 4 byte instructions.
 //
 // Arguments:
@@ -91,4 +86,47 @@ _fetch_guest_instruction:
 4:
     // Took a fault, return -1.
     not   a0, zero
+    ret
+
+// memcpy() to a user address.
+.global _copy_to_user
+_copy_to_user:
+   // handle_trap assumes t0 holds the address of where we want to jump to when we encounter
+   // a fault and will stick SCAUSE in t1.
+   la    t0, _ret_from_copy
+   // _ret_from_copy assumes the return value is in t2.
+   mv    t2, zero
+1:
+   beq   t2, a2, _ret_from_copy
+   lb    t3, (a1)
+2:
+   sb t3, (a0)
+   add_extable 2b
+   addi  a0, a0, 1
+   addi  a1, a1, 1
+   addi  t2, t2, 1
+   j     1b
+
+// memcpy() from a user address.
+.global _copy_from_user
+_copy_from_user:
+   // handle_trap assumes t0 holds the address of where we want to jump to when we encounter
+   // a fault and will stick SCAUSE in t1.
+   la    t0, _ret_from_copy
+   // _ret_from_copy assumes the return value is in t2.
+   mv    t2, zero
+1:
+   beq   t2, a2, _ret_from_copy
+2:
+   lb t3, (a1)
+   add_extable 2b
+   sb    t3, (a0)
+   addi  a0, a0, 1
+   addi  a1, a1, 1
+   addi  t2, t2, 1
+   j     1b
+
+.align 2
+_ret_from_copy:
+    mv    a0, t2
     ret

--- a/src/umode.rs
+++ b/src/umode.rs
@@ -15,7 +15,7 @@ use riscv_elf::ElfMap;
 use riscv_regs::{Exception::UserEnvCall, GeneralPurposeRegisters, GprIndex, Readable, Trap, CSR};
 use s_mode_utils::print::*;
 use sync::Once;
-use u_mode_api::{Error as UmodeApiError, HypCall, TryIntoRegisters, UmodeRequest};
+use u_mode_api::{Error as UmodeApiError, HypCall, OpResult, TryIntoRegisters, UmodeRequest};
 
 /// Host GPR and which must be saved/restored when entering/exiting U-mode.
 #[derive(Default)]
@@ -233,6 +233,8 @@ global_asm!(
 pub enum Error {
     /// U-mode task returned an error while running.
     Exec(ExecError),
+    /// U-mode task completed execution but returned an error.
+    Request(UmodeApiError),
     /// Error while sharing data.
     HypMap(HypMapError),
 }
@@ -244,8 +246,8 @@ pub enum ExecError {
     UnexpectedTrap,
     /// Umode called panic.
     Panic,
-    /// Error in umode.
-    Umode(UmodeApiError),
+    /// U-mode API error.
+    Api(UmodeApiError),
 }
 
 // Entry for umode task.
@@ -267,13 +269,13 @@ impl UmodeTask {
     pub fn setup_this_cpu() -> Result<(), Error> {
         let arch = UmodeCpuArchState::default();
         let mut task = UmodeTask { arch };
-        task.reset().map_err(Error::Exec)?;
+        task.reset()?;
         // Install umode cpu state in the current cpu.
         PerCpu::this_cpu().set_umode_task(task);
         Ok(())
     }
 
-    fn reset(&mut self) -> Result<(), ExecError> {
+    fn reset(&mut self) -> Result<(), Error> {
         // Initialize umode CPU state to run at ELF entry.
         let mut arch = UmodeCpuArchState::default();
         // Unwrap okay: this is called after `Self::init()`.
@@ -293,7 +295,7 @@ impl UmodeTask {
         // sstatus set to 0 (by default) is actually okay.
         self.arch = arch;
         // Run task until it initializes itself and calls HypCall::NextOp().
-        self.run()?;
+        self.run().map_err(Error::Exec)?.map_err(Error::Request)?;
         Ok(())
     }
 
@@ -301,32 +303,29 @@ impl UmodeTask {
         req: UmodeRequest,
         shared_data: Option<T>,
     ) -> Result<u64, Error> {
-        let mut task = PerCpu::this_cpu().umode_task_mut();
+        let this_cpu = PerCpu::this_cpu();
+        let mut task = this_cpu.umode_task_mut();
         req.to_registers(task.arch.umode_regs.gprs.a_regs_mut());
         if let Some(data) = shared_data {
-            PerCpu::this_cpu()
+            this_cpu
                 .page_table()
                 .share_with_umode(data)
                 .map_err(Error::HypMap)?;
         }
         let ret = task.run();
-        if let Err(e) = &ret {
-            match e {
-                ExecError::UnexpectedTrap | ExecError::Panic => {
-                    // Reset on unrecoverable u-mode error.
-                    // 1. restore memory to original state
-                    PerCpu::this_cpu().page_table().restore_umode();
-                    // 2. setup umode again.
-                    // Panic if we can't restore umode: the hypervisor is in an unrecoverable state.
-                    task.reset().expect("Failed to recover U-mode.");
-                }
-                ExecError::Umode(_) => {}
-            }
+        // Errors encountered while executing the operation are unrecoverable: reset U-mode.
+        if ret.is_err() {
+            // 1. restore memory to original state
+            this_cpu.page_table().restore_umode();
+            // 2. setup umode again.
+            // Panic if we can't restore umode: the hypervisor is in an unrecoverable state.
+            task.reset().expect("Failed to recover U-mode.");
         }
         if shared_data.is_some() {
-            PerCpu::this_cpu().page_table().clear_umode_shared();
+            this_cpu.page_table().clear_umode_shared();
         }
-        ret.map_err(Error::Exec)
+        let res = ret.map_err(Error::Exec)?;
+        res.map_err(Error::Request)
     }
 
     /// Send a request and execute U-mode until an error is returned.
@@ -342,7 +341,7 @@ impl UmodeTask {
         Self::execute_request(req, Some(shared_data))
     }
 
-    fn handle_ecall(&mut self) -> ControlFlow<Result<u64, ExecError>> {
+    fn handle_ecall(&mut self) -> ControlFlow<Result<OpResult, ExecError>> {
         let regs = self.arch.umode_regs.gprs.a_regs();
         let cflow = match HypCall::try_from_registers(regs) {
             Ok(hypercall) => match hypercall {
@@ -358,11 +357,11 @@ impl UmodeTask {
                     // No return. Leave umode registers untouched and return.
                     ControlFlow::Continue(())
                 }
-                HypCall::NextOp(result) => ControlFlow::Break(result.map_err(ExecError::Umode)),
+                HypCall::NextOp(result) => ControlFlow::Break(Ok(result)),
             },
             Err(err) => {
                 // Hypervisor could not parse the hypercall. Stop running umode and return error.
-                ControlFlow::Break(Err(ExecError::Umode(err)))
+                ControlFlow::Break(Err(ExecError::Api(err)))
             }
         };
         // Increase SEPC to skip ecall on entry.
@@ -382,7 +381,7 @@ impl UmodeTask {
     }
 
     // Run `umode` until result is returned.
-    fn run(&mut self) -> Result<u64, ExecError> {
+    fn run(&mut self) -> Result<OpResult, ExecError> {
         loop {
             self.run_to_exit();
             match Trap::from_scause(self.arch.trap_csrs.scause).unwrap() {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -200,7 +200,7 @@ impl From<UmodeApiError> for EcallError {
 impl From<UmodeError> for EcallError {
     fn from(error: UmodeError) -> EcallError {
         match error {
-            UmodeError::Exec(ExecError::Umode(api_error)) => api_error.into(),
+            UmodeError::Request(api_error) => api_error.into(),
             _ => EcallError::Sbi(SbiError::Failed),
         }
     }

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -4,7 +4,6 @@
 
 use arrayvec::ArrayVec;
 use attestation::AttestationManager;
-use core::arch::global_asm;
 use core::marker::PhantomData;
 use drivers::{imsic::*, iommu::*, pci::PciBarPage, pci::PciDevice, pci::PcieRoot};
 use page_tracking::{
@@ -66,8 +65,6 @@ pub enum InstructionFetchError {
 }
 
 pub type InstructionFetchResult = core::result::Result<DecodedInstruction, InstructionFetchError>;
-
-global_asm!(include_str!("guest_mem.S"));
 
 // The copy to/from guest memory routines defined in guest_mem.S.
 extern "C" {

--- a/u-mode-api/src/cert.rs
+++ b/u-mode-api/src/cert.rs
@@ -20,13 +20,11 @@ pub type MeasurementRegisterSha384 = [u8; SHA384_LEN];
 /// certificate.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub struct GetEvidenceShared {
+pub struct MeasurementRegisters {
     /// Measurement registers in SHA-384. In `fwid` order.
     pub msmt_regs: [MeasurementRegisterSha384; MSMT_REGISTERS],
-    /// CDI Id.
-    pub cdi_id: CdiId,
 }
 
-// Safety: `GetEvidenceShared` is a POD struct without implicit padding and therefore can be
+// Safety: `MeasurementRegisters` is a POD struct without implicit padding and therefore can be
 // initialized from a byte array.
-unsafe impl DataInit for GetEvidenceShared {}
+unsafe impl DataInit for MeasurementRegisters {}

--- a/u-mode-api/src/lib.rs
+++ b/u-mode-api/src/lib.rs
@@ -182,6 +182,9 @@ impl TryIntoRegisters for UmodeRequest {
 
 // HypCall: calls from umode to hypervisor.
 
+/// Result returned from Umode Op execution.
+pub type OpResult = Result<u64, Error>;
+
 /// Calls from umode to the hypervisors.
 pub enum HypCall {
     /// Panic and exit immediately.
@@ -189,7 +192,7 @@ pub enum HypCall {
     /// Print a character for debug.
     PutChar(u8),
     /// Return result of previous request and wait for next operation.
-    NextOp(Result<u64, Error>),
+    NextOp(OpResult),
 }
 
 const HYPC_PANIC: u64 = 0;

--- a/u-mode/BUILD
+++ b/u-mode/BUILD
@@ -24,6 +24,8 @@ rust_binary(
         "@rice-index//:ed25519-dalek",
         "@rice-index//:generic-array",
         "@rice-index//:sha2",
+        "@rice-index//:signature",
+        "@rice-index//:zeroize",
     ],
 )
 


### PR DESCRIPTION
This PR is an acculumation of changes that have been going in a private branch since December.

Recents discussion with @sameo have brought a different approach to using rice for attestation in a world where attestation manager and certificate genration are separated. This changes the interface for U-mode when it comes to certificate generation.

It also adds support for copy to/from user, using the same mechanism used for vm addresses.

