### PR TITLE
Fix issue with finding link file for dbg and fastbuild builds.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -124,11 +124,11 @@ objcopy_to_object(
 rust_binary(
     name = "salus",
     srcs = glob(["src/*.rs"]),
-    data = glob(["src/*.S"]) + [":umode_to_object"],
-    linker_script = ":l_rule",
+    data = glob(["src/*.S"]) + [":umode_to_object", ":l_rule"],
     rustc_flags = [
         "-Ctarget-feature=+v",
         "--codegen=link-arg=-nostartfiles",
+        "-Clink-arg=-T$(location //:l_rule)"
     ],
     deps = [
         "//attestation",


### PR DESCRIPTION
There was an issue finding or creating a linker file for a dbg or fastbuild build. This fixes that.