### PR TITLE
build: Enable Rust Analyzer support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,6 +11,7 @@ build --incompatible_enable_cc_toolchain_resolution
 
 build --platforms="@rules_rivos//platforms:riscv64-none"
 test --platforms=
+run --platforms=
 build --@rules_rust//rust/toolchain/channel=nightly
 
 # Rust Clippy configuration:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,6 +36,10 @@ load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_regi
 
 rules_rust_dependencies()
 
+load("@rules_rust//tools/rust_analyzer:deps.bzl", "rust_analyzer_dependencies")
+
+rust_analyzer_dependencies()
+
 # Register Rust toolchains. rules_rust gives us the latest stable Rust
 # release from the rules_rust release, and the nightly build from that
 # date. For Salus, we use the nightly build to take advantage of some


### PR DESCRIPTION
The metadata can be generated with:

bazel run @rules_rust//tools/rust_analyzer:gen_rust_project

Users of VScode can automate this with:

https://bazelbuild.github.io/rules_rust/rust_analyzer.html#vscode

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
