### PR TITLE
Ignore rust-project.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ bazel-out
 bazel-salus
 bazel-testlogs
 .idea/
+rust-project.json


### PR DESCRIPTION
In order to use rust-analyzer with the project and given we moved away from Cargo, we need to generated a rust-project.json file so that rust-analyzer can run properly. This file should be ignored.