### PR TITLE
build: Replace deprecated "iso-date" use in WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,15 +40,19 @@ load("@rules_rust//tools/rust_analyzer:deps.bzl", "rust_analyzer_dependencies")
 
 rust_analyzer_dependencies()
 
+load("@rules_rust//rust:defs.bzl", "rust_common")
+
 # Register Rust toolchains. rules_rust gives us the latest stable Rust
 # release from the rules_rust release, and the nightly build from that
 # date. For Salus, we use the nightly build to take advantage of some
 # nightly-only language features, but we keep it stable and only update
 # it once per month.
+# A stable version (as specified in rust_common.default_version), must
+# be included as some of the dependencies require it.
 rust_register_toolchains(
     edition = "2021",
     extra_target_triples = ["riscv64gc-unknown-none-elf"],
-    iso_date = "2023-2-26",
+    versions = [rust_common.default_version, "nightly/2023-02-26"],
 )
 
 load("//:deps.bzl", "salus_dependencies")


### PR DESCRIPTION
This addresses the following warning:

DEBUG: /home/rob/.cache/bazel/_bazel_rob/fb5120ab77a24b2e7ea36ba7223ecbaf/external/rules_rust/rust/repositories.bzl:160:14: `rust_register.toolchains.iso_date` is deprecated. Please use `versions` instead: https://bazelbuild.github.io/rules_rust/flatten.html#rust_register_toolchains-versions

With this change the nightly and stable toolchain versions are
specified. The use of rust_common.default_version means other imported
code using @rules_rust will follow the same version as unfortunately it
not possible to have multiple toolchain versions per channel (e.g.
stable, beta, nightly, etc.)

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
