### PR TITLE
Fix generation of documentation

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -10,7 +10,7 @@
 # bazel test //:rustfmt-all
 # bazel test //:test-all
 
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_clippy", "rust_test", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_clippy", "rust_doc", "rust_test", "rustfmt_test")
 load("//:objcopy.bzl", "objcopy_to_object")
 load("//:lds.bzl", "lds_rule")
 
@@ -44,6 +44,29 @@ filegroup(
         "//test-workloads:clippy",
         "//u-mode:clippy",
         "//u-mode-api:clippy",
+    ],
+)
+
+filegroup(
+    name = "doc-all",
+    srcs = [
+        "salus-doc",
+        "//attestation:attestation-doc",
+        "//data-model:data-model-doc",
+        "//device-tree:device-tree-doc",
+        "//drivers:drivers-doc",
+        "//hyp-alloc:hyp-alloc-doc",
+        "//libuser:libuser-doc",
+        "//page-tracking:page-tracking-doc",
+        "//riscv-elf:riscv-elf-doc",
+        "//riscv-page-tables:riscv-page-tables-doc",
+        "//riscv-pages:riscv-pages-doc",
+        "//riscv-regs:riscv-regs-doc",
+        "//s-mode-utils:s-mode-utils-doc",
+        "//sync:sync-doc",
+        "//test-system:test-system-doc",
+        "//u-mode:u-mode-doc",
+        "//u-mode-api:u-mode-api-doc",
     ],
 )
 
@@ -124,11 +147,14 @@ objcopy_to_object(
 rust_binary(
     name = "salus",
     srcs = glob(["src/*.rs"]),
-    data = glob(["src/*.S"]) + [":umode_to_object", ":l_rule"],
+    compile_data = glob(["src/*.S"]) + [
+        ":umode_to_object",
+        ":l_rule",
+    ],
     rustc_flags = [
         "-Ctarget-feature=+v",
         "--codegen=link-arg=-nostartfiles",
-        "-Clink-arg=-T$(location //:l_rule)"
+        "-Clink-arg=-T$(location //:l_rule)",
     ],
     deps = [
         "//attestation",
@@ -169,6 +195,11 @@ rust_clippy(
 rustfmt_test(
     name = "salus-rustfmt",
     targets = ["salus"],
+)
+
+rust_doc(
+    name = "salus-doc",
+    crate = ":salus",
 )
 
 rust_test(

--- a/attestation/BUILD
+++ b/attestation/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_doc", "rust_library", "rustfmt_test")
 
 rust_library(
     name = "attestation",
@@ -37,4 +37,9 @@ rust_clippy(
 rustfmt_test(
     name = "rustfmt",
     targets = ["attestation"],
+)
+
+rust_doc(
+    name = "attestation-doc",
+    crate = ":attestation",
 )

--- a/data-model/BUILD
+++ b/data-model/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rust_test", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_doc", "rust_library", "rust_test", "rustfmt_test")
 
 rust_library(
     name = "data-model",
@@ -25,5 +25,10 @@ rustfmt_test(
 rust_test(
     name = "data-model-test",
     testonly = True,
+    crate = ":data-model",
+)
+
+rust_doc(
+    name = "data-model-doc",
     crate = ":data-model",
 )

--- a/device-tree/BUILD
+++ b/device-tree/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rust_test", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_doc", "rust_library", "rust_test", "rustfmt_test")
 
 rust_library(
     name = "device-tree",
@@ -27,5 +27,10 @@ rustfmt_test(
 
 rust_test(
     name = "device-tree-test",
+    crate = ":device-tree",
+)
+
+rust_doc(
+    name = "device-tree-doc",
     crate = ":device-tree",
 )

--- a/drivers/BUILD
+++ b/drivers/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rust_test", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_doc", "rust_library", "rust_test", "rustfmt_test")
 
 rust_library(
     name = "drivers",
@@ -41,5 +41,10 @@ rustfmt_test(
 
 rust_test(
     name = "drivers-test",
+    crate = ":drivers",
+)
+
+rust_doc(
+    name = "drivers-doc",
     crate = ":drivers",
 )

--- a/hyp-alloc/BUILD
+++ b/hyp-alloc/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rust_test", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_doc", "rust_library", "rust_test", "rustfmt_test")
 
 rust_library(
     name = "hyp-alloc",
@@ -27,5 +27,10 @@ rustfmt_test(
 
 rust_test(
     name = "hyp-alloc-test",
+    crate = ":hyp-alloc",
+)
+
+rust_doc(
+    name = "hyp-alloc-doc",
     crate = ":hyp-alloc",
 )

--- a/libuser/BUILD
+++ b/libuser/BUILD
@@ -4,12 +4,12 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_doc", "rust_library", "rustfmt_test")
 
 rust_library(
     name = "libuser",
     srcs = glob(["src/**/*.rs"]),
-    data = glob(["src/**/*.S"]),
+    compile_data = glob(["src/**/*.S"]),
     deps = ["//u-mode-api"],
 )
 
@@ -21,4 +21,9 @@ rust_clippy(
 rustfmt_test(
     name = "rustfmt",
     targets = ["libuser"],
+)
+
+rust_doc(
+    name = "libuser-doc",
+    crate = ":libuser",
 )

--- a/page-tracking/BUILD
+++ b/page-tracking/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rust_test", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_doc", "rust_library", "rust_test", "rustfmt_test")
 
 rust_library(
     name = "page-tracking",
@@ -28,5 +28,10 @@ rustfmt_test(
 
 rust_test(
     name = "page-tracking-test",
+    crate = ":page-tracking",
+)
+
+rust_doc(
+    name = "page-tracking-doc",
     crate = ":page-tracking",
 )

--- a/riscv-elf/BUILD
+++ b/riscv-elf/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rust_test", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_doc", "rust_library", "rust_test", "rustfmt_test")
 
 rust_library(
     name = "riscv-elf",
@@ -24,5 +24,10 @@ rustfmt_test(
 
 rust_test(
     name = "riscv-elf-test",
+    crate = ":riscv-elf",
+)
+
+rust_doc(
+    name = "riscv-elf-doc",
     crate = ":riscv-elf",
 )

--- a/riscv-page-tables/BUILD
+++ b/riscv-page-tables/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rust_test", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_doc", "rust_library", "rust_test", "rustfmt_test")
 
 rust_library(
     name = "riscv-page-tables",
@@ -28,5 +28,10 @@ rustfmt_test(
 
 rust_test(
     name = "riscv-page-tables-test",
+    crate = ":riscv-page-tables",
+)
+
+rust_doc(
+    name = "riscv-page-tables-doc",
     crate = ":riscv-page-tables",
 )

--- a/riscv-pages/BUILD
+++ b/riscv-pages/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rust_test", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_doc", "rust_library", "rust_test", "rustfmt_test")
 
 rust_library(
     name = "riscv-pages",
@@ -24,5 +24,10 @@ rustfmt_test(
 
 rust_test(
     name = "riscv-pages-test",
+    crate = ":riscv-pages",
+)
+
+rust_doc(
+    name = "riscv-pages-doc",
     crate = ":riscv-pages",
 )

--- a/riscv-regs/BUILD
+++ b/riscv-regs/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_doc", "rust_library", "rustfmt_test")
 
 rust_library(
     name = "riscv-regs",
@@ -28,4 +28,9 @@ rust_clippy(
 rustfmt_test(
     name = "rustfmt",
     targets = ["riscv-regs"],
+)
+
+rust_doc(
+    name = "riscv-regs-doc",
+    crate = ":riscv-regs",
 )

--- a/s-mode-utils/BUILD
+++ b/s-mode-utils/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_doc", "rust_library", "rustfmt_test")
 
 rust_library(
     name = "s-mode-utils",
@@ -23,4 +23,9 @@ rust_clippy(
 rustfmt_test(
     name = "rustfmt",
     targets = ["s-mode-utils"],
+)
+
+rust_doc(
+    name = "s-mode-utils-doc",
+    crate = ":s-mode-utils",
 )

--- a/sync/BUILD
+++ b/sync/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_doc", "rust_library", "rustfmt_test")
 
 rust_library(
     name = "sync",
@@ -20,4 +20,9 @@ rust_clippy(
 rustfmt_test(
     name = "rustfmt",
     targets = ["sync"],
+)
+
+rust_doc(
+    name = "sync-doc",
+    crate = ":sync",
 )

--- a/test-system/BUILD
+++ b/test-system/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_doc", "rust_library", "rustfmt_test")
 
 rust_library(
     name = "test-system",
@@ -19,4 +19,9 @@ rust_clippy(
 rustfmt_test(
     name = "rustfmt",
     targets = ["test-system"],
+)
+
+rust_doc(
+    name = "test-system-doc",
+    crate = ":test-system",
 )

--- a/u-mode-api/BUILD
+++ b/u-mode-api/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_library", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_clippy", "rust_doc", "rust_library", "rustfmt_test")
 
 rust_library(
     name = "u-mode-api",
@@ -23,4 +23,9 @@ rust_clippy(
 rustfmt_test(
     name = "rustfmt",
     targets = ["u-mode-api"],
+)
+
+rust_doc(
+    name = "u-mode-api-doc",
+    crate = ":u-mode-api",
 )

--- a/u-mode/BUILD
+++ b/u-mode/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_clippy", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_clippy", "rust_doc", "rustfmt_test")
 load("@rules_rust//crate_universe:defs.bzl", "crate", "crates_repository")
 
 rust_binary(
@@ -37,4 +37,9 @@ rust_clippy(
 rustfmt_test(
     name = "rustfmt",
     targets = ["umode"],
+)
+
+rust_doc(
+    name = "u-mode-doc",
+    crate = ":umode",
 )


### PR DESCRIPTION
Went through and figured out why rust_doc() wouldn't work. Fixed it and created targets to generate all docs.