### PR TITLE
Vm: Use EcallAction::Forward for share/unshare calls from guest.

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2357,10 +2357,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
 
                 // Always block given we expect a TLB increment to be triggered from the host.
                 let action = match result {
-                    Ok(_) => EcallAction::Break(
-                        VmExitCause::ForwardedEcall(SbiMessage::TeeGuest(guest_func)),
-                        SbiReturn::success(0),
-                    ),
+                    Ok(_) => EcallAction::Forward(SbiMessage::TeeGuest(guest_func)),
                     Err(_) => result.map(|_| 0).into(),
                 };
                 return action;


### PR DESCRIPTION
Given we do post processing after the share/unshare calls from guest in `try_complete_pending_op` and use `set_ecall_result` to set the ECALL results returned from the host, we end up incrementing sepc second time. First time when we call `set_ecall_result` from `run_vcpu` under EcallAction::Break case.

This skips the next instruction(s) (fp load and stack pointer adjustment instructions in case of kvm) and leads to strange issues.