### PR TITLE
Fixes and improvement for Salus unit testing

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -147,19 +147,7 @@ objcopy_to_object(
     out = "umode.o",
 )
 
-rust_binary(
-    name = "salus",
-    srcs = glob(["src/*.rs"]),
-    compile_data = glob(["src/*.S"]) + [
-        ":umode_to_object",
-        ":l_rule",
-    ],
-    rustc_flags = [
-        "-Ctarget-feature=+v",
-        "--codegen=link-arg=-nostartfiles",
-        "-Clink-arg=-T$(location //:l_rule)",
-    ],
-    deps = [
+salus_deps = [
         "//attestation",
         "//data-model",
         "//device-tree",
@@ -188,7 +176,21 @@ rust_binary(
         "@salus-index//:arrayvec",
         "@salus-index//:memoffset",
         "@salus-index//:static_assertions",
+]
+
+rust_binary(
+    name = "salus",
+    srcs = glob(["src/*.rs"]),
+    compile_data = glob(["src/*.S"]) + [
+        ":umode_to_object",
+        ":l_rule",
     ],
+    rustc_flags = [
+        "-Ctarget-feature=+v",
+        "--codegen=link-arg=-nostartfiles",
+        "-Clink-arg=-T$(location //:l_rule)",
+    ],
+    deps = salus_deps,
 )
 
 rust_clippy(
@@ -216,33 +218,5 @@ rust_test(
         "-Clink-arg=-Tsrc/salus-test.lds",
         "--codegen=link-arg=-nostartfiles",
     ],
-    deps = [
-        "//attestation",
-        "//data-model",
-        "//device-tree",
-        "//drivers",
-        "//hyp-alloc",
-        "//mtt",
-        "//page-tracking",
-        "//rice",
-        "//riscv-elf",
-        "//riscv-page-tables",
-        "//riscv-pages",
-        "//riscv-regs",
-        "//s-mode-utils",
-        "//sbi-rs",
-        "//sync",
-        "//test-system",
-        "//u-mode-api",
-        "@rice-index//:const-oid",
-        "@rice-index//:der",
-        "@rice-index//:digest",
-        "@rice-index//:ed25519-dalek",
-        "@rice-index//:generic-array",
-        "@rice-index//:hkdf",
-        "@rice-index//:sha2",
-        "@salus-index//:arrayvec",
-        "@salus-index//:memoffset",
-        "@salus-index//:static_assertions",
-    ],
+    deps = salus_deps,
 )

--- a/src/salus-test.lds
+++ b/src/salus-test.lds
@@ -59,6 +59,8 @@ SECTIONS
 
     PROVIDE(_stack_start = ALIGN(_bss_end, 4096));
     PROVIDE(_stack_end = _stack_start + 0x80000);
+    PROVIDE(_overflow_stack_start = _stack_end);
+    PROVIDE(_overflow_stack_end = _overflow_stack_start + 0x2000);
 
     /DISCARD/ : {
         *(.eh_frame)

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2438,3 +2438,25 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
         Ok(0)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_system::*;
+
+    #[test_case]
+    fn MmioOpcodeTest() -> TestResult {
+        test_result_true!(MmioOpcode::Load64.is_load(), "MmioOpcode::Load64")?;
+        test_result_true!(MmioOpcode::Load32.is_load(), "MmioOpcode::Load32")?;
+        test_result_true!(MmioOpcode::Load32U.is_load(), "MmioOpcode::Load32U")?;
+        test_result_true!(MmioOpcode::Load16.is_load(), "MmioOpcode::Load16")?;
+        test_result_true!(MmioOpcode::Load16U.is_load(), "MmioOpcode::Load16U")?;
+        test_result_true!(MmioOpcode::Load8.is_load(), "MmioOpcode::Load8")?;
+        test_result_true!(MmioOpcode::Load8U.is_load(), "MmioOpcode::Load8U")?;
+        test_result_false!(MmioOpcode::Store64.is_load(), "MmioOpcode::Store64")?;
+        test_result_false!(MmioOpcode::Store32.is_load(), "MmioOpcode::Store32")?;
+        test_result_false!(MmioOpcode::Store16.is_load(), "MmioOpcode::Store16")?;
+        test_result_false!(MmioOpcode::Store8.is_load(), "MmioOpcode::Store8")?;
+        Ok(())
+    }
+}

--- a/src/vm_pmu.rs
+++ b/src/vm_pmu.rs
@@ -474,3 +474,37 @@ impl VmPmuState {
         result
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_system::*;
+
+    #[test_case]
+    fn CounterMaskIterTest() -> TestResult {
+        let mut cmi = CounterMaskIter::new(0xff, 0x100).into_iter();
+
+        if cmi.next().unwrap() != 263 {
+            return Err(TestFailure::FailedAt("test1"));
+        }
+
+        if cmi.next().is_some() {
+            return Err(TestFailure::FailedAt("test2"));
+        }
+        let mut cmi = CounterMaskIter::new(0xff, 0x300).into_iter();
+
+        if cmi.next().unwrap() != 263 {
+            return Err(TestFailure::FailedAt("test3"));
+        }
+
+        if cmi.next().unwrap() != 264 {
+            return Err(TestFailure::FailedAt("test4"));
+        }
+
+        if cmi.next().is_some() {
+            return Err(TestFailure::FailedAt("test5"));
+        }
+
+        Ok(())
+    }
+}

--- a/test-workloads/src/bin/guestvm.rs
+++ b/test-workloads/src/bin/guestvm.rs
@@ -173,9 +173,9 @@ pub fn test_vector() -> TestResult {
 
     if failed {
         println!("Vector registers did not restore correctly");
-        TestResult::Fail
+        Err(TestFailure::Fail)
     } else {
-        TestResult::Pass
+        Ok(())
     }
 }
 
@@ -185,7 +185,7 @@ const TEST_CSR: &[u8] = include_bytes!("test-ed25519.der");
 fn test_attestation() -> TestResult {
     if base::probe_sbi_extension(sbi_rs::EXT_ATTESTATION).is_err() {
         println!("Platform doesn't support attestation extension");
-        return TestResult::Fail;
+        return Err(TestFailure::Fail);
     }
 
     let caps = attestation::get_capabilities().expect("Failed to get attestation capabilities");
@@ -198,7 +198,7 @@ fn test_attestation() -> TestResult {
         .contains(sbi_rs::EvidenceFormat::DiceTcbInfo)
     {
         println!("DICE TcbInfo format is not supported");
-        return TestResult::Fail;
+        return Err(TestFailure::Fail);
     }
 
     // SHA384 for "helloworld"
@@ -216,12 +216,12 @@ fn test_attestation() -> TestResult {
     test_assert!(!result, "pcr attestation measurement");
     if pcr_read.as_slice() != expected_pcr {
         println!("Wrong runtime PCR #1 measurement");
-        return TestResult::Fail;
+        return Err(TestFailure::Fail);
     }
 
     if TEST_CSR.len() > MAX_CSR_LEN {
         println!("Test CSR is too large");
-        return TestResult::Fail;
+        return Err(TestFailure::Fail);
     }
 
     let request_data = [0u8; sbi_rs::EVIDENCE_DATA_BLOB_SIZE];
@@ -233,7 +233,7 @@ fn test_attestation() -> TestResult {
         Err(e) => {
             println!("Attestation error {e:?}");
             println!("Guest evidence call failed");
-            return TestResult::Fail;
+            return Err(TestFailure::Fail);
         }
         Ok(cert_bytes) => cert_bytes,
     };
@@ -277,7 +277,7 @@ fn test_attestation() -> TestResult {
         tvm_fwid.digest.as_bytes().len()
     );
 
-    TestResult::Pass
+    Ok(())
 }
 
 fn test_memory_sharing() -> TestResult {
@@ -331,7 +331,7 @@ fn test_memory_sharing() -> TestResult {
         .expect("GuestVm -- ShareMemory failed");
     }
 
-    TestResult::Pass
+    Ok(())
 }
 
 fn test_emulated_mmio() -> TestResult {
@@ -352,7 +352,7 @@ fn test_emulated_mmio() -> TestResult {
             .expect("GuestVm - RemoveEmulatedMmioRegion failed");
     }
 
-    TestResult::Pass
+    Ok(())
 }
 
 fn test_interrupts() -> TestResult {
@@ -384,7 +384,7 @@ fn test_interrupts() -> TestResult {
         println!("External interrupt NOT pending in GuestVm");
     }
 
-    TestResult::Pass
+    Ok(())
 }
 
 #[no_mangle]


### PR DESCRIPTION
* Fixed build so that salus and unit tests share dependencies
* added Testable trait to print which test is being run
* Added FailedAt to TestResult enumeration
* Expaned macros where needed
* Expanded test runner function
* Added multiple example tests
* Added two tests (MmioOpcodeTest and  CounterMaskIterTest) to show how testing works