### PR TITLE
Map Salus stack in a fixed VA address.

### DIFF
--- a/page-tracking/src/hw_mem_map.rs
+++ b/page-tracking/src/hw_mem_map.rs
@@ -85,9 +85,6 @@ pub enum HwReservedMemType {
     /// The hypervisor heap. For boot-time dynamic memory allocation.
     HypervisorHeap,
 
-    /// The hypervisor per-CPU memory area.
-    HypervisorPerCpu,
-
     /// The system page map.
     PageMap,
 
@@ -380,7 +377,6 @@ impl fmt::Display for HwReservedMemType {
             HwReservedMemType::FirmwareReserved => write!(f, "firmware"),
             HwReservedMemType::HypervisorImage => write!(f, "hypervisor image"),
             HwReservedMemType::HypervisorHeap => write!(f, "hypervisor heap"),
-            HwReservedMemType::HypervisorPerCpu => write!(f, "hypervisor pcpu"),
             HwReservedMemType::PageMap => write!(f, "page map"),
             HwReservedMemType::HostKernelImage => write!(f, "host kernel"),
             HwReservedMemType::HostInitramfsImage => write!(f, "host initramfs"),

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -4,5 +4,7 @@
 
 use core::arch::global_asm;
 
-global_asm!(include_str!("start.S"));
+use crate::hyp_layout::HYP_STACK_TOP;
+
+global_asm!(include_str!("start.S"), HYP_STACK_TOP=const HYP_STACK_TOP);
 global_asm!(include_str!("mem_extable.S"));

--- a/src/hyp_layout.rs
+++ b/src/hyp_layout.rs
@@ -83,21 +83,16 @@ pub const UMODE_INPUT_SIZE: u64 = 4 * 1024;
 const_assert!(PageSize::Size4k.is_aligned(UMODE_INPUT_SIZE));
 
 /// Address of the hypervisor stack top.
-#[allow(dead_code)]
 pub const HYP_STACK_TOP: u64 = 0xffff_ffff_ffe0_0000;
 // Align stack top to 2M to ease huge page mappings.
 const_assert!(PageSize::Size2M.is_aligned(HYP_STACK_TOP));
 /// Number of 4k-pages reserved for each CPU as their stack.
-#[allow(dead_code)]
 pub const HYP_STACK_PAGES: u64 = 0x80;
 /// Size of stack in bytes.
-#[allow(dead_code)]
 pub const HYP_STACK_SIZE: u64 = HYP_STACK_PAGES * PageSize::Size4k as u64;
 /// End of stack (lower address)
-#[allow(dead_code)]
 pub const HYP_STACK_BOTTOM: u64 = HYP_STACK_TOP - HYP_STACK_SIZE;
 /// Page address of the stack bottom.
-#[allow(dead_code)]
 pub const HYP_STACK_BOTTOM_PAGE_ADDR: PageAddr<SupervisorVirt> =
     PageAddr::new_const::<HYP_STACK_BOTTOM>();
 

--- a/src/hyp_layout.rs
+++ b/src/hyp_layout.rs
@@ -22,6 +22,12 @@
 // +-------------------------+ UMODE_INPUT_START
 // | Umode Input Area        |
 // +-------------------------+ +UMODE_INPUT_SIZE
+// | (unused)                |
+// +-------------------------+ HYP_STACK_BOTTOM (HYP_STACK_TOP - HYP_STACK_SIZE)
+// | Hypervisor Stack        |
+// +-------------------------+ HYP_STACK_TOP (0xffff_ffff_ffe0_0000)
+// | (unused 2Mb)            |
+// +-------------------------+ End of Address Space.
 
 use riscv_pages::{PageAddr, PageSize, SupervisorVirt};
 use static_assertions::const_assert;
@@ -75,6 +81,25 @@ const_assert!(PageSize::Size4k.is_aligned(UMODE_INPUT_START));
 /// Size of the U-mode Input Region.
 pub const UMODE_INPUT_SIZE: u64 = 4 * 1024;
 const_assert!(PageSize::Size4k.is_aligned(UMODE_INPUT_SIZE));
+
+/// Address of the hypervisor stack top.
+#[allow(dead_code)]
+pub const HYP_STACK_TOP: u64 = 0xffff_ffff_ffe0_0000;
+// Align stack top to 2M to ease huge page mappings.
+const_assert!(PageSize::Size2M.is_aligned(HYP_STACK_TOP));
+/// Number of 4k-pages reserved for each CPU as their stack.
+#[allow(dead_code)]
+pub const HYP_STACK_PAGES: u64 = 0x80;
+/// Size of stack in bytes.
+#[allow(dead_code)]
+pub const HYP_STACK_SIZE: u64 = HYP_STACK_PAGES * PageSize::Size4k as u64;
+/// End of stack (lower address)
+#[allow(dead_code)]
+pub const HYP_STACK_BOTTOM: u64 = HYP_STACK_TOP - HYP_STACK_SIZE;
+/// Page address of the stack bottom.
+#[allow(dead_code)]
+pub const HYP_STACK_BOTTOM_PAGE_ADDR: PageAddr<SupervisorVirt> =
+    PageAddr::new_const::<HYP_STACK_BOTTOM>();
 
 // Returns true if `addr` is contained in the U-mode binary area.
 fn is_umode_binary_addr(addr: u64) -> bool {

--- a/src/hyp_map.rs
+++ b/src/hyp_map.rs
@@ -89,7 +89,6 @@ impl HwMapRegion {
                 Some(PteLeafPerms::R)
             }
             HwMemRegionType::Reserved(HwReservedMemType::HypervisorHeap)
-            | HwMemRegionType::Reserved(HwReservedMemType::HypervisorPerCpu)
             | HwMemRegionType::Reserved(HwReservedMemType::PageMap)
             | HwMemRegionType::Mmio(_) => Some(PteLeafPerms::RW),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -464,9 +464,6 @@ extern "C" fn primary_init(hart_id: u64, fdt_addr: u64) -> CpuParams {
     // Probe for hardcoded reset device. Not really a probe.
     ResetDriver::probe_from(&hyp_dt, &mut mem_map).expect("Failed to set up Reset Device");
 
-    // Set up per-CPU memory and boot the secondary CPUs.
-    PerCpu::init(hart_id, &mut mem_map);
-
     // Create an allocator for the remaining pages. Anything that's left over will be mapped
     // into the host VM.
     let mut hyp_mem = HypPageAlloc::new(&mut mem_map);
@@ -522,6 +519,9 @@ extern "C" fn primary_init(hart_id: u64, fdt_addr: u64) -> CpuParams {
 
     // Create the hypervisor mapping from the hardware memory map and the U-mode ELF.
     HypMap::init(mem_map, &umode_elf).expect("Cannot create Hypervisor map.");
+
+    // Set up per-CPU memory and prepare the structures for secondary CPUs boot.
+    PerCpu::init(hart_id, &mut hyp_mem);
 
     // Create per-cpu page tables.
     let cpu_info = CpuInfo::get();

--- a/src/main.rs
+++ b/src/main.rs
@@ -594,6 +594,7 @@ extern "C" fn secondary_main() {}
 #[no_mangle]
 extern "C" fn secondary_init(hart_id: u64) -> CpuParams {
     setup_csrs();
+    PerCpu::setup_this_cpu(hart_id);
 
     test_declare_pass!("secondary init", hart_id);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ mod vm_pmu;
 use device_tree::{DeviceTree, Fdt};
 use drivers::{
     imsic::Imsic, iommu::Iommu, pci::PcieRoot, pmu::PmuInfo, reset::ResetDriver, uart::UartDriver,
-    CpuId, CpuInfo,
+    CpuInfo,
 };
 use host_vm::{HostVm, HostVmLoader};
 use hyp_alloc::HypAlloc;
@@ -522,13 +522,6 @@ extern "C" fn primary_init(hart_id: u64, fdt_addr: u64) -> CpuParams {
 
     // Set up per-CPU memory and prepare the structures for secondary CPUs boot.
     PerCpu::init(hart_id, &mut hyp_mem);
-
-    // Create per-cpu page tables.
-    let cpu_info = CpuInfo::get();
-    for i in 0..cpu_info.num_cpus() {
-        let page_table = HypMap::get().new_page_table(&mut hyp_mem);
-        PerCpu::set_cpu_page_table(CpuId::new(i), page_table);
-    }
 
     // Find and initialize the IOMMU.
     match Iommu::probe_from(PcieRoot::get(), &mut || {

--- a/src/salus-test.lds
+++ b/src/salus-test.lds
@@ -57,7 +57,7 @@ SECTIONS
         PROVIDE(_bss_end = .);
     } >ram AT>ram :bss
 
-    PROVIDE(_stack_start = _bss_end);
+    PROVIDE(_stack_start = ALIGN(_bss_end, 4096));
     PROVIDE(_stack_end = _stack_start + 0x80000);
 
     /DISCARD/ : {

--- a/src/salus_lds.tmpl
+++ b/src/salus_lds.tmpl
@@ -61,7 +61,7 @@ SECTIONS
         PROVIDE(_bss_end = .);
     } >ram AT>ram :bss
 
-    PROVIDE(_stack_start = _bss_end);
+    PROVIDE(_stack_start = ALIGN(_bss_end, 4096));
     PROVIDE(_stack_end = _stack_start + 0x80000);
     PROVIDE(_umode_bin = _binary_bazel_out_k8_{LVL}_bin_u_mode_umode_start);
     PROVIDE(_umode_bin_len = _binary_bazel_out_k8_{LVL}_bin_u_mode_umode_size);

--- a/src/smp.rs
+++ b/src/smp.rs
@@ -6,18 +6,23 @@ use core::arch::asm;
 use core::cell::{RefCell, RefMut};
 use drivers::{imsic::Imsic, CpuId, CpuInfo};
 use page_tracking::HypPageAlloc;
-use riscv_pages::{PageSize, SupervisorPageAddr};
+use riscv_pages::{
+    InternalDirty, PageAddr, PageSize, RawAddr, SequentialPages, SupervisorPageAddr,
+};
 use riscv_regs::{sstatus, ReadWriteable, CSR};
 use s_mode_utils::print::*;
 use sbi_rs::api::state;
 use sync::Once;
 
+use crate::hyp_layout::HYP_STACK_PAGES;
 use crate::hyp_map::{HypMap, HypPageTable};
 use crate::umode::UmodeTask;
 use crate::vm_id::VmIdTracker;
 
-// The secondary CPU entry point, defined in start.S.
 extern "C" {
+    static _stack_start: u8;
+    static _stack_end: u8;
+    // The secondary CPU entry point, defined in start.S.
     fn _secondary_start();
 }
 
@@ -30,10 +35,8 @@ pub struct PerCpu {
     page_table: HypPageTable,
     umode_task: Once<RefCell<UmodeTask>>,
     online: Once<bool>,
+    stack_top_addr: SupervisorPageAddr,
 }
-
-/// The number of pages we allocate per CPU: the CPU's stack + it's `PerCpu` structure.
-const PER_CPU_PAGES: u64 = 8;
 
 /// The base address of the per-CPU memory region.
 static PER_CPU_BASE: Once<SupervisorPageAddr> = Once::new();
@@ -43,26 +46,60 @@ impl PerCpu {
     /// boot CPU's) per-CPU area is initialized and loaded into TP as well.
     pub fn init(boot_hart_id: u64, hyp_mem: &mut HypPageAlloc) {
         let cpu_info = CpuInfo::get();
+        let boot_cpu = cpu_info
+            .hart_id_to_cpu(boot_hart_id as u32)
+            .expect("Cannot find boot CPU ID");
 
-        // Find somewhere to put the per-CPU memory.
-        let total_size = PER_CPU_PAGES * cpu_info.num_cpus() as u64 * PageSize::Size4k as u64;
+        // Allocate memory for per-CPU structures.
+        let pcpu_size = core::mem::size_of::<PerCpu>() as u64 * cpu_info.num_cpus() as u64;
         let pcpu_pages =
-            hyp_mem.take_pages_for_hyp_state(PageSize::num_4k_pages(total_size) as usize);
+            hyp_mem.take_pages_for_hyp_state(PageSize::num_4k_pages(pcpu_size) as usize);
         let pcpu_base = pcpu_pages.base();
         PER_CPU_BASE.call_once(|| pcpu_base);
 
+        // Allocate memory for the secondary CPUs stack.
+        let stacks_page_count = HYP_STACK_PAGES * (cpu_info.num_cpus() as u64 - 1);
+        let stacks_pages = hyp_mem.take_pages_for_hyp_state(stacks_page_count as usize);
+
         VmIdTracker::init();
 
-        // Now initialize each PerCpu structure.
+        // Unwrap okay: HYP_STACK_PAGES is non zero.
+        let mut pcpu_stacks =
+            stacks_pages.into_chunks_iter(core::num::NonZeroU64::new(HYP_STACK_PAGES).unwrap());
         for i in 0..cpu_info.num_cpus() {
             let cpu_id = CpuId::new(i);
+            // Boot CPU is special. Doesn't use the PCPU_BASE area as stack.
+            let stack_pages = if cpu_id == boot_cpu {
+                Self::boot_cpu_stack()
+            } else {
+                // Unwrap okay. We allocated the area for `num_cpus() - 1` pages and we skip the
+                // bootstrap CPU above.
+                let pcpu_stack = pcpu_stacks.next().unwrap();
+                // Change state from InternalClean to InternalDirty. Pages are clean but this is not
+                // important for the stack (in the boot CPU case, pages are dirty because the stack is
+                // in use).
+                // Safe because the chunk is composed by hypervisor pages owned by `pcpu_stack`.
+                unsafe {
+                    SequentialPages::<InternalDirty>::from_mem_range(
+                        pcpu_stack.base(),
+                        pcpu_stack.page_size(),
+                        pcpu_stack.len(),
+                    )
+                    .unwrap()
+                }
+            };
+            let stack_top_addr = stack_pages
+                .base()
+                .checked_add_pages(stack_pages.len())
+                .unwrap();
             let ptr = Self::ptr_for_cpu(cpu_id);
             let pcpu = PerCpu {
                 cpu_id,
                 vmid_tracker: RefCell::new(VmIdTracker::new()),
-                page_table: HypMap::get().new_page_table(hyp_mem),
+                page_table: HypMap::get().new_page_table(hyp_mem, stack_pages),
                 umode_task: Once::new(),
                 online: Once::new(),
+                stack_top_addr,
             };
             // Safety: ptr is guaranteed to be properly aligned and point to valid memory owned by
             // PerCpu. No other CPUs are alive at this point, so it cannot be concurrently modified
@@ -70,27 +107,61 @@ impl PerCpu {
             unsafe { core::ptr::write(ptr as *mut PerCpu, pcpu) };
         }
 
-        // Load TP with the address of our PerCpu struct so that we're consistent with secondary
-        // CPUs once they're brought up.
-        let my_tp = Self::ptr_for_cpu(cpu_info.hart_id_to_cpu(boot_hart_id as u32).unwrap()) as u64;
-        unsafe {
-            // Safe since we're the only users of TP.
-            asm!("mv tp, {rs}", rs = in(reg) my_tp)
-        };
-
+        // Initialize TP register and set this CPU online to be consistent with secondary CPUs.
+        Self::setup_this_cpu(boot_hart_id);
         let me = Self::this_cpu();
         me.set_online();
     }
 
+    /// Initializes the TP pointer to point to PerCpu data.
+    pub fn setup_this_cpu(hart_id: u64) {
+        let cpu_info = CpuInfo::get();
+        let cpu_id = cpu_info
+            .hart_id_to_cpu(hart_id as u32)
+            .expect("Cannot find CPU ID");
+
+        // Load TP with the address of our PerCpu struct.
+        let tp = Self::ptr_for_cpu(cpu_id) as u64;
+        unsafe {
+            // Safe since we're the only users of TP.
+            asm!("mv tp, {rs}", rs = in(reg) tp)
+        };
+    }
+
+    fn boot_cpu_stack() -> SequentialPages<InternalDirty> {
+        // Get the pages of the current stack as created by the linker.
+        // Safe because `_stack_start` is created by the linker.
+        let stack_startaddr = unsafe {
+            PageAddr::new(RawAddr::supervisor(core::ptr::addr_of!(_stack_start) as u64))
+                .expect("_stack_start is not page aligned.")
+        };
+        // Safe because `_stack_end` is created by the linker.
+        let stack_endaddr = unsafe {
+            PageAddr::new(RawAddr::supervisor(core::ptr::addr_of!(_stack_end) as u64))
+                .expect("_stack_end is not page aligned.")
+        };
+        // Safe because the pages in this range are in the `HypervisorImage` memory region and are only
+        // used for the boot cpu stack.
+        unsafe {
+            SequentialPages::from_page_range(stack_startaddr, stack_endaddr, PageSize::Size4k)
+                .unwrap()
+        }
+    }
+
     /// Returns a pointer to the `PerCpu` for the given CPU.
     fn ptr_for_cpu(cpu_id: CpuId) -> *const PerCpu {
-        let cpu_end = PER_CPU_BASE
+        let pcpu_addr = PER_CPU_BASE
             .get()
             .unwrap()
-            .checked_add_pages((1 + cpu_id.raw() as u64) * PER_CPU_PAGES)
+            .raw()
+            .checked_increment(cpu_id.raw() as u64 * core::mem::size_of::<PerCpu>() as u64)
             .unwrap();
-        let pcpu_addr = cpu_end.bits() - core::mem::size_of::<PerCpu>() as u64;
-        pcpu_addr as *const PerCpu
+        pcpu_addr.bits() as *const PerCpu
+    }
+
+    /// Returns the top of the stack for this CPU.
+    fn stack_top_addr(&self) -> SupervisorPageAddr {
+        self.stack_top_addr
     }
 
     /// Returns this CPU's `PerCpu` structure.
@@ -171,24 +242,23 @@ pub fn start_secondary_cpus() {
             continue;
         }
 
-        // Start the hart with it's PerCpu struct in A1; _secondary_start will stash it in TP.
-        let pcpu = PerCpu::ptr_for_cpu(cpu_id);
+        // Start the hart with its stack physical address in A1.
+        // Safe since it is set up to point to a valid PerCpu struct in init().
+        let pcpu = unsafe { PerCpu::ptr_for_cpu(cpu_id).as_ref().unwrap() };
+        let sp = pcpu.stack_top_addr();
+
         // Safety: _secondary_start is guaranteed by the linker to be the code to start secondary
         // CPUs. pcpu will only be shared with one cpu.
         unsafe {
             state::hart_start(
                 cpu_info.cpu_to_hart_id(cpu_id).unwrap() as u64,
                 (_secondary_start as *const fn()) as u64,
-                pcpu as u64,
+                sp.bits(),
             )
             .expect("Failed to start CPU {i}");
         }
 
         // Synchronize with the CPU coming online. TODO: Timeout?
-        let pcpu = unsafe {
-            // Safe since TP is set up to point to a valid PerCpu struct in init().
-            pcpu.as_ref().unwrap()
-        };
         pcpu.online.wait();
     }
 

--- a/src/start.S
+++ b/src/start.S
@@ -31,6 +31,8 @@ _start:
     csrw satp, a0
     // Flush TLBs.
     sfence.vma
+    // Switch to VA-mapped stack.
+    li  sp, {HYP_STACK_TOP}
     call primary_main
     j    wfi_loop
 
@@ -44,14 +46,15 @@ _secondary_start:
 .option pop
     csrw sstatus, zero
     csrw sie, zero
-    // TP holds the address of our PerCpu struct, which is also the top of our stack.
+    // At start, A1 holds the top of the stack.
     mv   sp, a1
-    mv   tp, a1
     call secondary_init
     // a0 contains SATP value
     csrw satp, a0
     // Flush TLBs.
     sfence.vma
+    // Switch to VA-mapped stack.
+    li   sp, {HYP_STACK_TOP}
     call secondary_main
 wfi_loop:
     wfi

--- a/src/start.S
+++ b/src/start.S
@@ -26,7 +26,12 @@ _start:
     blt  a3, a4, 1b
 
     la   sp, _stack_end
-    call kernel_init
+    call primary_init
+    // a0 contains SATP value
+    csrw satp, a0
+    // Flush TLBs.
+    sfence.vma
+    call primary_main
     j    wfi_loop
 
 // The entry point for secondary CPUs.
@@ -43,6 +48,11 @@ _secondary_start:
     mv   sp, a1
     mv   tp, a1
     call secondary_init
+    // a0 contains SATP value
+    csrw satp, a0
+    // Flush TLBs.
+    sfence.vma
+    call secondary_main
 wfi_loop:
     wfi
     j    wfi_loop


### PR DESCRIPTION
Small patches, profound changes. Fixes #240 

This PR maps salus stack in a VA space. Initialization happens now in two stages.

The first stage (init) is when everything (including stack) is mapped in a contiguous physical mapping in the VA.
The second stage (launch) is called once the page table and the va-mapped stack has been setup.

Ideally, we whould like to push as much as possible into the second stage. But this is future work and requires more consideration.
