### PR TITLE
.github: Only run per commit build check on PRs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Run tests
       run: bazel test //:test-all
     - name: Check all commits build
+      if: ${{ github.event_name == 'pull_request' }}
       run: |
         set -e
         commits=$(git rev-list origin/${{ github.base_ref }}..${{ github.sha }})


### PR DESCRIPTION
The sequence of commits between the head of the PR and the base branch
point is only available on PRs therefore limit the running of commit
buildability check to PRs only.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
