### PR TITLE
build: Fix clippy issue

### DIFF
--- a/src/trap.rs
+++ b/src/trap.rs
@@ -206,7 +206,7 @@ fn pc_in_extable(pc: u64) -> bool {
 
 #[no_mangle]
 extern "C" fn handle_stack_overflow(tf_ptr: *mut TrapFrame) {
-    let mut tf = unsafe { tf_ptr.as_mut().unwrap() };
+    let tf = unsafe { tf_ptr.as_mut().unwrap() };
     println!("Stack overflow (please note: T1 register is clobbered below)");
     println!("{}", tf);
     panic!("Stack overflow!");


### PR DESCRIPTION
Resolves following clippy warning:
```rust
warning: variable does not need to be mutable                                                
   --> src/trap.rs:209:9                                                                     
    |                                                                                        
209 |     let mut tf = unsafe { tf_ptr.as_mut().unwrap() };                                  
    |         ----^^                                                                         
    |         |                                                                              
    |         help: remove this `mut`                                                        
    |                                                                                        
    = note: `#[warn(unused_mut)]` on by default                                              

warning: 1 warning emitted
```