### PR TITLE
sbi: Update for sbi-rs changes to SbiReturn type

### DIFF
--- a/s-mode-utils/src/sbi_console.rs
+++ b/s-mode-utils/src/sbi_console.rs
@@ -60,7 +60,7 @@ impl ConsoleWriter for SbiConsoleV01 {
             // Safety: message doesn't contain pointers and the ecall doesn't touch memory so this
             // is trivially safe.
             unsafe {
-                ecall_send(&message).unwrap();
+                ecall_send::<()>(&message).unwrap();
             }
         }
     }

--- a/src/host_vm.rs
+++ b/src/host_vm.rs
@@ -429,15 +429,15 @@ impl HostVmRunner {
                             }
                             Ok(DebugConsole(DebugConsoleFunction::PutString { len, addr })) => {
                                 let sbi_ret = match self.handle_put_string(&vm, addr, len) {
-                                    Ok(n) => SbiReturn::success(n),
+                                    Ok(n) => SbiReturn::success(n as i64),
                                     Err(n) => SbiReturn {
                                         error_code: SbiError::InvalidAddress as i64,
-                                        return_value: n,
+                                        return_value: n as i64,
                                     },
                                 };
 
                                 self.gprs.set_reg(GprIndex::A0, sbi_ret.error_code as u64);
-                                self.gprs.set_reg(GprIndex::A1, sbi_ret.return_value);
+                                self.gprs.set_reg(GprIndex::A1, sbi_ret.return_value as u64);
                             }
                             Ok(PutChar(c)) => {
                                 print!("{}", c as u8 as char);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -223,7 +223,7 @@ impl From<EcallResult<u64>> for EcallAction {
     fn from(result: EcallResult<u64>) -> EcallAction {
         use EcallAction::*;
         match result {
-            Ok(val) => Continue(SbiReturn::success(val)),
+            Ok(val) => Continue(SbiReturn::success(val as i64)),
             Err(EcallError::Sbi(e)) => Continue(e.into()),
             Err(EcallError::PageFault(pf, e, addr)) => {
                 use PageFaultType::*;
@@ -963,7 +963,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
             // report real values here.
             _ => 0,
         };
-        SbiReturn::success(ret)
+        SbiReturn::success(ret as i64)
     }
 
     fn handle_debug_console(&self, debug_con_func: DebugConsoleFunction) -> EcallAction {
@@ -2382,7 +2382,7 @@ impl<'a, T: GuestStagePagingMode> FinalizedVm<'a, T> {
         match result {
             Ok(r) => EcallAction::Break(
                 VmExitCause::ResumableEcall(SbiMessage::CoveGuest(guest_func)),
-                SbiReturn::success(r),
+                SbiReturn::success(r as i64),
             ),
             Err(_) => result.into(),
         }

--- a/src/vm_cpu.rs
+++ b/src/vm_cpu.rs
@@ -917,7 +917,7 @@ impl<'vcpu, 'pages, 'host, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, '
             }
             SbiReturnType::Standard(ret) => {
                 self.set_gpr(GprIndex::A0, ret.error_code as u64);
-                self.set_gpr(GprIndex::A1, ret.return_value);
+                self.set_gpr(GprIndex::A1, ret.return_value as u64);
             }
         }
     }
@@ -1157,7 +1157,7 @@ impl<'vcpu, 'pages, 'host, T: GuestStagePagingMode> ActiveVmCpu<'vcpu, 'pages, '
                     }
                     _ => SbiReturnType::Standard(SbiReturn {
                         error_code: self.host_context.guest_gpr(GprIndex::A0) as i64,
-                        return_value: self.host_context.guest_gpr(GprIndex::A1),
+                        return_value: self.host_context.guest_gpr(GprIndex::A1) as i64,
                     }),
                 };
 

--- a/test-workloads/src/bin/tellus.rs
+++ b/test-workloads/src/bin/tellus.rs
@@ -535,7 +535,9 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
         len: core::mem::size_of::<sbi_rs::TsmInfo>() as u64,
     });
     // Safety: The passed info pointer is bogus and nothing should be written to our memory.
-    unsafe { ecall_send(&msg).expect_err("TsmGetInfo succeeded with an invalid pointer") };
+    unsafe {
+        ecall_send::<()>(&msg).expect_err("TsmGetInfo succeeded with an invalid pointer");
+    };
 
     // Donate the pages necessary to create the TVM.
     // Safety: The passed-in pages are unmapped and we do not access them again until they're
@@ -881,14 +883,14 @@ extern "C" fn kernel_init(hart_id: u64, fdt_addr: u64) {
                                 addr,
                                 len,
                             ) {
-                                Ok(n) => SbiReturn::success(n),
+                                Ok(n) => SbiReturn::success(n as i64),
                                 Err(n) => SbiReturn {
                                     error_code: SbiError::InvalidAddress as i64,
-                                    return_value: n,
+                                    return_value: n as i64,
                                 },
                             };
                             shmem.set_gpr(GprIndex::A0 as usize, sbi_ret.error_code as u64);
-                            shmem.set_gpr(GprIndex::A1 as usize, sbi_ret.return_value);
+                            shmem.set_gpr(GprIndex::A1 as usize, sbi_ret.return_value as u64);
                         }
                         Ok(PutChar(c)) => {
                             print!("{}", c as u8 as char);


### PR DESCRIPTION
The SbiReturn type now contains a signed value for the return value to
match the spec.

Fixes: #38

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
