### PR TITLE
ci: Build each commit in the forward order

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,9 +36,8 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       run: |
         set -e
-        commits=$(git rev-list origin/${{ github.base_ref }}..${{ github.sha }})
+        commits=$(git rev-list --reverse origin/${{ github.base_ref }}..${{ github.sha }})
         for commit in $commits; do git checkout $commit; bazel build //:salus-all; done
-        git checkout ${{ github.sha }}
     - name: Copy bins
       run: mkdir test-bins && cp bazel-bin/salus test-bins/ && cp bazel-bin/test-workloads/tellus_guestvm test-bins/
     - name: QEMU test


### PR DESCRIPTION
By default, git rev-list returns a list of commits in reverse order. This caused an unexpected behavior with the tellus/guestvm integration tests. Because the last commit to be built was the first commit of the pull request, both salus and tellus_guestvm binaries didn't include all the changes from that same pull request.

The way to fix this is by using --reverse option from git rev-list, so that we can walk through each commit in the forward direction.