### PR TITLE
ci: Run clippy with warnings treated as errors

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,7 +16,7 @@ build --@rules_rust//rust/toolchain/channel=nightly
 
 # Rust Clippy configuration:
 # - Deny on missing docs
-build --@rules_rust//:clippy_flags=-Dmissing-docs
+build --@rules_rust//:clippy_flags=-Dmissing-docs,-Dwarnings
 
 # Use the workspace status feature to include the git commit in the build:
 # https://bazel.build/docs/user-manual#workspace-status


### PR DESCRIPTION
We don't want clippy warnings to be merged into the main branch, which is why we use -Dwarnings clippy flag to indicate that all warnings should be treated as errors. This will indicate the bazel build failed and prevent any pull request with such warnings from being merged.