### PR TITLE
.github: Reorder steps to reduce build time

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,12 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: 0
+    - name: Check all commits build
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        set -e
+        commits=$(git rev-list --reverse origin/${{ github.base_ref }}..${{ github.sha }})
+        for commit in $commits; do git checkout $commit; bazel build //:salus-all; done
     - name: Build
       run: bazel build //:salus-all
     - name: Lint
@@ -32,12 +38,6 @@ jobs:
       run: bazel test //:rustfmt-all
     - name: Run tests
       run: bazel test //:test-all
-    - name: Check all commits build
-      if: ${{ github.event_name == 'pull_request' }}
-      run: |
-        set -e
-        commits=$(git rev-list --reverse origin/${{ github.base_ref }}..${{ github.sha }})
-        for commit in $commits; do git checkout $commit; bazel build //:salus-all; done
     - name: Copy bins
       run: mkdir test-bins && cp bazel-bin/salus test-bins/ && cp bazel-bin/test-workloads/tellus_guestvm test-bins/
     - name: QEMU test


### PR DESCRIPTION
Now that the checks for commit buildability run older to newest (HEAD)
if this check is done ahead of the general build step then on PR builds
the build step will become an effective no-op reducing the total time to
run a PR based build.

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
