### PR TITLE
Improve boot-time

### DIFF
--- a/riscv-page-tables/src/page_table.rs
+++ b/riscv-page-tables/src/page_table.rs
@@ -1043,7 +1043,6 @@ impl<'a, T: FirstStagePagingMode> FirstStageMapper<'a, T> {
     /// # Safety
     ///
     /// Don't create aliases.
-    #[allow(dead_code)]
     pub unsafe fn map_contiguous(
         &self,
         start_vaddr: PageAddr<T::MappedAddressSpace>,

--- a/riscv-page-tables/src/page_table.rs
+++ b/riscv-page-tables/src/page_table.rs
@@ -970,7 +970,7 @@ impl<'a, T: FirstStagePagingMode> FirstStageMapper<'a, T> {
     /// # Safety
     ///
     /// Don't create aliases.
-    pub unsafe fn map_addr(
+    pub unsafe fn map_one(
         &self,
         vaddr: PageAddr<T::MappedAddressSpace>,
         paddr: PageAddr<SupervisorPhys>,

--- a/riscv-page-tables/src/sv48.rs
+++ b/riscv-page-tables/src/sv48.rs
@@ -115,7 +115,7 @@ mod test {
                     page.size() as usize / mem::size_of::<u64>(),
                 );
                 slice[0] = 0xdeadbeef;
-                assert!(mapper.map_addr(gpa, page.addr(), pte_fields).is_ok());
+                assert!(mapper.map_one(gpa, page.addr(), pte_fields).is_ok());
             }
         }
     }

--- a/src/hyp_map.rs
+++ b/src/hyp_map.rs
@@ -135,7 +135,7 @@ impl HwMapRegion {
             // Safety: all regions come from the HW memory map. we will create exactly one mapping for
             // each page and will switch to using that mapping exclusively.
             unsafe {
-                mapper.map_addr(virt, phys, self.pte_fields).unwrap();
+                mapper.map_one(virt, phys, self.pte_fields).unwrap();
             }
         }
     }
@@ -214,7 +214,7 @@ impl UmodeElfRegion {
             // Safety: all regions are user mappings. User mappings are not considered aliases because
             // they cannot be accessed by supervisor mode directly (sstatus.SUM needs to be 1).
             unsafe {
-                mapper.map_addr(virt, phys, self.pte_fields).unwrap();
+                mapper.map_one(virt, phys, self.pte_fields).unwrap();
             }
         }
     }
@@ -300,7 +300,7 @@ impl UmodeInputRegion {
             // physical mappings no CPU will be able to access these pages through the U-mode
             // mappings.
             unsafe {
-                mapper.map_addr(virt, phys, pte_fields).unwrap();
+                mapper.map_one(virt, phys, pte_fields).unwrap();
             }
         }
         // Safety: the range `(start..max_addr)` is mapped in U-mode as read-only and was uniquely
@@ -367,7 +367,7 @@ impl HypStackRegion {
             // Safety: we unmapped the stack pages from the 1:1 map, so no aliases have been created
             // in this page table.
             unsafe {
-                mapper.map_addr(virt, phys, pte_fields).unwrap();
+                mapper.map_one(virt, phys, pte_fields).unwrap();
             }
         }
     }
@@ -490,7 +490,7 @@ impl UmodeSlotMapper<'_> {
         // Safety: pages are mapped in user mode, so no aliases of salus mappings have been
         // created. Pages are owned by guest, so no mapping of hypervisor pages are created.
         self.mapper
-            .map_addr(vaddr, paddr, self.perms)
+            .map_one(vaddr, paddr, self.perms)
             .map_err(|_| Error::MapFailed)
     }
 }


### PR DESCRIPTION
We are currently walking TWO times the page tables for each PTE we map.

One when we lock, the other when we map. This is the main reason why our paging code is so slow.

This patch  addresses both issues for the hypervisor mapping case.

This is just the first step to make our paging code faster. On my machine this patch reduces the boot of salus (real time) from 24 seconds to 7 seconds.
