### PR TITLE
Reduce use of .expect() during boot

### DIFF
--- a/page-tracking/src/hw_mem_map.rs
+++ b/page-tracking/src/hw_mem_map.rs
@@ -114,6 +114,9 @@ pub enum Error {
 
     /// Creation of SequentialPages failed
     SequentialPages,
+
+    /// Hypervisor image isn't in contiguous DRAM
+    NonContiguousHypervisorImage,
 }
 /// Holds the result of memory map operations.
 pub type Result<T> = result::Result<T, Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,7 @@ fn build_memory_map<T: GuestStagePagingMode>(fdt: &Fdt) -> MemMapResult<HwMemMap
         .memory_regions()
         .find(|r| start >= r.base() && stack_end <= r.base().checked_add(r.size()).unwrap())
         .map(|r| RawAddr::supervisor(r.base()))
-        .expect("Hypervisor image does not reside in a contiguous range of DRAM");
+        .ok_or(MemMapError::NonContiguousHypervisorImage)?;
 
     // Reserve everything from the start of the region the hypervisor is in up until the top of
     // the hypervisor stack.

--- a/src/start.S
+++ b/src/start.S
@@ -26,14 +26,14 @@ _start:
     blt  a3, a4, 1b
 
     la   sp, _stack_end
-    call primary_init
+    call _primary_init
     // a0 contains SATP value
     csrw satp, a0
     // Flush TLBs.
     sfence.vma
     // Switch to VA-mapped stack.
     li  sp, {HYP_STACK_TOP}
-    call primary_main
+    call _primary_main
     j    wfi_loop
 
 // The entry point for secondary CPUs.
@@ -48,14 +48,14 @@ _secondary_start:
     csrw sie, zero
     // At start, A1 holds the top of the stack.
     mv   sp, a1
-    call secondary_init
+    call _secondary_init
     // a0 contains SATP value
     csrw satp, a0
     // Flush TLBs.
     sfence.vma
     // Switch to VA-mapped stack.
     li   sp, {HYP_STACK_TOP}
-    call secondary_main
+    call _secondary_main
 wfi_loop:
     wfi
     j    wfi_loop


### PR DESCRIPTION
- main: Return error from build_memory_map() for hypervisor image check
- main: Don't use .expect() for startup error handling
