### PR TITLE
Increase the default number of imsic file to 5

### DIFF
--- a/scripts/common_variables
+++ b/scripts/common_variables
@@ -50,4 +50,4 @@ EXTRA_CPU=${VECTORS:+",v=on,vlen=256,elen=64"}
 CPU_TYPE=rv64${EXTRA_CPU}
 CPU_ARGS="${CPU_TYPE},x-smaia=true,x-ssaia=true,sscofpmf=true"
 
-MACH_ARGS="-M virt,aia=aplic-imsic,aia-guests=4 -cpu ${CPU_ARGS} -smp ${NCPU} -m ${MEM_SIZE} -nographic"
+MACH_ARGS="-M virt,aia=aplic-imsic,aia-guests=5 -cpu ${CPU_ARGS} -smp ${NCPU} -m ${MEM_SIZE} -nographic"


### PR DESCRIPTION
If host scheduler tries to schedule more number of vcpus on a pcpu that its number of imsic file, it will result in TVM failure. This is a common scenario when we run two TVMs with 2 vcpus which is a common test case.

Increasing the number of imsic files only helps to run the bare minimum setup in multi-TVM SMP configuration.

In the long run, the host kernel can't do much about it except notifying the VMM about the correct reason i.e. insufficient imsic files. Its upto the VMM to decide whether it wants to show appropriate error to the user or perform lazy pinning if possible.