### PR TITLE
Remove last use of .expect() during Salus boot

### DIFF
--- a/drivers/src/iommu/mod.rs
+++ b/drivers/src/iommu/mod.rs
@@ -89,7 +89,7 @@ mod tests {
                 .unwrap()
                 .build()
         };
-        let hyp_mem = HypPageAlloc::new(&mut hw_map);
+        let hyp_mem = HypPageAlloc::new(&mut hw_map).unwrap();
         let (page_tracker, host_pages) = PageTracker::from(hyp_mem, PageSize::Size4k as u64);
         // Leak the backing ram so it doesn't get freed
         std::mem::forget(backing_mem);

--- a/riscv-page-tables/src/test_stubs.rs
+++ b/riscv-page-tables/src/test_stubs.rs
@@ -35,7 +35,7 @@ pub fn stub_sys_memory() -> StubState {
             .unwrap()
             .build()
     };
-    let mut hyp_mem = HypPageAlloc::new(&mut hw_map);
+    let mut hyp_mem = HypPageAlloc::new(&mut hw_map).unwrap();
     let root_pages = hyp_mem.take_pages_for_host_state_with_alignment(4, Sv48x4::TOP_LEVEL_ALIGN);
     let pte_pages = hyp_mem.take_pages_for_host_state(3);
     let (page_tracker, host_pages) = PageTracker::from(hyp_mem, MEM_ALIGN as u64);

--- a/src/main.rs
+++ b/src/main.rs
@@ -399,7 +399,7 @@ impl Display for Error {
             CpuMissingFeature(feature) => write!(f, "Missing required CPU feature: {:?}", feature),
             CpuTopologyGeneration(e) => write!(f, "Failed to generate CPU topology: {}", e),
             CreateHypervisorMap(e) => write!(f, "Cannot create Hypervisor map: {:?}", e),
-            CreateSmpState(e) => write!(f, "Error during (per CPU) SMP setup: {:?}", e),
+            CreateSmpState(e) => write!(f, "Error during (per CPU) SMP setup: {}", e),
             FdtCreation(e) => write!(f, "Failed to construct device-tree: {}", e),
             FdtParsing(e) => write!(f, "Failed to read FDT: {}", e),
             HeapOutOfSpace => write!(f, "Not enough free memory for hypervisor heap"),
@@ -407,7 +407,7 @@ impl Display for Error {
             LoadUserMode(e) => write!(f, "Cannot load user-mode ELF binary: {:?}", e),
             RequiredDeviceProbe(e) => write!(f, "Failed to probe required device: {}", e),
             SetupUserMode(e) => write!(f, "Failed to setup user-mode: {:?}", e),
-            StartSecondaryCpus(e) => write!(f, "Error running secondary CPUs: {:?}", e),
+            StartSecondaryCpus(e) => write!(f, "Error running secondary CPUs: {}", e),
             UserModeNop(e) => write!(f, "Failed to execute a NOP in user-mode: {:?}", e),
         }
     }


### PR DESCRIPTION
This PR removes the last use of .expect() during the Salus boot replacing with error reporting.

- main: Use fmt::Display for errors that have it
- hyp_map, smp: Propagate error from stack memory allocation
- page-tracking: Propagate errors from hypervisor page allocator

See: #100 