### PR TITLE
build: Treat unit tests warnings as errors

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -217,6 +217,7 @@ rust_test(
         "-Ctarget-feature=+v",
         "-Clink-arg=-Tsrc/salus-test.lds",
         "--codegen=link-arg=-nostartfiles",
+        "-Dwarnings",
     ],
     deps = salus_deps,
 )

--- a/data-model/BUILD
+++ b/data-model/BUILD
@@ -26,6 +26,9 @@ rust_test(
     name = "data-model-test",
     testonly = True,
     crate = ":data-model",
+    rustc_flags = [
+        "-Dwarnings",
+    ],
 )
 
 rust_doc(

--- a/device-tree/BUILD
+++ b/device-tree/BUILD
@@ -28,6 +28,9 @@ rustfmt_test(
 rust_test(
     name = "device-tree-test",
     crate = ":device-tree",
+    rustc_flags = [
+        "-Dwarnings",
+    ],
 )
 
 rust_doc(

--- a/drivers/BUILD
+++ b/drivers/BUILD
@@ -42,6 +42,9 @@ rustfmt_test(
 rust_test(
     name = "drivers-test",
     crate = ":drivers",
+    rustc_flags = [
+        "-Dwarnings",
+    ],
 )
 
 rust_doc(

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -215,7 +215,7 @@ mod tests {
     #[test]
     fn build_cpu_info() {
         let tree = stub_tree();
-        CpuInfo::parse_from(&tree);
+        CpuInfo::parse_from(&tree).unwrap();
 
         let cpu_info = CpuInfo::get();
         assert!(cpu_info.has_sstc());
@@ -242,7 +242,7 @@ mod tests {
     #[test]
     fn probe_imsic() {
         let tree = stub_tree();
-        CpuInfo::parse_from(&tree);
+        CpuInfo::parse_from(&tree).unwrap();
         let mut mem_map = stub_mem_map();
         Imsic::probe_from(&tree, &mut mem_map).unwrap();
 

--- a/hyp-alloc/BUILD
+++ b/hyp-alloc/BUILD
@@ -28,6 +28,9 @@ rustfmt_test(
 rust_test(
     name = "hyp-alloc-test",
     crate = ":hyp-alloc",
+    rustc_flags = [
+        "-Dwarnings",
+    ],
 )
 
 rust_doc(

--- a/mtt/BUILD
+++ b/mtt/BUILD
@@ -30,4 +30,7 @@ rustfmt_test(
 rust_test(
     name = "mtt-test",
     crate = ":mtt",
+    rustc_flags = [
+        "-Dwarnings",
+    ],
 )

--- a/page-tracking/BUILD
+++ b/page-tracking/BUILD
@@ -29,6 +29,9 @@ rustfmt_test(
 rust_test(
     name = "page-tracking-test",
     crate = ":page-tracking",
+    rustc_flags = [
+        "-Dwarnings",
+    ],
 )
 
 rust_doc(

--- a/riscv-elf/BUILD
+++ b/riscv-elf/BUILD
@@ -25,6 +25,9 @@ rustfmt_test(
 rust_test(
     name = "riscv-elf-test",
     crate = ":riscv-elf",
+    rustc_flags = [
+        "-Dwarnings",
+    ],
 )
 
 rust_doc(

--- a/riscv-page-tables/BUILD
+++ b/riscv-page-tables/BUILD
@@ -29,6 +29,9 @@ rustfmt_test(
 rust_test(
     name = "riscv-page-tables-test",
     crate = ":riscv-page-tables",
+    rustc_flags = [
+        "-Dwarnings",
+    ],
 )
 
 rust_doc(

--- a/riscv-pages/BUILD
+++ b/riscv-pages/BUILD
@@ -27,6 +27,9 @@ rustfmt_test(
 rust_test(
     name = "riscv-pages-test",
     crate = ":riscv-pages",
+    rustc_flags = [
+        "-Dwarnings",
+    ],
 )
 
 rust_doc(


### PR DESCRIPTION
Turn on the rustc flag `-Dwarnings` for all bazel rust tests so that all warnings would show up as errors.

Fixes #309