### PR TITLE
page-tracking: Optimize huge pages maintenance

### DIFF
--- a/page-tracking/src/page_info.rs
+++ b/page-tracking/src/page_info.rs
@@ -136,6 +136,24 @@ impl PageInfo {
         self.state
     }
 
+    /// Returns the list of owners.
+    pub fn owners(&self) -> PageOwnerVec {
+        self.owners.clone()
+    }
+
+    /// Updates the current page info.
+    pub fn update(
+        &mut self,
+        mem_type: MemType,
+        state: PageState,
+        owners: PageOwnerVec,
+    ) -> PageTrackingResult<()> {
+        self.state = state;
+        self.owners = owners;
+        self.mem_type = mem_type;
+        Ok(())
+    }
+
     /// Returns if the page is free.
     pub fn is_free(&self) -> bool {
         matches!(self.state, PageState::Free)

--- a/page-tracking/src/page_list.rs
+++ b/page-tracking/src/page_list.rs
@@ -47,7 +47,7 @@ impl<P: PhysPage> PageList<P> {
     ) -> Self {
         let mut len = 1;
         let mut tail = head;
-        while let Some(addr) = page_tracker.linked_page(tail, page_size) {
+        while let Some(addr) = page_tracker.linked_page(tail) {
             len += 1;
             tail = addr;
         }
@@ -68,8 +68,7 @@ impl<P: PhysPage> PageList<P> {
             return Err(PageTrackingError::InvalidPageSize);
         }
         if let Some(tail_addr) = self.tail {
-            self.page_tracker
-                .link_pages(tail_addr, page.addr(), page.size())?;
+            self.page_tracker.link_pages(tail_addr, page.addr())?;
             self.tail = Some(page.addr());
         } else {
             self.head = Some(page.addr());
@@ -82,7 +81,7 @@ impl<P: PhysPage> PageList<P> {
     /// Removes the head of the list.
     pub fn pop(&mut self) -> Option<P> {
         let addr = self.head?;
-        self.head = self.page_tracker.unlink_page(addr, self.page_size);
+        self.head = self.page_tracker.unlink_page(addr);
         if self.head.is_none() {
             // List is now empty.
             self.tail = None;
@@ -113,7 +112,7 @@ impl<P: PhysPage> PageList<P> {
             return true;
         }
         let mut prev = self.head.unwrap();
-        while let Some(addr) = self.page_tracker.linked_page(prev, self.page_size) {
+        while let Some(addr) = self.page_tracker.linked_page(prev) {
             if let Some(next) = prev.checked_add_pages_with_size(1, self.page_size) && addr == next {
                 prev = next;
             } else {

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -1870,6 +1870,11 @@ impl<'a, T: GuestStagePagingMode> FinalizedVmPages<'a, T> {
             .page_tracker
             .unblock_page(pa, one_size_larger_page_size)
             .unwrap();
+        // Unwrap ok: Sub pages exist.
+        self.inner
+            .page_tracker
+            .copy_head_page_to_sub_pages(pa, one_size_larger_page_size)
+            .unwrap();
         Ok(())
     }
 


### PR DESCRIPTION
The goal is to optimize the way the PageTracker updates huge pages, by acting only on the head page rather than updating all the 4k pages from the huge page range.

When a huge page is mapped into a TVM, we can manage only the head page through the block/unblock lifecycle. When the TVM gets destroyed, we need all the pages to be back to a proper state, which is why we force the subpages to be the same state as the head page.

We also need to handle the case where a page range is shared differently. In that case, we can't assume two TVMs share the page at the same granularity, which is why we can't manipulate only the head page, but instead we must update all the subpages.

Last thing, we must handle a page demotion in a special way, by updating all the subpages states, given the demotion happened while the PageTracker was operating only on the head page of the huge page.