### PR TITLE
Parameterize gdb script to enable different version of gdb to be run

### DIFF
--- a/scripts/common_variables
+++ b/scripts/common_variables
@@ -51,3 +51,6 @@ CPU_TYPE=rv64${EXTRA_CPU}
 CPU_ARGS="${CPU_TYPE},x-smaia=true,x-ssaia=true,sscofpmf=true"
 
 MACH_ARGS="-M virt,aia=aplic-imsic,aia-guests=5 -cpu ${CPU_ARGS} -smp ${NCPU} -m ${MEM_SIZE} -nographic"
+
+GDB=${GDB:-riscv64-unknown-elf-gdb}
+GDB_ARGS=${GDB_ARGS:-}

--- a/scripts/run_gdb.sh
+++ b/scripts/run_gdb.sh
@@ -3,4 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-riscv64-unknown-elf-gdb bazel-bin/src/salus --ex "target remote localhost:1234"
+. scripts/common_variables
+
+set -x
+
+${GDB} ${SALUS_BINS}salus ${GDB_ARGS} --ex "target remote localhost:1234"


### PR DESCRIPTION
This change was inspired by the desire to run my own copy of gdb with tui (Text User Interface) enabled.