### PR TITLE
Fix 'Property not found' when executing 'qemu-system-riscv64'

### DIFF
--- a/scripts/common_variables
+++ b/scripts/common_variables
@@ -48,7 +48,7 @@ EXTRA_QEMU_ARGS=${EXTRA_QEMU_ARGS:-""}
 EXTRA_CPU=",v=on,vlen=256,elen=64"
 
 CPU_TYPE=rv64${EXTRA_CPU}
-CPU_ARGS="${CPU_TYPE},smaia=true,ssaia=true,sscofpmf=true"
+CPU_ARGS="${CPU_TYPE},x-smaia=true,x-ssaia=true,sscofpmf=true"
 
 MACH_ARGS="-M virt,aia=aplic-imsic,aia-guests=5 -cpu ${CPU_ARGS} -smp ${NCPU} -m ${MEM_SIZE} -nographic"
 


### PR DESCRIPTION
When executing `qemu-system-riscv64`, I encounter an error indicating that the properties `smaia` and `ssaia` were not found.

After reviewing QEMU’s source code:
- https://github.com/rivosinc/qemu/blob/salus-integration-10312022/target/riscv/cpu.c#L1067
- https://github.com/rivosinc/qemu/blob/salus-integration-10312022/target/riscv/cpu.c#L1068

I found that the correct property names are `x-smaia` and `x-ssaia` (in `scripts/common_variables`).