### PR TITLE
ci: github - submodule update before build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         set -e
         commits=$(git rev-list --reverse origin/${{ github.base_ref }}..${{ github.sha }})
-        for commit in $commits; do git checkout $commit; bazel build //:salus-all; done
+        for commit in $commits; do git checkout $commit; git submodule update; bazel build //:salus-all; done
     - name: Build
       run: bazel build //:salus-all
     - name: Lint


### PR DESCRIPTION
there is a bug where a PR updates a submodule in a commit other than the first in the chain. The tree will have the updated submodule from the later commit instead of the one that was current for the commit being tested. This is because the CI script didn't update the submodules before testing each commit.

Add the update so that each commit is tested with the submodules it specifies.