### PR TITLE
Guest console read support via Debug Console Read SBI function

### DIFF
--- a/drivers/src/uart.rs
+++ b/drivers/src/uart.rs
@@ -65,12 +65,12 @@ impl UartDriver {
             base_address: Mutex::new(NonNull::new(base_address as _).unwrap()),
         };
         UART_DRIVER.call_once(|| uart);
-        Console::set_writer(UART_DRIVER.get().unwrap());
+        Console::set_driver(UART_DRIVER.get().unwrap());
         Ok(())
     }
 }
 
-impl ConsoleWriter for UartDriver {
+impl ConsoleDriver for UartDriver {
     /// Write an entire byte sequence to this UART.
     fn write_bytes(&self, bytes: &[u8]) {
         let base_address = self.base_address.lock();

--- a/s-mode-utils/src/sbi_console.rs
+++ b/s-mode-utils/src/sbi_console.rs
@@ -6,7 +6,7 @@ use sbi_rs::api::debug_console::console_puts;
 use sbi_rs::{ecall_send, SbiMessage};
 use sync::{Mutex, Once};
 
-use crate::print::{Console, ConsoleWriter};
+use crate::print::{Console, ConsoleDriver};
 
 /// Driver for an SBI based console.
 pub struct SbiConsole {
@@ -23,11 +23,11 @@ impl SbiConsole {
             buffer: Mutex::new(console_buffer),
         };
         SBI_CONSOLE.call_once(|| console);
-        Console::set_writer(SBI_CONSOLE.get().unwrap());
+        Console::set_driver(SBI_CONSOLE.get().unwrap());
     }
 }
 
-impl ConsoleWriter for SbiConsole {
+impl ConsoleDriver for SbiConsole {
     /// Write an entire byte sequence to the SBI console.
     fn write_bytes(&self, bytes: &[u8]) {
         let mut buffer = self.buffer.lock();
@@ -48,11 +48,11 @@ static SBI_CONSOLE_V01: SbiConsoleV01 = SbiConsoleV01 {};
 impl SbiConsoleV01 {
     /// Sets the SBI legacy console as the system console.
     pub fn set_as_console() {
-        Console::set_writer(&SBI_CONSOLE_V01);
+        Console::set_driver(&SBI_CONSOLE_V01);
     }
 }
 
-impl ConsoleWriter for SbiConsoleV01 {
+impl ConsoleDriver for SbiConsoleV01 {
     /// Write an entire byte sequence to the SBI console.
     fn write_bytes(&self, bytes: &[u8]) {
         for &b in bytes {

--- a/src/host_vm.rs
+++ b/src/host_vm.rs
@@ -4,6 +4,7 @@
 
 use arrayvec::{ArrayString, ArrayVec};
 use core::{fmt, num, ops::ControlFlow, slice};
+use data_model::VolatileSlice;
 use device_tree::{DeviceTree, DeviceTreeResult, DeviceTreeSerializer};
 use drivers::{imsic::*, iommu::*, pci::*, CpuId, CpuInfo};
 use page_tracking::collections::PageBox;
@@ -21,7 +22,7 @@ use crate::guest_tracking::{GuestVm, Guests, Result as GuestTrackingResult};
 use crate::smp;
 use crate::vm::{FinalizedVm, Vm};
 use crate::vm_cpu::{VmCpu, VmCpuExitReporting, VmCpuParent, VmCpus};
-use crate::vm_pages::VmPages;
+use crate::vm_pages::{PinnedPages, Result as VmPagesResult, VmPages};
 
 // Page size of host VM pages.
 pub const HOST_VM_ALIGN: PageSize = PageSize::Size2M;
@@ -392,6 +393,20 @@ impl core::fmt::Display for MmioEmulationError {
     }
 }
 
+struct PinnedBuffer<'a> {
+    slice: VolatileSlice<'a>,
+    // `_pinned` must remain in scope to keep the buffer that is backing `slice` valid.
+    _pinned: PinnedPages,
+}
+
+impl<'a> core::ops::Deref for PinnedBuffer<'a> {
+    type Target = VolatileSlice<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.slice
+    }
+}
+
 #[derive(Default)]
 struct HostVmRunner {
     scause: u64,
@@ -438,6 +453,18 @@ impl HostVmRunner {
                                 addr_hi: _,
                             })) => {
                                 let sbi_ret = match self.handle_write(&vm, addr, len) {
+                                    Ok(n) => SbiReturn::success(n as i64),
+                                    Err(n) => SbiReturn {
+                                        error_code: SbiError::InvalidAddress as i64,
+                                        return_value: n as i64,
+                                    },
+                                };
+
+                                self.gprs.set_reg(GprIndex::A0, sbi_ret.error_code as u64);
+                                self.gprs.set_reg(GprIndex::A1, sbi_ret.return_value as u64);
+                            }
+                            Ok(DebugConsole(DebugConsoleFunction::Read { len, addr, .. })) => {
+                                let sbi_ret = match self.handle_read(&vm, addr, len) {
                                     Ok(n) => SbiReturn::success(n as i64),
                                     Err(n) => SbiReturn {
                                         error_code: SbiError::InvalidAddress as i64,
@@ -527,46 +554,91 @@ impl HostVmRunner {
         Ok(())
     }
 
+    fn pin_console_buffer<T: GuestStagePagingMode>(
+        &mut self,
+        vm: &FinalizedVm<T>,
+        addr: u64,
+        len: usize,
+    ) -> VmPagesResult<PinnedBuffer> {
+        // Pin the pages that hold the buffer. We assume that the buffer is physically contiguous,
+        // which should be the case since that's how we set up the host VM's address space. Note
+        // that safety does not depend on this assumption because `pin_shared_pages` will return an
+        // error when the physical page range is fond to be non-contiguous.
+        let page_addr = GuestPageAddr::with_round_down(
+            GuestPhysAddr::guest(addr, vm.page_owner_id()),
+            PageSize::Size4k,
+        );
+        let offset = addr - page_addr.bits();
+        let num_pages = PageSize::num_4k_pages(offset + len as u64);
+        let pinned = vm.vm_pages().pin_shared_pages(page_addr, num_pages)?;
+        let hyp_addr = pinned.range().base().bits() + offset;
+        // Safety: The buffer is valid and remains so as long as `pinned` remains in scope, which
+        // PinnedBuffer guarantees. byte pointers are always aligned correctly.
+        let slice = unsafe { VolatileSlice::from_raw_parts(hyp_addr as *mut u8, len) };
+        Ok(PinnedBuffer {
+            slice,
+            _pinned: pinned,
+        })
+    }
+
     fn handle_write<T: GuestStagePagingMode>(
         &mut self,
         vm: &FinalizedVm<T>,
         addr: u64,
         len: u64,
     ) -> core::result::Result<u64, u64> {
-        // Pin the pages that we'll be printing from. We assume that the buffer is physically
-        // contiguous, which should be the case since that's how we set up the host VM's address
-        // space.
-        let page_addr = GuestPageAddr::with_round_down(
-            GuestPhysAddr::guest(addr, vm.page_owner_id()),
-            PageSize::Size4k,
-        );
-        let offset = addr - page_addr.bits();
-        let num_pages = PageSize::num_4k_pages(offset + len);
-        let pinned = vm
-            .vm_pages()
-            .pin_shared_pages(page_addr, num_pages)
-            .map_err(|_| 0u64)?;
+        let len = len as usize;
+        let pinned = self.pin_console_buffer(vm, addr, len).map_err(|_| 0u64)?;
 
-        // Print the bytes in chunks. We copy to a temporary buffer as the bytes could be modified
-        // concurrently by the VM on another CPU.
         let mut copied = 0;
-        let mut hyp_addr = pinned.range().base().bits() + offset;
-        while copied != len {
+        while copied < len {
             let mut buf = [0u8; 256];
-            let to_copy = core::cmp::min(buf.len(), (len - copied) as usize);
-            for c in buf.iter_mut() {
-                // Safety: We've confirmed that the address is within a region of accessible memory
-                // and cannot be remapped as long as we hold the pin. `u8`s are always aligned and
-                // properly initialized.
-                *c = unsafe { core::ptr::read_volatile(hyp_addr as *const u8) };
-                hyp_addr += 1;
-            }
-            let s = core::str::from_utf8(&buf[..to_copy]).map_err(|_| copied)?;
+            let to_copy = core::cmp::min(buf.len(), len - copied);
+
+            // Unwrap OK: offset and length are within bounds by construction.
+            pinned
+                .sub_slice(copied, to_copy)
+                .unwrap()
+                .copy_to(&mut buf[..to_copy]);
+
+            let s = core::str::from_utf8(&buf[..to_copy]).map_err(|_| copied as u64)?;
             print!("{s}");
-            copied += to_copy as u64;
+
+            copied += to_copy;
         }
 
-        Ok(len)
+        Ok(copied as u64)
+    }
+
+    fn handle_read<T: GuestStagePagingMode>(
+        &mut self,
+        vm: &FinalizedVm<T>,
+        addr: u64,
+        len: u64,
+    ) -> core::result::Result<u64, u64> {
+        let len = len as usize;
+        let pinned = self.pin_console_buffer(vm, addr, len).map_err(|_| 0u64)?;
+
+        let mut copied = 0;
+        while copied < len {
+            let mut buf = [0u8; 256];
+            let to_copy = core::cmp::min(buf.len(), len - copied);
+
+            let read = core::cmp::min(to_copy, Console::read(&mut buf[..to_copy]));
+            if read == 0 {
+                break;
+            }
+
+            // Unwrap OK: offset and length are within bounds by construction.
+            pinned
+                .sub_slice(copied, read)
+                .unwrap()
+                .copy_from(&buf[..read]);
+
+            copied += read;
+        }
+
+        Ok(copied as u64)
     }
 
     fn handle_write_byte(&mut self, c: u8) {


### PR DESCRIPTION
This PR fills in a Debug Console Read implementation for use by guests. This is achieved by adding read support to the console abstraction, which is then used in the added SBI function handler.