### PR TITLE
Support for multiple PCI roots / IOMMUs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -27,6 +27,18 @@ config_setting(
     },
 )
 
+bool_flag(
+    name = "enable_hardware_ad_updates",
+    build_setting_default = 1,
+)
+
+config_setting(
+    name = "hardware_ad_updates",
+    flag_values = {
+      "enable_hardware_ad_updates": "true",
+    },
+)
+
 filegroup(
     name = "salus-all",
     srcs = [
@@ -204,6 +216,10 @@ rust_binary(
         "-Clink-arg=-T$(location //:l_rule)",
     ],
     deps = salus_deps,
+    crate_features = select({
+      ":hardware_ad_updates": ["hardware_ad_updates"],
+      "//conditions:default": [],
+    }),
 )
 
 rust_clippy(

--- a/BUILD
+++ b/BUILD
@@ -10,9 +10,22 @@
 # bazel test //:rustfmt-all
 # bazel test //:test-all
 
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_clippy", "rust_doc", "rust_test", "rustfmt_test")
 load("//:objcopy.bzl", "objcopy_to_object")
 load("//:lds.bzl", "lds_rule")
+
+bool_flag(
+    name = "enable_unsafe_enhanced_allocation",
+    build_setting_default = 0,
+)
+
+config_setting(
+    name = "unsafe_enhanced_allocation",
+    flag_values = {
+      "enable_unsafe_enhanced_allocation": "true",
+    },
+)
 
 filegroup(
     name = "salus-all",

--- a/device-tree/src/device_tree.rs
+++ b/device-tree/src/device_tree.rs
@@ -46,6 +46,8 @@ pub struct DeviceTreeNode {
 }
 
 pub type NodeArena = Arena<DeviceTreeNode, Global>;
+
+/// An ID for a device tree node. The node itself can be obtained via `DeviceTree::get_node`.
 pub type NodeId = ArenaId<DeviceTreeNode>;
 
 /// A tree representation of the hardware in a system based on v0.3 of the Devicetree Specification.

--- a/device-tree/src/lib.rs
+++ b/device-tree/src/lib.rs
@@ -13,7 +13,7 @@ mod error;
 mod fdt;
 mod serialize;
 
-pub use crate::device_tree::{DeviceTree, DeviceTreeIter, DeviceTreeNode};
+pub use crate::device_tree::{DeviceTree, DeviceTreeIter, DeviceTreeNode, NodeId};
 pub use error::Error as DeviceTreeError;
 pub use error::Result as DeviceTreeResult;
 pub use fdt::{Cpu, Fdt, FdtMemoryRegion, ImsicInfo};

--- a/drivers/BUILD
+++ b/drivers/BUILD
@@ -27,6 +27,10 @@ rust_library(
         "@salus-index//:static_assertions",
         "@salus-index//:tock-registers",
     ],
+    crate_features = select({
+      "//:unsafe_enhanced_allocation": ["unsafe_enhanced_allocation"],
+      "//conditions:default": [],
+    }),
 )
 
 rust_clippy(

--- a/drivers/BUILD
+++ b/drivers/BUILD
@@ -30,6 +30,9 @@ rust_library(
     crate_features = select({
       "//:unsafe_enhanced_allocation": ["unsafe_enhanced_allocation"],
       "//conditions:default": [],
+    }) + select({
+      "//:hardware_ad_updates": ["hardware_ad_updates"],
+      "//conditions:default": [],
     }),
 )
 

--- a/drivers/src/iommu/core.rs
+++ b/drivers/src/iommu/core.rs
@@ -84,6 +84,12 @@ impl Iommu {
             return Err(Error::MissingGStageSupport);
         }
 
+        if cfg!(feature = "hardware_ad_updates")
+            && !registers.capabilities.is_set(Capabilities::AmoHwad)
+        {
+            return Err(Error::MissingAmoHwadSupport);
+        }
+
         // Initialize the command queue.
         let command_queue = CommandQueue::new(get_page().ok_or(Error::OutOfPages)?);
         let mut cqb = LocalRegisterCopy::<u64, QueueBase::Register>::new(0);

--- a/drivers/src/iommu/device_directory.rs
+++ b/drivers/src/iommu/device_directory.rs
@@ -11,6 +11,7 @@ use static_assertions::const_assert;
 use sync::Mutex;
 
 use super::error::*;
+use super::gscid::GscId;
 use super::msi_page_table::MsiPageTable;
 use crate::pci::Address;
 
@@ -43,22 +44,6 @@ impl TryFrom<Address> for DeviceId {
 
     fn try_from(address: Address) -> Result<Self> {
         Self::new(address.bits()).ok_or(Error::PciAddressTooLarge(address))
-    }
-}
-
-/// Global Soft-Context ID. The equivalent of hgatp.VMID, but always 16 bits.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GscId(u16);
-
-impl GscId {
-    /// Creates a `GscId` from the raw `id`.
-    pub(super) fn new(id: u16) -> Self {
-        GscId(id)
-    }
-
-    /// Returns the raw bits of this `GscId`.
-    pub fn bits(&self) -> u16 {
-        self.0
     }
 }
 

--- a/drivers/src/iommu/device_directory.rs
+++ b/drivers/src/iommu/device_directory.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::marker::PhantomData;
+use enum_dispatch::enum_dispatch;
 use riscv_page_tables::{GuestStagePageTable, GuestStagePagingMode};
 use riscv_pages::*;
 use riscv_regs::dma_wmb;
@@ -15,10 +16,6 @@ use crate::pci::Address;
 
 // Maximum number of device ID bits used by the IOMMU.
 const DEVICE_ID_BITS: usize = 24;
-// Number of bits used to index into the leaf table.
-const LEAF_INDEX_BITS: usize = 6;
-// Number of bits used to index into intermediate tables.
-const NON_LEAF_INDEX_BITS: usize = 9;
 
 /// The device ID. Used to index into the device directory table. For PCI devices behind an IOMMU
 /// this is equivalent to the requester ID of the PCI device (i.e. the bits of the B/D/F).
@@ -38,16 +35,6 @@ impl DeviceId {
     /// Returns the raw bits of this `DeviceId`.
     pub fn bits(&self) -> u32 {
         self.0
-    }
-
-    // Returns the bits from this `DeviceId` used to index at `level`.
-    fn level_index_bits(&self, level: usize) -> usize {
-        if level == 0 {
-            (self.0 as usize) & ((1 << LEAF_INDEX_BITS) - 1)
-        } else {
-            let shift = LEAF_INDEX_BITS + NON_LEAF_INDEX_BITS * (level - 1);
-            ((self.0 as usize) >> shift) & ((1 << NON_LEAF_INDEX_BITS) - 1)
-        }
     }
 }
 
@@ -77,12 +64,20 @@ impl GscId {
 
 // Defines the translation context for a device. A valid device context enables translation for
 // DMAs from the corresponding device according to the tables programmed into the device context.
+// This is the base format, used when capabilities.MSI_FLAT isn't set.
 #[repr(C)]
-struct DeviceContext {
+struct DeviceContextBase {
     tc: u64,
     iohgatp: u64,
     fsc: u64,
     ta: u64,
+}
+
+// Extended format of the device context, used when capabilities.MSI_FLAT is set. The additional
+// fields control MSI address matching and translation.
+#[repr(C)]
+struct DeviceContextExtended {
+    base: DeviceContextBase,
     msiptp: u64,
     msi_addr_mask: u64,
     msi_addr_pattern: u64,
@@ -96,46 +91,52 @@ const DC_VALID: u64 = 1 << 0;
 // device. Prevents enabling of device contexts that weren't explicitly added with `add_device()`.
 const DC_SW_INVALIDATED: u64 = 1 << 31;
 
-impl DeviceContext {
+// Trait abstracting over base / extended device context format.
+trait DeviceContext {
+    const INDEX_BITS: [u8; 3];
+
+    fn base(&self) -> &DeviceContextBase;
+    fn base_mut(&mut self) -> &mut DeviceContextBase;
+
+    // Returns the bits from `device_id` used to index at `level`.
+    fn level_index_bits(device_id: DeviceId, level: usize) -> usize {
+        let mask = (1 << Self::INDEX_BITS[level]) - 1;
+        let shift = Self::INDEX_BITS.iter().take(level).sum::<u8>() as usize;
+        (device_id.0 as usize >> shift) & mask
+    }
+
     // Clears the device context structure.
     fn init(&mut self) {
-        self.tc = DC_SW_INVALIDATED;
-        self.iohgatp = 0;
-        self.fsc = 0;
-        self.ta = 0;
-        self.msiptp = 0;
-        self.msi_addr_mask = 0;
-        self.msi_addr_pattern = 0;
+        self.base_mut().tc = DC_SW_INVALIDATED;
+        self.base_mut().iohgatp = 0;
+        self.base_mut().fsc = 0;
+        self.base_mut().ta = 0;
     }
 
     // Returns if the device context corresponds to a present device.
     fn present(&self) -> bool {
-        (self.tc & (DC_VALID | DC_SW_INVALIDATED)) != 0
+        (self.base().tc & (DC_VALID | DC_SW_INVALIDATED)) != 0
     }
 
     // Returns if the device context is valid.
     fn valid(&self) -> bool {
-        (self.tc & DC_VALID) != 0
+        (self.base().tc & DC_VALID) != 0
     }
 
     // Marks the device context as valid, using `pt` and `msi_pt` for translation.
     fn set<T: GuestStagePagingMode>(
         &mut self,
         pt: &GuestStagePageTable<T>,
-        msi_pt: &MsiPageTable,
+        msi_pt: Option<&MsiPageTable>,
         gscid: GscId,
     ) {
-        const MSI_MODE_FLAT: u64 = 0x1;
-        const MSI_MODE_SHIFT: u64 = 60;
-        self.msiptp = msi_pt.base_address().pfn().bits() | (MSI_MODE_FLAT << MSI_MODE_SHIFT);
-
-        let (addr, mask) = msi_pt.msi_address_pattern();
-        self.msi_addr_mask = mask >> PFN_SHIFT;
-        self.msi_addr_pattern = addr.pfn().bits();
+        // This default implementation (appropriate for the base format) doesn't support MSI
+        // translation, and hence should never receive a valid `msi_pt` parameter.
+        assert!(msi_pt.is_none());
 
         const GSCID_SHIFT: u64 = 44;
         const HGATP_MODE_SHIFT: u64 = 60;
-        self.iohgatp = pt.get_root_address().pfn().bits()
+        self.base_mut().iohgatp = pt.get_root_address().pfn().bits()
             | ((gscid.bits() as u64) << GSCID_SHIFT)
             | (T::HGATP_MODE << HGATP_MODE_SHIFT);
 
@@ -143,12 +144,56 @@ impl DeviceContext {
         // as valid.
         dma_wmb();
 
-        self.tc = DC_VALID;
+        self.base_mut().tc = DC_VALID;
     }
 
     // Marks the device context as invalid.
     fn invalidate(&mut self) {
-        self.tc = DC_SW_INVALIDATED;
+        self.base_mut().tc = DC_SW_INVALIDATED;
+    }
+}
+
+impl DeviceContext for DeviceContextBase {
+    const INDEX_BITS: [u8; 3] = [7, 9, 8];
+
+    fn base(&self) -> &DeviceContextBase {
+        self
+    }
+    fn base_mut(&mut self) -> &mut DeviceContextBase {
+        self
+    }
+}
+
+impl DeviceContext for DeviceContextExtended {
+    const INDEX_BITS: [u8; 3] = [6, 9, 9];
+
+    fn base(&self) -> &DeviceContextBase {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut DeviceContextBase {
+        &mut self.base
+    }
+
+    fn set<T: GuestStagePagingMode>(
+        &mut self,
+        pt: &GuestStagePageTable<T>,
+        msi_pt: Option<&MsiPageTable>,
+        gscid: GscId,
+    ) {
+        if let Some(msi_pt) = msi_pt {
+            const MSI_MODE_FLAT: u64 = 0x1;
+            const MSI_MODE_SHIFT: u64 = 60;
+            self.msiptp = msi_pt.base_address().pfn().bits() | (MSI_MODE_FLAT << MSI_MODE_SHIFT);
+
+            let (addr, mask) = msi_pt.msi_address_pattern();
+            self.msi_addr_mask = mask >> PFN_SHIFT;
+            self.msi_addr_pattern = addr.pfn().bits();
+        } else {
+            self.msiptp = 0;
+        }
+
+        // NB: Pass a None `msi_pt` parameter to the base implementation.
+        self.base.set(pt, None, gscid);
     }
 }
 
@@ -179,23 +224,34 @@ impl NonLeafEntry {
     }
 }
 
+// Checks whether the table sizes at the different levels for a given DeviceContext look ok.
+const fn _check_ddt_layout<DC: DeviceContext>() -> bool {
+    DC::INDEX_BITS.len() == 3
+        && (size_of::<DC>() << DC::INDEX_BITS[0] == 4096)
+        && (size_of::<NonLeafEntry>() << DC::INDEX_BITS[1] == 4096)
+        && (size_of::<NonLeafEntry>() << DC::INDEX_BITS[2] <= 4096)
+}
+
+const_assert!(_check_ddt_layout::<DeviceContextBase>());
+const_assert!(_check_ddt_layout::<DeviceContextExtended>());
+
 // Represents a single entry in the device directory hierarchy.
-enum DeviceDirectoryEntry<'a> {
-    PresentLeaf(&'a mut DeviceContext),
-    NotPresentLeaf(&'a mut DeviceContext),
-    NextLevel(DeviceDirectoryTable<'a>),
+enum DeviceDirectoryEntry<'a, DC: DeviceContext> {
+    Leaf(&'a mut DC),
+    NextLevel(DeviceDirectoryTable<'a, DC>),
     Invalid(&'a mut NonLeafEntry, usize),
 }
 
 // Represents a single device directory table. Intermediate DDTs (level > 0) are made up entirely
 // of non-leaf entries, while Leaf DDTs (level == 0) are made up entirely of `DeviceContext`s.
-struct DeviceDirectoryTable<'a> {
+#[derive(Clone)]
+struct DeviceDirectoryTable<'a, DC: DeviceContext> {
     table_addr: SupervisorPageAddr,
     level: usize,
-    phantom: PhantomData<&'a mut DeviceDirectoryInner>,
+    phantom: PhantomData<&'a DC>,
 }
 
-impl<'a> DeviceDirectoryTable<'a> {
+impl<'a, DC: DeviceContext + 'a> DeviceDirectoryTable<'a, DC> {
     // Creates the root `DeviceDirectoryTable` from `owner`.
     fn from_root(owner: &'a mut DeviceDirectoryInner) -> Self {
         Self {
@@ -225,23 +281,19 @@ impl<'a> DeviceDirectoryTable<'a> {
     }
 
     // Returns the `DeviceDirectoryEntry` for `id` in this table.
-    fn entry_for_id(&mut self, id: DeviceId) -> DeviceDirectoryEntry<'a> {
-        let index = id.level_index_bits(self.level);
+    fn entry_for_id(&mut self, id: DeviceId) -> DeviceDirectoryEntry<'a, DC> {
+        let index = DC::level_index_bits(id, self.level);
         use DeviceDirectoryEntry::*;
         if self.is_leaf() {
             // Safety: self.table_addr is properly aligned and must point to an array of
             // `DeviceContext`s if this is a leaf table. Further, `index` is guaranteed
             // to be within in the bounds of the table.
             let dc = unsafe {
-                let ptr = (self.table_addr.bits() as *mut DeviceContext).add(index);
+                let ptr = (self.table_addr.bits() as *mut DC).add(index);
                 // Pointer must be non-NULL.
                 ptr.as_mut().unwrap()
             };
-            if dc.present() {
-                PresentLeaf(dc)
-            } else {
-                NotPresentLeaf(dc)
-            }
+            Leaf(dc)
         } else {
             // Safety: self.table_addr is properly aligned and must point to an array of
             // `NonLeafEntry`s if this is an intermediate table. Further, `index` is guaranteed
@@ -262,54 +314,142 @@ impl<'a> DeviceDirectoryTable<'a> {
         }
     }
 
-    // Returns the next-level table mapping `id`, using `get_page` to allocate a directory table
-    // page if necessary.
-    fn next_level_or_fill(
-        &mut self,
-        id: DeviceId,
-        get_page: &mut dyn FnMut() -> Option<Page<InternalClean>>,
-    ) -> Result<DeviceDirectoryTable<'a>> {
-        use DeviceDirectoryEntry::*;
-        let table = match self.entry_for_id(id) {
-            NextLevel(t) => t,
-            Invalid(nle, level) => {
-                let page = get_page().ok_or(Error::OutOfPages)?;
-                nle.set(page.pfn());
-                // Safety: We just allocated the page this entry points to and thus have unique
-                // ownership over the memory it refers to.
-                unsafe {
-                    // Unwrap ok, we just marked the entry as valid.
-                    Self::from_non_leaf_entry(nle, level).unwrap()
-                }
-            }
-            _ => {
-                return Err(Error::NotIntermediateTable);
-            }
-        };
-        Ok(table)
-    }
-
     // Returns if this is a leaf directory table.
     fn is_leaf(&self) -> bool {
         self.level == 0
     }
-}
 
-struct DeviceDirectoryInner {
-    root: Page<InternalClean>,
-    num_levels: usize,
-}
-
-impl DeviceDirectoryInner {
-    fn get_context_for_id(&mut self, id: DeviceId) -> Option<&mut DeviceContext> {
-        let mut entry = DeviceDirectoryTable::from_root(self).entry_for_id(id);
+    // Get the device context for the device identified by `id`.
+    fn get_context_for_id(&mut self, id: DeviceId) -> Option<&mut DC> {
+        let mut entry = self.entry_for_id(id);
         use DeviceDirectoryEntry::*;
         while let NextLevel(mut t) = entry {
             entry = t.entry_for_id(id);
         }
         match entry {
-            PresentLeaf(dc) => Some(dc),
+            Leaf(dc) if dc.present() => Some(dc),
             _ => None,
+        }
+    }
+
+    // Returns the device context for the device identified by `id`, creating it if necessary.
+    fn create_context_for_id(
+        &mut self,
+        id: DeviceId,
+        get_page: &mut dyn FnMut() -> Option<Page<InternalClean>>,
+    ) -> Result<&mut DC> {
+        let mut entry = self.entry_for_id(id);
+        loop {
+            use DeviceDirectoryEntry::*;
+            let mut table = match entry {
+                NextLevel(t) => t,
+                Invalid(nle, level) => {
+                    let page = get_page().ok_or(Error::OutOfPages)?;
+                    nle.set(page.pfn());
+                    // Safety: We just allocated the page this entry points to and thus have unique
+                    // ownership over the memory it refers to.
+                    unsafe {
+                        // Unwrap ok, we just marked the entry as valid.
+                        Self::from_non_leaf_entry(nle, level).unwrap()
+                    }
+                }
+                Leaf(dc) => return Ok(dc),
+            };
+            entry = table.entry_for_id(id);
+        }
+    }
+}
+
+// A trait providing directory mutation operations. Note that it does not have the specific device
+// context as type parameter, but is implemented (generically) for `DeviceDirectoryTable`
+// parameterized with specific device context types. Thus, this trait connects the API layer to the
+// differently typed table implementations.
+#[enum_dispatch(DeviceDirectoryOpsDispatch)]
+trait DeviceDirectoryOps {
+    // Adds the device with `id`, creating tables as necessary.
+    fn add_device(
+        &mut self,
+        id: DeviceId,
+        get_page: &mut dyn FnMut() -> Option<Page<InternalClean>>,
+    ) -> Result<()>;
+
+    // Updates the device context for `id` with the given parameters and marks it valid.
+    fn enable_device<T: GuestStagePagingMode>(
+        &mut self,
+        id: DeviceId,
+        pt: &GuestStagePageTable<T>,
+        msi_pt: Option<&MsiPageTable>,
+        gscid: GscId,
+    ) -> Result<()>;
+
+    // Invalidates the device context for `id`.
+    fn disable_device(&mut self, id: DeviceId) -> Result<()>;
+}
+
+impl<'a, DC: DeviceContext + 'a> DeviceDirectoryOps for DeviceDirectoryTable<'a, DC> {
+    fn add_device(
+        &mut self,
+        id: DeviceId,
+        get_page: &mut dyn FnMut() -> Option<Page<InternalClean>>,
+    ) -> Result<()> {
+        let dc = self.create_context_for_id(id, get_page)?;
+        if !dc.present() {
+            dc.init();
+        }
+        Ok(())
+    }
+
+    fn enable_device<T: GuestStagePagingMode>(
+        &mut self,
+        id: DeviceId,
+        pt: &GuestStagePageTable<T>,
+        msi_pt: Option<&MsiPageTable>,
+        gscid: GscId,
+    ) -> Result<()> {
+        let entry = self
+            .get_context_for_id(id)
+            .ok_or(Error::DeviceNotFound(id))?;
+        if entry.valid() {
+            return Err(Error::DeviceAlreadyEnabled(id));
+        }
+        entry.set(pt, msi_pt, gscid);
+        Ok(())
+    }
+
+    fn disable_device(&mut self, id: DeviceId) -> Result<()> {
+        let entry = self
+            .get_context_for_id(id)
+            .ok_or(Error::DeviceNotFound(id))?;
+        if !entry.valid() {
+            return Err(Error::DeviceNotEnabled(id));
+        }
+        entry.invalidate();
+        Ok(())
+    }
+}
+
+// A helper enum for dispatching DeviceDirectoryOps calls from non-type-parameterized context to
+// the type-parameterized DeviceDirectoryOps implementations for DeviceDirectoryTable.
+#[enum_dispatch]
+enum DeviceDirectoryOpsDispatch<'a> {
+    Base(DeviceDirectoryTable<'a, DeviceContextBase>),
+    Extended(DeviceDirectoryTable<'a, DeviceContextExtended>),
+}
+
+// Represents a device directory instance. The instance is protected by a Mutex and thus separate
+// from the API layer offered by `DeviceDirectory`.
+struct DeviceDirectoryInner {
+    root: Page<InternalClean>,
+    num_levels: usize,
+    format: DeviceContextFormat,
+}
+
+impl DeviceDirectoryInner {
+    fn ops(&mut self) -> DeviceDirectoryOpsDispatch {
+        use DeviceDirectoryOpsDispatch::*;
+        match self.format {
+            DeviceContextFormat::Base => Base(DeviceDirectoryTable::from_root(self)),
+            DeviceContextFormat::Extended => Extended(DeviceDirectoryTable::from_root(self)),
         }
     }
 }
@@ -331,6 +471,12 @@ impl DirectoryMode for Ddt3Level {
     const IOMMU_MODE: u64 = 4;
 }
 
+/// Indicates which device context format to use.
+pub enum DeviceContextFormat {
+    Base,
+    Extended,
+}
+
 /// Represents the device directory table for the IOMMU. The IOMMU hardware uses the DDT to map
 /// a requester ID to the translation context for the device.
 pub struct DeviceDirectory<D: DirectoryMode> {
@@ -340,10 +486,11 @@ pub struct DeviceDirectory<D: DirectoryMode> {
 
 impl<D: DirectoryMode> DeviceDirectory<D> {
     /// Creates a new `DeviceDirectory` using `root` as the root table page.
-    pub fn new(root: Page<InternalClean>) -> Self {
+    pub fn new(root: Page<InternalClean>, format: DeviceContextFormat) -> Self {
         let inner = DeviceDirectoryInner {
             root,
             num_levels: D::LEVELS,
+            format,
         };
         Self {
             inner: Mutex::new(inner),
@@ -356,6 +503,11 @@ impl<D: DirectoryMode> DeviceDirectory<D> {
         self.inner.lock().root.addr()
     }
 
+    /// Returns whether this IOMMU instance supports MSI page tables.
+    pub fn supports_msi_page_tables(&self) -> bool {
+        matches!(self.inner.lock().format, DeviceContextFormat::Extended)
+    }
+
     /// Adds and initializes a device context for `id` in this `DeviceDirectory`. The device
     /// context is initially invalid, i.e. translation is off for the device. Uses `get_page`
     /// to allocate intermediate directory table pages, if necessary.
@@ -365,16 +517,7 @@ impl<D: DirectoryMode> DeviceDirectory<D> {
         get_page: &mut dyn FnMut() -> Option<Page<InternalClean>>,
     ) -> Result<()> {
         let mut inner = self.inner.lock();
-        // Silence bogus auto-deref lint, see https://github.com/rust-lang/rust-clippy/issues/9101.
-        #[allow(clippy::explicit_auto_deref)]
-        let mut table = DeviceDirectoryTable::from_root(&mut *inner);
-        while !table.is_leaf() {
-            table = table.next_level_or_fill(id, get_page)?;
-        }
-        if let DeviceDirectoryEntry::NotPresentLeaf(dc) = table.entry_for_id(id) {
-            dc.init();
-        }
-        Ok(())
+        inner.ops().add_device(id, get_page)
     }
 
     /// Enables IOMMU translation for the specified device, using `pt` for 2nd-stage translation
@@ -384,38 +527,23 @@ impl<D: DirectoryMode> DeviceDirectory<D> {
         &self,
         id: DeviceId,
         pt: &GuestStagePageTable<T>,
-        msi_pt: &MsiPageTable,
+        msi_pt: Option<&MsiPageTable>,
         gscid: GscId,
     ) -> Result<()> {
-        if pt.page_owner_id() != msi_pt.owner() {
+        if msi_pt.is_some_and(|msi_pt| msi_pt.owner() != pt.page_owner_id()) {
             return Err(Error::OwnerMismatch);
         }
+
         let mut inner = self.inner.lock();
-        let entry = inner
-            .get_context_for_id(id)
-            .ok_or(Error::DeviceNotFound(id))?;
-        if entry.valid() {
-            return Err(Error::DeviceAlreadyEnabled(id));
+        if msi_pt.is_some() && !matches!(inner.format, DeviceContextFormat::Extended) {
+            return Err(Error::MsiTranslationUnsupported);
         }
-        entry.set(pt, msi_pt, gscid);
-        Ok(())
+        inner.ops().enable_device(id, pt, msi_pt, gscid)
     }
 
     /// Disables IOMMU translation for the specified device.
     pub fn disable_device(&self, id: DeviceId) -> Result<()> {
         let mut inner = self.inner.lock();
-        let entry = inner
-            .get_context_for_id(id)
-            .ok_or(Error::DeviceNotFound(id))?;
-        if !entry.valid() {
-            return Err(Error::DeviceNotEnabled(id));
-        }
-        entry.invalidate();
-        Ok(())
+        inner.ops().disable_device(id)
     }
-}
-
-fn _assert_ddt_layout() {
-    const_assert!(core::mem::size_of::<DeviceContext>() << LEAF_INDEX_BITS == 4096);
-    const_assert!(core::mem::size_of::<NonLeafEntry>() << NON_LEAF_INDEX_BITS == 4096);
 }

--- a/drivers/src/iommu/error.rs
+++ b/drivers/src/iommu/error.rs
@@ -12,6 +12,10 @@ use crate::pci::{Address, PciError};
 /// Errors resulting from interacting with the IOMMU.
 #[derive(Clone, Copy, Debug)]
 pub enum Error {
+    /// The device doesn't identify as an IOMMU.
+    NotAnIommu,
+    /// There are more than the maximum number of IOMMUs supported by the code.
+    TooManyIommus,
     /// Error encountered while probing and enabling the IOMMU PCI device.
     ProbingIommu(PciError),
     /// Couldn't find the IOMMU registers BAR.
@@ -48,6 +52,8 @@ pub enum Error {
     PciAddressTooLarge(Address),
     /// Mismatch between page table and device ownership.
     OwnerMismatch,
+    /// Device isn't managed by this IOMMU.
+    IommuMismatch,
     /// No device context found.
     DeviceNotFound(DeviceId),
     /// The device already has an active device context.

--- a/drivers/src/iommu/error.rs
+++ b/drivers/src/iommu/error.rs
@@ -4,7 +4,8 @@
 
 use riscv_pages::SupervisorPageAddr;
 
-use super::device_directory::{DeviceId, GscId};
+use super::device_directory::DeviceId;
+use super::gscid::GscId;
 use crate::imsic::ImsicLocation;
 use crate::pci::{Address, PciError};
 

--- a/drivers/src/iommu/error.rs
+++ b/drivers/src/iommu/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
     MissingGStageSupport,
     /// Missing required MSI translation support.
     MissingMsiSupport,
+    /// Missing A/D update support.
+    MissingAmoHwadSupport,
     /// Not enough pages were supplied to create an MSI page table.
     InsufficientMsiTablePages,
     /// The supplied MSI page table pages were not properly aligned.

--- a/drivers/src/iommu/error.rs
+++ b/drivers/src/iommu/error.rs
@@ -69,6 +69,8 @@ pub enum Error {
     GscIdInUse(GscId),
     /// MSI translation not supported.
     MsiTranslationUnsupported,
+    /// No feasible device directory mode.
+    DeviceDirectoryUnsupported,
 }
 
 /// Holds results for IOMMU operations.

--- a/drivers/src/iommu/error.rs
+++ b/drivers/src/iommu/error.rs
@@ -65,6 +65,8 @@ pub enum Error {
     GscIdAlreadyFree(GscId),
     /// Attempted to free a GSCID that's currently being used for translation.
     GscIdInUse(GscId),
+    /// MSI translation not supported.
+    MsiTranslationUnsupported,
 }
 
 /// Holds results for IOMMU operations.

--- a/drivers/src/iommu/gscid.rs
+++ b/drivers/src/iommu/gscid.rs
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2025 Rivos Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use riscv_pages::*;
+use sync::Mutex;
+
+use super::error::*;
+
+/// Global Soft-Context ID. The equivalent of hgatp.VMID, but always 16 bits.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GscId(u16);
+
+impl GscId {
+    /// Creates a `GscId` from the raw `id`.
+    pub(super) fn new(id: u16) -> Self {
+        GscId(id)
+    }
+
+    /// Returns the raw bits of this `GscId`.
+    pub fn bits(&self) -> u16 {
+        self.0
+    }
+}
+
+// Tracks the state of an allocated global soft-context ID (GSCID).
+#[derive(Clone, Copy, Debug)]
+pub(super) struct GscIdState {
+    pub(super) owner: PageOwnerId,
+    pub(super) ref_count: usize,
+}
+
+// We use a fixed-sized array to track available GSCIDs. We can't use a versioning scheme like we
+// would for CPU VMIDs since reassigning GSCIDs on overflow would require us to temporarily disable
+// DMA from all devices, which is extremely disruptive. Set a max of 64 allocated GSCIDs for now
+// since it's unlikely we'll have more than that number of active VMs with assigned devices for
+// the time being.
+const MAX_GSCIDS: usize = 64;
+
+// The global GSCID allocation table.
+pub(super) static GSCIDS: Mutex<[Option<GscIdState>; MAX_GSCIDS]> = Mutex::new([None; MAX_GSCIDS]);
+
+/// Allocates a new GSCID for `owner`.
+pub fn alloc_gscid(owner: PageOwnerId) -> Result<GscId> {
+    let mut gscids = GSCIDS.lock();
+    let next = gscids
+        .iter()
+        .position(|g| g.is_none())
+        .ok_or(Error::OutOfGscIds)?;
+    let state = GscIdState {
+        owner,
+        ref_count: 0,
+    };
+    gscids[next] = Some(state);
+    Ok(GscId::new(next as u16))
+}
+
+/// Releases `gscid`, which must not be in use in any active device contexts.
+pub fn free_gscid(gscid: GscId) -> Result<()> {
+    let mut gscids = GSCIDS.lock();
+    let state = gscids
+        .get_mut(gscid.bits() as usize)
+        .ok_or(Error::InvalidGscId(gscid))?;
+    match state {
+        Some(s) if s.ref_count > 0 => {
+            return Err(Error::GscIdInUse(gscid));
+        }
+        None => {
+            return Err(Error::GscIdAlreadyFree(gscid));
+        }
+        _ => {
+            *state = None;
+        }
+    }
+    Ok(())
+}

--- a/drivers/src/iommu/mod.rs
+++ b/drivers/src/iommu/mod.rs
@@ -5,14 +5,16 @@
 mod core;
 mod device_directory;
 mod error;
+mod gscid;
 mod msi_page_table;
 mod queue;
 mod registers;
 
 pub use self::core::Iommu;
-pub use device_directory::{DeviceId, GscId};
+pub use device_directory::DeviceId;
 pub use error::Error as IommuError;
 pub use error::Result as IommuResult;
+pub use gscid::{alloc_gscid, free_gscid, GscId};
 pub use msi_page_table::MsiPageTable;
 
 #[cfg(test)]

--- a/drivers/src/iommu/mod.rs
+++ b/drivers/src/iommu/mod.rs
@@ -204,7 +204,7 @@ mod tests {
         let ddt_page = page_tracker
             .assign_page_for_internal_state(pages.pop().unwrap(), PageOwnerId::host())
             .unwrap();
-        let ddt = DeviceDirectory::<Ddt3Level>::new(ddt_page);
+        let ddt = DeviceDirectory::<Ddt3Level>::new(ddt_page, DeviceContextFormat::Extended);
         for i in 0..16 {
             let id = DeviceId::new(i).unwrap();
             ddt.add_device(id, &mut || {
@@ -217,17 +217,21 @@ mod tests {
 
         let gscid = GscId::new(0);
         let dev = DeviceId::new(2).unwrap();
-        assert!(ddt.enable_device(dev, &pt, &msi_pt, gscid).is_ok());
+        assert!(ddt.enable_device(dev, &pt, Some(&msi_pt), gscid).is_ok());
         assert!(ddt.disable_device(dev).is_ok());
         let bad_dev = DeviceId::new(1 << 16).unwrap();
-        assert!(ddt.enable_device(bad_dev, &pt, &msi_pt, gscid).is_err());
+        assert!(ddt
+            .enable_device(bad_dev, &pt, Some(&msi_pt), gscid)
+            .is_err());
 
         let (bad_msi_pt, _) = stub_msi_page_table(
             page_tracker.clone(),
             &mut pages,
             PageOwnerId::new(5).unwrap(),
         );
-        assert!(ddt.enable_device(dev, &pt, &bad_msi_pt, gscid).is_err());
+        assert!(ddt
+            .enable_device(dev, &pt, Some(&bad_msi_pt), gscid)
+            .is_err());
     }
 
     #[test]

--- a/drivers/src/iommu/mod.rs
+++ b/drivers/src/iommu/mod.rs
@@ -204,7 +204,7 @@ mod tests {
         let ddt_page = page_tracker
             .assign_page_for_internal_state(pages.pop().unwrap(), PageOwnerId::host())
             .unwrap();
-        let ddt = DeviceDirectory::<Ddt3Level>::new(ddt_page, DeviceContextFormat::Extended);
+        let ddt = DeviceDirectory::new(ddt_page, DeviceContextFormat::Extended, 3);
         for i in 0..16 {
             let id = DeviceId::new(i).unwrap();
             ddt.add_device(id, &mut || {

--- a/drivers/src/iommu/queue.rs
+++ b/drivers/src/iommu/queue.rs
@@ -7,8 +7,9 @@ use core::mem::size_of;
 use data_model::{DataInit, VolatileMemory, VolatileSlice};
 use riscv_pages::*;
 
-use super::device_directory::{DeviceId, GscId};
+use super::device_directory::DeviceId;
 use super::error::*;
+use super::gscid::GscId;
 
 /// Type marker for a queue where software is the producer.
 pub enum Producer {}

--- a/drivers/src/iommu/registers.rs
+++ b/drivers/src/iommu/registers.rs
@@ -21,6 +21,7 @@ register_bitfields![u64,
         Sv57x4 OFFSET(19) NUMBITS(1),
         MsiFlat OFFSET(22) NUMBITS(1),
         MsiMrif OFFSET(23) NUMBITS(1),
+        AmoHwad OFFSET(24) NUMBITS(1),
     ],
 
     pub DirectoryPointer [

--- a/drivers/src/pci/address.rs
+++ b/drivers/src/pci/address.rs
@@ -103,6 +103,12 @@ pub struct BusRange {
     pub end: Bus,
 }
 
+impl BusRange {
+    pub fn contains(&self, bus: Bus) -> bool {
+        bus >= self.start && bus <= self.end
+    }
+}
+
 // Because Functions are only 3 bits, they are trivally valid Bus numbers(8 bits).
 impl From<Function> for Bus {
     fn from(f: Function) -> Self {
@@ -140,6 +146,11 @@ impl Address {
     /// Creates a new `Address` based on the provided components.
     pub fn new(seg: Segment, bus: Bus, dev: Device, func: Function) -> Address {
         Address(seg.0 << Segment::SHIFT | bus.0 << Bus::SHIFT | dev.0 << Device::SHIFT | func.0)
+    }
+
+    /// Creates an `Address` for the given segment.
+    pub fn segment_address(segment: Segment) -> Address {
+        Address(segment.0 << Segment::SHIFT)
     }
 
     /// Creates an `Address` for the given `Bus` on the first segment.

--- a/drivers/src/pci/error.rs
+++ b/drivers/src/pci/error.rs
@@ -79,6 +79,8 @@ pub enum Error {
     InvalidBarAddress(u64),
     /// The device does not have a BAR at the specified index.
     BarNotPresent(usize),
+    /// The BAR can't be programmed because the address is fixed.
+    BarIsFixed(usize),
     /// A VM has programmed a BAR or bridge window to cover a page it does not own.
     UnownedBarPage(SupervisorPageAddr),
     /// The PCI device is already owned.

--- a/riscv-page-tables/BUILD
+++ b/riscv-page-tables/BUILD
@@ -17,6 +17,10 @@ rust_library(
     rustc_flags = [
         "-Ctarget-feature=+h",
     ],
+    crate_features = select({
+      "//:hardware_ad_updates": ["hardware_ad_updates"],
+      "//conditions:default": [],
+    }),
 )
 
 rust_clippy(

--- a/riscv-page-tables/src/pte.rs
+++ b/riscv-page-tables/src/pte.rs
@@ -189,13 +189,19 @@ impl PteFieldBits {
     pub fn leaf_with_perms(perms: PteLeafPerms) -> Self {
         let mut ret = Self::default();
         ret.bits |= perms as u64;
+
+        #[cfg(not(feature = "hardware_ad_updates"))]
+        {
+            ret.set_bit(PteFieldBit::Accessed);
+            ret.set_bit(PteFieldBit::Dirty);
+        }
+
         ret
     }
 
     /// Creates a new status for a leaf entry with the given `perms`.
     pub fn user_leaf_with_perms(perms: PteLeafPerms) -> Self {
-        let mut ret = Self::default();
-        ret.bits |= perms as u64;
+        let mut ret = Self::leaf_with_perms(perms);
         ret.set_bit(PteFieldBit::User);
         ret
     }

--- a/src/host_vm.rs
+++ b/src/host_vm.rs
@@ -276,15 +276,12 @@ impl<T: GuestStagePagingMode> HostVmLoader<T> {
                 let pages = pci.take_host_resource(res_type).unwrap();
                 self.vm.add_pci_pages(gpa, pages);
             }
-            // Attach our PCI devices to the IOMMU.
-            if Iommu::get().is_some() {
-                for dev in pci.devices() {
-                    let mut dev = dev.lock();
-                    if dev.owner() == Some(PageOwnerId::host()) {
-                        // Silence buggy clippy warning.
-                        #[allow(clippy::explicit_auto_deref)]
-                        self.vm.attach_pci_device(&mut *dev);
-                    }
+            // Attach our PCI devices to their respective IOMMU.
+            for dev in pci.devices() {
+                let mut dev = dev.lock();
+                if dev.owner() == Some(PageOwnerId::host()) && Iommu::get_for_device(&dev).is_some()
+                {
+                    self.vm.attach_pci_device(&mut dev);
                 }
             }
         }
@@ -642,7 +639,7 @@ impl<T: GuestStagePagingMode> HostVm<T> {
 
         let imsic_geometry = Imsic::get().host_vm_geometry();
         // Reserve MSI page table pages if we have an IOMMU.
-        let msi_table_pages = Iommu::get().map(|_| {
+        let msi_table_pages = Iommu::get_iommus().next().map(|_| {
             let msi_table_size = MsiPageTable::required_table_size(&imsic_geometry);
             hyp_mem.take_pages_for_host_state_with_alignment(
                 PageSize::num_4k_pages(msi_table_size) as usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -492,7 +492,7 @@ fn primary_init(hart_id: u64, fdt_addr: u64) -> Result<CpuParams, Error> {
         // We don't implement or use the SBI timer extension and thus require Sstc for timers.
         return Err(Error::CpuMissingFeature(RequiredCpuFeature::Sstc));
     }
-    if !cpu_info.has_svadu() {
+    if cfg!(feature = "hardware_ad_updates") && !cpu_info.has_svadu() {
         // Salus assumes that hardware will update the accessed and dirty bits in the page table.
         // It can't handle faults for updating them.
         return Err(Error::CpuMissingFeature(RequiredCpuFeature::Svadu));

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -981,16 +981,17 @@ impl Drop for VmIommuContext {
 
         // Detach any devices we own from the IOMMU.
         let owner = self.msi_page_table.owner();
-        let pci = PcieRoot::get();
-        for dev in pci.devices() {
-            let mut dev = dev.lock();
-            if dev.owner() == Some(owner) {
-                // Unwrap ok: `self.gscid` must be valid and match the ownership of the device
-                // to have been attached in the first place.
-                //
-                // Silence buggy clippy warning.
-                #[allow(clippy::explicit_auto_deref)]
-                iommu.detach_pci_device(&mut *dev, self.gscid).unwrap();
+        for pci in PcieRoot::get_roots() {
+            for dev in pci.devices() {
+                let mut dev = dev.lock();
+                if dev.owner() == Some(owner) {
+                    // Unwrap ok: `self.gscid` must be valid and match the ownership of the device
+                    // to have been attached in the first place.
+                    //
+                    // Silence buggy clippy warning.
+                    #[allow(clippy::explicit_auto_deref)]
+                    iommu.detach_pci_device(&mut *dev, self.gscid).unwrap();
+                }
             }
         }
 

--- a/src/vm_pages.rs
+++ b/src/vm_pages.rs
@@ -963,10 +963,7 @@ pub struct VmIommuContext {
 impl VmIommuContext {
     // Creates a new `VmIommuContext` using `msi_page_table`.
     fn new(msi_page_table: MsiPageTable) -> Result<Self> {
-        let gscid = Iommu::get()
-            .ok_or(Error::NoIommu)?
-            .alloc_gscid(msi_page_table.owner())
-            .map_err(Error::AllocatingGscId)?;
+        let gscid = alloc_gscid(msi_page_table.owner()).map_err(Error::AllocatingGscId)?;
         Ok(Self {
             msi_page_table,
             gscid,
@@ -997,7 +994,7 @@ impl Drop for VmIommuContext {
 
         // Unwrap ok: `self.gscid` must be valid and freeable since we've detached all devices
         // using it.
-        iommu.free_gscid(self.gscid).unwrap();
+        free_gscid(self.gscid).unwrap();
     }
 }
 


### PR DESCRIPTION
This PR generalizes salus' handling of PCI segments and IOMMUs:
- Salus can now manage multiple PCI segments and multiple IOMMUs
- Device-to-IOMMU mapping now respects mapping information in the device tree to determine which IOMMU is responsible for a given device.
- The IOMMU device directory code can handle both base and extended format, as well as 1-3 levels of tree depth.
- There's a new build option for A/D PTE bit management: Either rely on A/D updating support (which must be present), or initialize A/D bits to 1.
- Support the Enhanced Allocation PCI capability.